### PR TITLE
fix: apply post-merge review fixes for #36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 NOTARY_PROFILE ?= minute-notary
 DIST_PROFILE ?=
 ARCHIVE ?=

--- a/Minute/Sources/App/MinuteAppStore.entitlements
+++ b/Minute/Sources/App/MinuteAppStore.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>

--- a/Minute/Sources/ViewModels/UpdaterViewModel.swift
+++ b/Minute/Sources/ViewModels/UpdaterViewModel.swift
@@ -42,17 +42,23 @@ final class UpdaterViewModel: ObservableObject {
 
             driver.canCheckForUpdatesPublisher
                 .receive(on: RunLoop.main)
-                .assign(to: \.canCheckForUpdates, on: self)
+                .sink { [weak self] value in
+                    self?.canCheckForUpdates = value
+                }
                 .store(in: &cancellables)
 
             driver.automaticallyChecksForUpdatesPublisher
                 .receive(on: RunLoop.main)
-                .assign(to: \.automaticallyChecksForUpdates, on: self)
+                .sink { [weak self] value in
+                    self?.automaticallyChecksForUpdates = value
+                }
                 .store(in: &cancellables)
 
             driver.automaticallyDownloadsUpdatesPublisher
                 .receive(on: RunLoop.main)
-                .assign(to: \.automaticallyDownloadsUpdates, on: self)
+                .sink { [weak self] value in
+                    self?.automaticallyDownloadsUpdates = value
+                }
                 .store(in: &cancellables)
         } else {
             canCheckForUpdates = false

--- a/MinuteCore/Sources/MinuteCore/Domain/ReleaseValidationSummary.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/ReleaseValidationSummary.swift
@@ -139,19 +139,31 @@ public struct ReleaseValidationSummary: Codable, Sendable, Equatable {
     }
 
     public mutating func refreshOverallStatus(requiredChecks: [ReleaseValidationCheckType]) {
-        let checkMap = Dictionary(uniqueKeysWithValues: checks.map { ($0.checkType, $0.status) })
-        let failed = requiredChecks.contains { checkMap[$0] == .failed }
-        if failed {
-            overallStatus = .failed
-            return
+        let checkMap = checks.reduce(into: [ReleaseValidationCheckType: ReleaseValidationCheckStatus]()) { map, check in
+            guard let existing = map[check.checkType] else {
+                map[check.checkType] = check.status
+                return
+            }
+            map[check.checkType] = worstStatus(existing, check.status)
         }
 
-        let missing = requiredChecks.contains { checkMap[$0] == nil }
-        if missing {
-            overallStatus = .failed
-            return
+        let hasBlockingStatus = requiredChecks.contains { requiredCheck in
+            guard let status = checkMap[requiredCheck] else { return true }
+            return status != .passed
         }
+        overallStatus = hasBlockingStatus ? .failed : .passed
+    }
 
-        overallStatus = .passed
+    private func worstStatus(
+        _ lhs: ReleaseValidationCheckStatus,
+        _ rhs: ReleaseValidationCheckStatus
+    ) -> ReleaseValidationCheckStatus {
+        if lhs == .failed || rhs == .failed {
+            return .failed
+        }
+        if lhs == .skipped || rhs == .skipped {
+            return .skipped
+        }
+        return .passed
     }
 }

--- a/MinuteCore/Tests/MinuteCoreTests/ReleaseValidationSummaryTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/ReleaseValidationSummaryTests.swift
@@ -104,4 +104,96 @@ struct ReleaseValidationSummaryTests {
 
         #expect(summary.overallStatus == .failed)
     }
+
+    @Test
+    func refreshOverallStatus_reportsFailedWhenRequiredCheckIsSkipped() {
+        var summary = ReleaseValidationSummary(
+            runID: "run-4",
+            profile: .direct,
+            overallStatus: .passed,
+            checks: [
+                ReleaseValidationCheckResult(
+                    checkType: .profileConfig,
+                    target: "profile",
+                    status: .passed,
+                    message: "profile is valid"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .signature,
+                    target: "Minute.app",
+                    status: .passed,
+                    message: "signature valid"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .updaterPolicy,
+                    target: "Minute.app",
+                    status: .passed,
+                    message: "updater policy valid"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .artifactPolicy,
+                    target: "output",
+                    status: .skipped,
+                    message: "artifact policy skipped unexpectedly"
+                ),
+            ],
+            artifacts: []
+        )
+
+        summary.refreshOverallStatus(requiredChecks: DistributionProfile.direct.requiredValidationChecks)
+
+        #expect(summary.overallStatus == .failed)
+    }
+
+    @Test
+    func refreshOverallStatus_prefersWorstStatusWhenChecksContainDuplicates() {
+        var summary = ReleaseValidationSummary(
+            runID: "run-5",
+            profile: .appStore,
+            overallStatus: .passed,
+            checks: [
+                ReleaseValidationCheckResult(
+                    checkType: .profileConfig,
+                    target: "profile",
+                    status: .passed,
+                    message: "profile is valid"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .signature,
+                    target: "Minute.app",
+                    status: .passed,
+                    message: "signature valid"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .signature,
+                    target: "Sparkle.framework",
+                    status: .failed,
+                    message: "sparkle signature invalid"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .sandboxPolicy,
+                    target: "Minute.app",
+                    status: .passed,
+                    message: "sandbox valid"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .updaterPolicy,
+                    target: "Minute.app",
+                    status: .passed,
+                    message: "updater disabled"
+                ),
+                ReleaseValidationCheckResult(
+                    checkType: .artifactPolicy,
+                    target: "output",
+                    status: .passed,
+                    message: "artifact policy valid"
+                ),
+            ],
+            artifacts: []
+        )
+
+        summary.refreshOverallStatus(requiredChecks: DistributionProfile.appStore.requiredValidationChecks)
+
+        #expect(summary.overallStatus == .failed)
+    }
 }

--- a/MinuteTests/UpdaterProfileBehaviorTests.swift
+++ b/MinuteTests/UpdaterProfileBehaviorTests.swift
@@ -25,6 +25,7 @@ struct UpdaterProfileBehaviorTests {
             "MINUTEDistributionProfile": "app-store",
             "MINUTEEnableUpdater": "NO",
         ])
+        defer { try? FileManager.default.removeItem(at: bundleURL.deletingLastPathComponent()) }
         let bundle = try #require(Bundle(url: bundleURL))
 
         let config = AppDistributionConfiguration.current(bundle: bundle)

--- a/scripts/normalize-app-store-archive.sh
+++ b/scripts/normalize-app-store-archive.sh
@@ -113,6 +113,8 @@ if [ -d "$SPARKLE_FRAMEWORK" ]; then
   find "$SPARKLE_FRAMEWORK/Versions" -type f -name "Autoupdate" -print0 2>/dev/null | while IFS= read -r -d '' autoupdate; do
     sign_path "$autoupdate" "$HELPER_ENTITLEMENTS_PATH"
   done
+
+  sign_path "$SPARKLE_FRAMEWORK"
 fi
 
 app_entitlements="$TEMP_DIR/app-entitlements.plist"

--- a/scripts/release-notarize.sh
+++ b/scripts/release-notarize.sh
@@ -350,6 +350,8 @@ sign_sparkle_helpers() {
   find "$sparkle_framework/Versions" -type f -name "Autoupdate" -print0 2>/dev/null | while IFS= read -r -d '' autoupdate; do
     sign_path "$autoupdate" "$helper_fallback"
   done
+
+  sign_path "$sparkle_framework"
 }
 
 INFO_PLIST="$APP_PATH/Contents/Info.plist"
@@ -482,7 +484,9 @@ if [ "$GENERATE_APPCAST" = "1" ]; then
     echo "Copied appcast to $APPCAST_DEST"
   fi
 
-  summary_add_artifact "$SUMMARY_PATH" "appcast" "$APPCAST_DEST" "$DIST_PROFILE"
+  if [ -n "$APPCAST_DEST" ]; then
+    summary_add_artifact "$SUMMARY_PATH" "appcast" "$APPCAST_DEST" "$DIST_PROFILE"
+  fi
 fi
 
 summary_set_status "$SUMMARY_PATH" "completed"

--- a/scripts/sign-hardened-runtime.sh
+++ b/scripts/sign-hardened-runtime.sh
@@ -103,6 +103,8 @@ if [ -d "$SPARKLE_FRAMEWORK" ]; then
   find "$SPARKLE_FRAMEWORK/Versions" -type f -name "Autoupdate" -print0 2>/dev/null | while IFS= read -r -d '' autoupdate; do
     sign_path "$autoupdate" "$HELPER_FALLBACK"
   done
+
+  sign_path "$SPARKLE_FRAMEWORK"
 fi
 
 VENDOR_DIR="$SRCROOT/MinuteCore/Vendor"


### PR DESCRIPTION
This follow-up PR applies the review fixes that were committed after PR #36 was already merged.

## Why
PR #36 merged before these review changes landed, so main is missing them.

## Included fixes
- set Makefile shell to Bash for profile helper sourcing
- add App Store sandbox entitlement to MinuteAppStore.entitlements
- avoid assign(to:on:) retain cycle in UpdaterViewModel
- harden ReleaseValidationSummary.refreshOverallStatus for duplicate check types
- add tests for skipped/duplicate validation check behavior
- clean up temporary test bundle in UpdaterProfileBehaviorTests
- re-sign Sparkle.framework bundle after signing nested Sparkle components
- avoid recording empty appcast artifact path in release summary

## Validation
- ./scripts/tests/release-profile-args-smoke.sh
- ./scripts/tests/release-direct-profile-smoke.sh
- ./scripts/tests/release-app-store-artifacts-smoke.sh
- ./scripts/tests/release-app-store-preflight-smoke.sh
- xcodebuild -workspace Minute.xcworkspace -scheme MinuteCore -configuration Debug test -destination 'platform=macOS'
- xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug test -destination 'platform=macOS'

Refs: #36
