### PR TITLE
chore: refactor and simplify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,8 @@ If CI is added, prefer using `xcodebuild` so it matches local behavior.
 - Local app settings persistence for global vocabulary config + session-scoped in-memory override state; no new vault output files (011-vocabulary-boosting)
 - Swift (SwiftUI app target, Swift package modules) + SwiftUI, AppKit, Combine, MinuteCore, existing settings view models/services (012-settings-improvements)
 - Existing local settings persistence (`UserDefaults` + local file-backed app state where already used); no new storage systems (012-settings-improvements)
+- Swift 5.9+ (Xcode 15.x), Swift tools 6.2 for `MinuteCore` package + SwiftUI, Combine, AVFoundation, ScreenCaptureKit, UserNotifications, MinuteCore package modules (013-simplify-architecture)
+- Local files (vault outputs and temporary session artifacts) + local preferences in `UserDefaults` (013-simplify-architecture)
 
 ## Recent Changes
 - 011-vocabulary-boosting: Added Swift (SwiftUI app target + Swift tools 6.2 package) + SwiftUI, MinuteCore, FluidAudio, OSLog, existing model manager/status components

--- a/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
+++ b/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
@@ -67,14 +67,6 @@ final class MeetingPipelineViewModel: ObservableObject {
         var isFirstInferenceDeferred: Bool
     }
 
-    private struct ObservedDefaultsSnapshot: Equatable {
-        var vaultRootBookmark: Data?
-        var vaultRootPathDisplay: String?
-        var outputLanguageRawValue: String?
-        var transcriptionBackendID: String?
-        var vocabularySettings: GlobalVocabularyBoostingSettings
-    }
-
     enum CaptureState: Equatable {
         case ready
         case recording
@@ -192,7 +184,7 @@ final class MeetingPipelineViewModel: ObservableObject {
     private let defaults: UserDefaults
 
     private var defaultsObserver: AnyCancellable?
-    private var observedDefaultsSnapshot: ObservedDefaultsSnapshot?
+    private var observedDefaultsSnapshot: PipelineDefaultsObserver.Snapshot?
     private var cancellables: Set<AnyCancellable> = []
     private var processingTask: Task<Void, Never>?
     private var backgroundProcessingObserverTask: Task<Void, Never>?
@@ -484,41 +476,27 @@ final class MeetingPipelineViewModel: ObservableObject {
 
     private func handleDefaultsDidChange() {
         let snapshot = makeObservedDefaultsSnapshot()
-        guard snapshot != observedDefaultsSnapshot else { return }
-
-        let previous = observedDefaultsSnapshot
+        let changed = PipelineDefaultsObserver.changedDomains(previous: observedDefaultsSnapshot, current: snapshot)
+        guard changed.hasChanges else { return }
         observedDefaultsSnapshot = snapshot
 
-        guard let previous else {
-            refreshVaultStatus()
-            refreshOutputLanguageSetting()
-            refreshTranscriptionBackendSetting()
-            refreshVocabularySettings()
-            return
-        }
-
-        let vaultStatusChanged =
-            previous.vaultRootBookmark != snapshot.vaultRootBookmark
-            || previous.vaultRootPathDisplay != snapshot.vaultRootPathDisplay
-        if vaultStatusChanged {
+        if changed.requiresFullRefresh || changed.vaultStatusChanged {
             refreshVaultStatus()
         }
-        if previous.outputLanguageRawValue != snapshot.outputLanguageRawValue {
+        if changed.requiresFullRefresh || changed.outputLanguageChanged {
             refreshOutputLanguageSetting()
         }
-        if previous.transcriptionBackendID != snapshot.transcriptionBackendID {
+        if changed.requiresFullRefresh || changed.transcriptionBackendChanged {
             refreshTranscriptionBackendSetting()
         }
-        if previous.vocabularySettings != snapshot.vocabularySettings {
+        if changed.requiresFullRefresh || changed.vocabularySettingsChanged {
             refreshVocabularySettings()
         }
     }
 
-    private func makeObservedDefaultsSnapshot() -> ObservedDefaultsSnapshot {
-        return ObservedDefaultsSnapshot(
-            vaultRootBookmark: defaults.data(forKey: AppConfiguration.Defaults.vaultRootBookmarkKey),
-            vaultRootPathDisplay: defaults.string(forKey: AppConfiguration.Defaults.vaultRootPathDisplayKey),
-            outputLanguageRawValue: defaults.string(forKey: AppConfiguration.Defaults.outputLanguageKey),
+    private func makeObservedDefaultsSnapshot() -> PipelineDefaultsObserver.Snapshot {
+        PipelineDefaultsObserver.makeSnapshot(
+            defaults: defaults,
             transcriptionBackendID: transcriptionBackendStore.selectedBackendID(),
             vocabularySettings: vocabularySettingsStore.load()
         )
@@ -1728,21 +1706,6 @@ final class MeetingPipelineViewModel: ObservableObject {
         let pb = NSPasteboard.general
         pb.clearContents()
         pb.setString(content, forType: .string)
-    }
-}
-
-private struct FailingTranscriptionService: TranscriptionServicing {
-    let error: MinuteError
-
-    init(error: Error) {
-        self.error = ErrorHandler.minuteError(
-            for: error,
-            fallback: .whisperFailed(exitCode: -1, output: ErrorHandler.debugMessage(for: error))
-        )
-    }
-
-    func transcribe(wavURL: URL) async throws -> TranscriptionResult {
-        throw error
     }
 }
 

--- a/Minute/Sources/ViewModels/ModelSetupLifecycleController.swift
+++ b/Minute/Sources/ViewModels/ModelSetupLifecycleController.swift
@@ -1,0 +1,125 @@
+import Combine
+import Foundation
+import MinuteCore
+
+@MainActor
+final class ModelSetupLifecycleController: ObservableObject {
+    enum State: Equatable {
+        case checking
+        case ready
+        case needsDownload(message: String?)
+        case downloading(progress: ModelDownloadProgress?)
+    }
+
+    @Published private(set) var state: State = .checking
+    @Published private(set) var lastValidation = ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])
+
+    private let modelManager: any ModelManaging
+    private let displayName: (String) -> String
+    private var downloadTask: Task<Void, Never>?
+    private var validationTask: Task<Void, Never>?
+
+    init(
+        modelManager: any ModelManaging,
+        displayName: @escaping (String) -> String
+    ) {
+        self.modelManager = modelManager
+        self.displayName = displayName
+    }
+
+    deinit {
+        downloadTask?.cancel()
+        validationTask?.cancel()
+    }
+
+    func refresh() {
+        scheduleValidation()
+    }
+
+    func startDownload() {
+        downloadTask?.cancel()
+        state = .downloading(progress: ModelDownloadProgress(fractionCompleted: 0, label: "Starting download"))
+
+        downloadTask = Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let validation = try await modelManager.validateModels()
+                if !validation.invalidModelIDs.isEmpty {
+                    try await modelManager.removeModels(withIDs: validation.invalidModelIDs)
+                }
+
+                try await modelManager.ensureModelsPresent { [weak self] update in
+                    Task { @MainActor [weak self] in
+                        self?.state = .downloading(progress: update)
+                    }
+                }
+
+                state = .checking
+                await refreshStatus()
+            } catch {
+                let message = ErrorHandler.userMessage(for: error, fallback: "Failed to download models.")
+                state = .needsDownload(message: message)
+            }
+        }
+    }
+
+    private func scheduleValidation() {
+        validationTask?.cancel()
+        validationTask = Task { [weak self] in
+            guard let self else { return }
+            await refreshStatus()
+        }
+    }
+
+    private func refreshStatus() async {
+        if case .downloading = state {
+            return
+        }
+        guard !Task.isCancelled else { return }
+
+        let wasReady: Bool
+        if case .ready = state {
+            wasReady = true
+        } else {
+            wasReady = false
+        }
+
+        if !wasReady {
+            state = .checking
+        }
+
+        do {
+            let result = try await modelManager.validateModels()
+            guard !Task.isCancelled else { return }
+            lastValidation = result
+            if result.isReady {
+                state = .ready
+            } else {
+                state = .needsDownload(message: modelMessage(from: result))
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            lastValidation = ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])
+            let message = ErrorHandler.userMessage(for: error, fallback: "Failed to check model status.")
+            state = .needsDownload(message: message)
+        }
+    }
+
+    private func modelMessage(from result: ModelValidationResult) -> String {
+        if result.missingModelIDs.isEmpty && result.invalidModelIDs.isEmpty {
+            return "Models ready."
+        }
+
+        var parts: [String] = []
+        if !result.missingModelIDs.isEmpty {
+            let names = result.missingModelIDs.map(displayName)
+            parts.append("Missing: \(names.joined(separator: ", "))")
+        }
+        if !result.invalidModelIDs.isEmpty {
+            let names = result.invalidModelIDs.map(displayName)
+            parts.append("Invalid: \(names.joined(separator: ", "))")
+        }
+        return parts.joined(separator: " ")
+    }
+}

--- a/Minute/Sources/ViewModels/PipelineDefaultsObserver.swift
+++ b/Minute/Sources/ViewModels/PipelineDefaultsObserver.swift
@@ -1,0 +1,64 @@
+import Foundation
+import MinuteCore
+
+struct PipelineDefaultsObserver {
+    struct Snapshot: Equatable {
+        var vaultRootBookmark: Data?
+        var vaultRootPathDisplay: String?
+        var outputLanguageRawValue: String?
+        var transcriptionBackendID: String?
+        var vocabularySettings: GlobalVocabularyBoostingSettings
+    }
+
+    struct ChangedDomains: Equatable {
+        var requiresFullRefresh: Bool
+        var vaultStatusChanged: Bool
+        var outputLanguageChanged: Bool
+        var transcriptionBackendChanged: Bool
+        var vocabularySettingsChanged: Bool
+
+        var hasChanges: Bool {
+            requiresFullRefresh
+                || vaultStatusChanged
+                || outputLanguageChanged
+                || transcriptionBackendChanged
+                || vocabularySettingsChanged
+        }
+    }
+
+    static func makeSnapshot(
+        defaults: UserDefaults,
+        transcriptionBackendID: String?,
+        vocabularySettings: GlobalVocabularyBoostingSettings
+    ) -> Snapshot {
+        Snapshot(
+            vaultRootBookmark: defaults.data(forKey: AppConfiguration.Defaults.vaultRootBookmarkKey),
+            vaultRootPathDisplay: defaults.string(forKey: AppConfiguration.Defaults.vaultRootPathDisplayKey),
+            outputLanguageRawValue: defaults.string(forKey: AppConfiguration.Defaults.outputLanguageKey),
+            transcriptionBackendID: transcriptionBackendID,
+            vocabularySettings: vocabularySettings
+        )
+    }
+
+    static func changedDomains(previous: Snapshot?, current: Snapshot) -> ChangedDomains {
+        guard let previous else {
+            return ChangedDomains(
+                requiresFullRefresh: true,
+                vaultStatusChanged: true,
+                outputLanguageChanged: true,
+                transcriptionBackendChanged: true,
+                vocabularySettingsChanged: true
+            )
+        }
+
+        return ChangedDomains(
+            requiresFullRefresh: false,
+            vaultStatusChanged:
+                previous.vaultRootBookmark != current.vaultRootBookmark
+                || previous.vaultRootPathDisplay != current.vaultRootPathDisplay,
+            outputLanguageChanged: previous.outputLanguageRawValue != current.outputLanguageRawValue,
+            transcriptionBackendChanged: previous.transcriptionBackendID != current.transcriptionBackendID,
+            vocabularySettingsChanged: previous.vocabularySettings != current.vocabularySettings
+        )
+    }
+}

--- a/Minute/Sources/ViewModels/PipelineStatusPresenter.swift
+++ b/Minute/Sources/ViewModels/PipelineStatusPresenter.swift
@@ -1,0 +1,217 @@
+import Foundation
+import MinuteCore
+
+struct PipelineStatusPresenter {
+    struct Input {
+        var state: MeetingPipelineState
+        var backgroundProcessingSnapshot: BackgroundProcessingSnapshot
+        var isFirstScreenInferenceDeferred: Bool
+        var progress: Double?
+        var recoverableRecordings: [RecoverableRecording]
+        var recordingWarningDetail: String?
+    }
+
+    enum Action: Equatable {
+        case keepRecording
+        case cancelBackgroundProcessing(clearPending: Bool)
+        case retryBackgroundProcessing
+        case recoverRecording(RecoverableRecording)
+        case discardRecoverableRecording(RecoverableRecording)
+        case process
+        case revealInFinder(URL)
+    }
+
+    struct Presentation: Equatable {
+        var title: String
+        var detail: String
+        var progress: Double?
+        var showsActivity: Bool
+        var isError: Bool
+        var primaryActionTitle: String?
+        var primaryAction: Action?
+        var secondaryActionTitle: String?
+        var secondaryAction: Action?
+        var showsCloseButton: Bool
+    }
+
+    func presentation(for input: Input, dismissedStatusDrawerID: String?) -> Presentation? {
+        if let dismissibleID = dismissibleStatusDrawerID(for: input.state),
+           dismissibleID == dismissedStatusDrawerID {
+            return nil
+        }
+
+        if case .recording = input.state,
+           let warningDetail = input.recordingWarningDetail {
+            return Presentation(
+                title: "Do you want to keep recording?",
+                detail: warningDetail,
+                progress: nil,
+                showsActivity: false,
+                isError: true,
+                primaryActionTitle: "Keep Recording",
+                primaryAction: .keepRecording,
+                secondaryActionTitle: nil,
+                secondaryAction: nil,
+                showsCloseButton: false
+            )
+        }
+
+        if input.backgroundProcessingSnapshot.activeMeetingID != nil {
+            let stage = input.backgroundProcessingSnapshot.activeStage
+            let progress = input.backgroundProcessingSnapshot.activeProgress
+            let hasPending = input.backgroundProcessingSnapshot.pendingMeetingID != nil
+
+            let title: String
+            switch stage {
+            case .downloadingModels:
+                title = "Downloading Models"
+            case .transcribing:
+                title = "Transcribing"
+            case .summarizing:
+                title = "Summarizing"
+            case .writing:
+                title = "Writing"
+            case nil:
+                title = "Processing"
+            }
+
+            let baseDetail = input.isFirstScreenInferenceDeferred
+                ? "Your recorded meeting is processing. Screen context disabled until processing is done."
+                : "Your recorded meeting is processing in the background."
+            let detail = hasPending
+                ? baseDetail + " Another meeting is pending next."
+                : baseDetail
+
+            return Presentation(
+                title: title,
+                detail: detail,
+                progress: progress,
+                showsActivity: progress == nil,
+                isError: false,
+                primaryActionTitle: "Cancel",
+                primaryAction: .cancelBackgroundProcessing(clearPending: true),
+                secondaryActionTitle: nil,
+                secondaryAction: nil,
+                showsCloseButton: false
+            )
+        }
+
+        if case .idle = input.state {
+            switch input.backgroundProcessingSnapshot.lastOutcome {
+            case .failed(let message):
+                return Presentation(
+                    title: "Processing failed",
+                    detail: message,
+                    progress: nil,
+                    showsActivity: false,
+                    isError: true,
+                    primaryActionTitle: "Retry",
+                    primaryAction: .retryBackgroundProcessing,
+                    secondaryActionTitle: nil,
+                    secondaryAction: nil,
+                    showsCloseButton: false
+                )
+            case .canceled:
+                return Presentation(
+                    title: "Processing was canceled",
+                    detail: "You can retry this meeting later.",
+                    progress: nil,
+                    showsActivity: false,
+                    isError: false,
+                    primaryActionTitle: "Retry",
+                    primaryAction: .retryBackgroundProcessing,
+                    secondaryActionTitle: nil,
+                    secondaryAction: nil,
+                    showsCloseButton: false
+                )
+            case .completed, nil:
+                break
+            }
+        }
+
+        if case .idle = input.state,
+           let recovery = input.recoverableRecordings.first {
+            let folderName = recovery.sessionURL.lastPathComponent
+            return Presentation(
+                title: "Unfinished meeting found",
+                detail: "An unfinished meeting was found in \(folderName). Do you want to recover it?",
+                progress: nil,
+                showsActivity: false,
+                isError: false,
+                primaryActionTitle: "Recover",
+                primaryAction: .recoverRecording(recovery),
+                secondaryActionTitle: "Delete",
+                secondaryAction: .discardRecoverableRecording(recovery),
+                showsCloseButton: false
+            )
+        }
+
+        switch input.state {
+        case .recorded:
+            return Presentation(
+                title: "Recording ready",
+                detail: "This meeting is ready to process.",
+                progress: nil,
+                showsActivity: false,
+                isError: false,
+                primaryActionTitle: "Process",
+                primaryAction: .process,
+                secondaryActionTitle: nil,
+                secondaryAction: nil,
+                showsCloseButton: false
+            )
+        case .processing, .writing, .importing:
+            return Presentation(
+                title: input.state.statusLabel,
+                detail: "Meeting is being processed.",
+                progress: input.progress,
+                showsActivity: input.progress == nil,
+                isError: false,
+                primaryActionTitle: nil,
+                primaryAction: nil,
+                secondaryActionTitle: nil,
+                secondaryAction: nil,
+                showsCloseButton: false
+            )
+        case .done(let noteURL, _):
+            return Presentation(
+                title: "Meeting ready",
+                detail: "Your note, transcript, and audio are in the vault.",
+                progress: nil,
+                showsActivity: false,
+                isError: false,
+                primaryActionTitle: "Reveal in Finder",
+                primaryAction: .revealInFinder(noteURL),
+                secondaryActionTitle: nil,
+                secondaryAction: nil,
+                showsCloseButton: true
+            )
+        case .failed(let error, _):
+            return Presentation(
+                title: "Processing failed",
+                detail: ErrorHandler.userMessage(for: error, fallback: "Processing failed."),
+                progress: nil,
+                showsActivity: false,
+                isError: true,
+                primaryActionTitle: nil,
+                primaryAction: nil,
+                secondaryActionTitle: nil,
+                secondaryAction: nil,
+                showsCloseButton: true
+            )
+        default:
+            return nil
+        }
+    }
+
+    func dismissibleStatusDrawerID(for state: MeetingPipelineState) -> String? {
+        switch state {
+        case .recorded(let audioTempURL, _, let startedAt, let stoppedAt):
+            return "recorded:\(audioTempURL.path):\(startedAt.timeIntervalSinceReferenceDate):\(stoppedAt.timeIntervalSinceReferenceDate)"
+        case .done(let noteURL, _):
+            return "done:\(noteURL.path)"
+        default:
+            return nil
+        }
+    }
+}

--- a/Minute/Sources/Views/MeetingNotes/MarkdownViewerOverlay.swift
+++ b/Minute/Sources/Views/MeetingNotes/MarkdownViewerOverlay.swift
@@ -1,5 +1,6 @@
 import AppKit
 import MarkdownUI
+import MinuteCore
 import SwiftUI
 
 struct MarkdownViewerOverlay: View {
@@ -291,7 +292,7 @@ struct MarkdownViewerOverlay: View {
                   !activeRenderPlainText,
                   let editor = speakerEditor,
                   let transcript = (rawTranscriptContent ?? transcriptContent),
-                  TranscriptLineParser.containsSpeakerHeader(transcript) {
+                  MeetingNoteParsing.containsSpeakerHeader(transcript) {
             InteractiveTranscriptView(
                 transcript: transcript,
                 speakerName: editor.speakerName,
@@ -506,13 +507,13 @@ private struct InteractiveTranscriptView: View {
     let saveSpeakerNames: () -> Void
 
     var body: some View {
-        let (header, body) = TranscriptLineParser.splitHeaderAndBody(transcript)
-        let lines = TranscriptLineParser.parse(body)
+        let split = MeetingNoteParsing.splitTranscriptHeaderAndBody(transcript)
+        let lines = MeetingNoteParsing.parseTranscriptLines(split.body)
 
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 6) {
-                if !header.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Markdown(Frontmatter.decorateContent(header))
+                if !split.header.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Markdown(Frontmatter.decorateContent(split.header))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.bottom, 12)
                 }
@@ -563,11 +564,6 @@ private struct InteractiveTranscriptView: View {
     }
 }
 
-private enum TranscriptLine: Equatable {
-    case speakerHeader(TranscriptSpeakerHeader)
-    case text(String)
-}
-
 enum TranscriptSpeakerColorResolver {
     static func color(for speakerID: Int) -> Color {
         let hue = CGFloat(TranscriptSpeakerHueResolver.hue(for: speakerID))
@@ -589,104 +585,8 @@ enum TranscriptSpeakerHueResolver {
     }
 }
 
-private struct TranscriptSpeakerHeader: Equatable {
-    var speakerId: Int
-    var detectedName: String?
-    var suffix: String
-}
-
-private enum TranscriptLineParser {
-    /// Deterministic parser for speaker header lines.
-    ///
-    /// Supported formats (examples):
-    /// - `Speaker 1 (Einar) [00:00 - 00:43] ...`
-    /// - `Speaker 3 [01:04 - 01:12] ...`
-    ///
-    /// Parsing strategy:
-    /// - Only recognizes lines whose trimmed prefix starts with `Speaker <digits>`
-    /// - Captures optional `(Name)` that appears immediately after the id
-    /// - Captures the suffix starting at the first ` [` (bracketed time range + trailing text)
-    static func parse(_ transcript: String) -> [TranscriptLine] {
-        let lines = transcript.split(separator: "\n", omittingEmptySubsequences: false)
-        return lines.map { sub in
-            let line = String(sub)
-            if let header = parseSpeakerHeader(line) {
-                return .speakerHeader(header)
-            }
-            return .text(line)
-        }
-    }
-
-    static func splitHeaderAndBody(_ transcript: String) -> (header: String, body: String) {
-        let lines = transcript.split(separator: "\n", omittingEmptySubsequences: false)
-
-        var firstHeaderIndex: Int?
-        for (index, lineSub) in lines.enumerated() {
-            if parseSpeakerHeader(String(lineSub)) != nil {
-                firstHeaderIndex = index
-                break
-            }
-        }
-
-        guard let firstHeaderIndex else {
-            return (header: transcript, body: "")
-        }
-
-        let headerLines = lines.prefix(firstHeaderIndex)
-        let bodyLines = lines.suffix(from: firstHeaderIndex)
-
-        return (
-            header: headerLines.joined(separator: "\n"),
-            body: bodyLines.joined(separator: "\n")
-        )
-    }
-
-    static func containsSpeakerHeader(_ transcript: String) -> Bool {
-        for lineSub in transcript.split(separator: "\n", omittingEmptySubsequences: false) {
-            if parseSpeakerHeader(String(lineSub)) != nil {
-                return true
-            }
-        }
-        return false
-    }
-
-    private static func parseSpeakerHeader(_ line: String) -> TranscriptSpeakerHeader? {
-        let leadingWhitespace = line.prefix { $0.isWhitespace }
-        let remainder = line.dropFirst(leadingWhitespace.count)
-        let trimmed = remainder.trimmingCharacters(in: .whitespaces)
-
-        guard trimmed.hasPrefix("Speaker ") else { return nil }
-
-        let afterPrefix = trimmed.dropFirst("Speaker ".count)
-        let digits = afterPrefix.prefix { $0.isNumber }
-        guard let speakerId = Int(digits) else { return nil }
-
-        let afterDigits = afterPrefix.dropFirst(digits.count)
-        var detectedName: String?
-
-        let afterDigitsTrimmed = afterDigits.trimmingCharacters(in: .whitespaces)
-        if afterDigitsTrimmed.hasPrefix("(") {
-            if let closeIndex = afterDigitsTrimmed.firstIndex(of: ")") {
-                let nameRange = afterDigitsTrimmed.index(after: afterDigitsTrimmed.startIndex)..<closeIndex
-                let name = String(afterDigitsTrimmed[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-                if !name.isEmpty {
-                    detectedName = name
-                }
-            }
-        }
-
-        guard let bracketRange = trimmed.range(of: " [") else {
-            // No canonical time bracket means we treat it as a normal line to avoid false positives.
-            return nil
-        }
-
-        let suffix = String(trimmed[bracketRange.lowerBound...])
-        return TranscriptSpeakerHeader(speakerId: speakerId, detectedName: detectedName, suffix: suffix)
-    }
-}
-
 private struct SpeakerHeaderRow: View {
-    let header: TranscriptSpeakerHeader
+    let header: MeetingNoteParsing.SpeakerHeader
     let speakerColor: Color
     let currentDisplayName: String?
     let knownProfileNames: [String]

--- a/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift
+++ b/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift
@@ -47,9 +47,11 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
     @Published private(set) var transcriptDisplayContent: String?
     @Published private(set) var transcriptErrorMessage: String?
     @Published private(set) var renderTranscriptPlainText: Bool = false
-    @Published private(set) var selectedItem: MeetingNoteItem?
-    @Published private(set) var selectedTab: MeetingNotePreviewTab = .summary
-    @Published var isOverlayPresented: Bool = false
+    @Published private(set) var overlayState = MeetingNotesOverlayState()
+
+    var selectedItem: MeetingNoteItem? { overlayState.selectedItem }
+    var selectedTab: MeetingNotePreviewTab { overlayState.selectedTab }
+    var isOverlayPresented: Bool { overlayState.isPresented }
 
     // US3: Speaker naming (frontmatter-only persistence).
     @Published private(set) var speakerIDs: [Int] = []
@@ -160,10 +162,8 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
 
     func select(_ item: MeetingNoteItem) {
         resetSpeakerNamingState()
-        selectedItem = item
-        selectedTab = .summary
+        overlayState.select(item)
         resetTranscriptState()
-        isOverlayPresented = true
         startLoadingSummary(for: item)
 
         // Load speaker IDs from the transcript in the background so the Speakers UI is consistent
@@ -274,7 +274,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
 
     func selectTab(_ tab: MeetingNotePreviewTab) {
         guard selectedTab != tab else { return }
-        selectedTab = tab
+        overlayState.selectTab(tab)
         if tab == .transcription {
             loadTranscriptIfNeeded()
         }
@@ -283,9 +283,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
     func dismissOverlay() {
         loadTask?.cancel()
         transcriptLoadTask?.cancel()
-        isOverlayPresented = false
-        selectedItem = nil
-        selectedTab = .summary
+        overlayState.dismiss()
         noteContent = nil
         overlayErrorMessage = nil
         renderPlainText = false
@@ -588,7 +586,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
                 self?.renderTranscriptPlainText = shouldRenderPlainText
                 self?.isLoadingTranscript = false
 
-                self?.transcriptSpeakerIDs = Self.parseSpeakerIDs(fromTranscriptMarkdown: content)
+                self?.transcriptSpeakerIDs = MeetingNoteParsing.parseSpeakerIDs(fromTranscriptMarkdown: content)
 
                 self?.refreshSpeakerDraftsIfPossible()
                 self?.updateTranscriptDisplayContent()
@@ -621,7 +619,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
                 let content = try await self?.runBrowserOperation { browser in
                     try await browser.loadTranscriptContent(for: item)
                 } ?? ""
-                let ids = Self.parseSpeakerIDs(fromTranscriptMarkdown: content)
+                let ids = MeetingNoteParsing.parseSpeakerIDs(fromTranscriptMarkdown: content)
                 self?.transcriptSpeakerIDs = ids
                 self?.refreshSpeakerDraftsIfPossible()
             } catch is CancellationError {
@@ -652,7 +650,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
     }
 
     private func refreshSpeakerDraftsIfPossible() {
-        let speakerIDsFromTranscript = Set(Self.parseSpeakerIDs(fromTranscriptMarkdown: transcriptContent))
+        let speakerIDsFromTranscript = Set(MeetingNoteParsing.parseSpeakerIDs(fromTranscriptMarkdown: transcriptContent))
             .union(transcriptSpeakerIDs)
 
         // Load existing mapping from the meeting note frontmatter, if present.
@@ -768,61 +766,10 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
         }
 
         // Display-only transform: replace "Speaker N" headings when a name exists.
-        transcriptDisplayContent = Self.rewriteSpeakerHeadingsForDisplay(
+        transcriptDisplayContent = MeetingNoteParsing.rewriteSpeakerHeadingsForDisplay(
             transcriptMarkdown: raw,
             speakerDisplayNames: speakerNameDrafts
         )
-    }
-
-    nonisolated static func parseSpeakerIDs(fromTranscriptMarkdown markdown: String?) -> [Int] {
-        guard let markdown else { return [] }
-
-        var ids: Set<Int> = []
-        for line in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard trimmed.hasPrefix("Speaker ") else { continue }
-
-            let afterPrefix = trimmed.dropFirst("Speaker ".count)
-            let digits = afterPrefix.prefix { $0.isNumber }
-            if let id = Int(digits) {
-                ids.insert(id)
-            }
-        }
-
-        return ids.sorted()
-    }
-
-    nonisolated static func rewriteSpeakerHeadingsForDisplay(
-        transcriptMarkdown: String,
-        speakerDisplayNames: [Int: String]
-    ) -> String {
-        let lines = transcriptMarkdown.split(separator: "\n", omittingEmptySubsequences: false)
-        var out: [String] = []
-        out.reserveCapacity(lines.count)
-
-        for lineSub in lines {
-            let line = String(lineSub)
-            let leadingWhitespace = line.prefix { $0.isWhitespace }
-            let remainder = line.dropFirst(leadingWhitespace.count)
-            let trimmed = remainder.trimmingCharacters(in: .whitespaces)
-
-            if trimmed.hasPrefix("Speaker ") {
-                let afterPrefix = trimmed.dropFirst("Speaker ".count)
-                let digits = afterPrefix.prefix { $0.isNumber }
-                if let id = Int(digits),
-                   let name = speakerDisplayNames[id]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !name.isEmpty,
-                   let bracketRange = trimmed.range(of: " [") {
-                    // Replace the entire heading token (Speaker N + optional " (Name)") with the current name.
-                    let suffix = String(trimmed[bracketRange.lowerBound...])
-                    out.append(String(leadingWhitespace) + name + suffix)
-                    continue
-                }
-            }
-            out.append(line)
-        }
-
-        return out.joined(separator: "\n")
     }
 
     nonisolated private static func makeVaultAccess() -> VaultAccess {
@@ -840,21 +787,8 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
         transcriptsRelativePath: String
     ) -> URL {
         let baseName = item.fileURL.deletingPathExtension().lastPathComponent
-        let root = Self.directoryURL(from: vaultRootURL, relativePath: transcriptsRelativePath)
+        let root = VaultPathNormalizer.directoryURL(from: vaultRootURL, relativePath: transcriptsRelativePath)
         return root.appendingPathComponent("\(baseName).md")
-    }
-
-    nonisolated private static func directoryURL(from vaultRootURL: URL, relativePath: String) -> URL {
-        let components = relativePath
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-            .split(separator: "/")
-            .map(String.init)
-            .filter { !$0.isEmpty && $0 != "." && $0 != ".." }
-
-        return components.reduce(vaultRootURL) { partial, component in
-            partial.appendingPathComponent(component, isDirectory: true)
-        }
     }
 
     nonisolated private static func defaultBrowserProvider() -> any MeetingNotesBrowsing {

--- a/Minute/Sources/Views/MeetingNotes/MeetingNotesOverlayState.swift
+++ b/Minute/Sources/Views/MeetingNotes/MeetingNotesOverlayState.swift
@@ -1,0 +1,34 @@
+import MinuteCore
+
+struct MeetingNotesOverlayState: Equatable {
+    var selectedItem: MeetingNoteItem?
+    var selectedTab: MeetingNotePreviewTab
+    var isPresented: Bool
+
+    init(
+        selectedItem: MeetingNoteItem? = nil,
+        selectedTab: MeetingNotePreviewTab = .summary,
+        isPresented: Bool = false
+    ) {
+        self.selectedItem = selectedItem
+        self.selectedTab = selectedTab
+        self.isPresented = isPresented
+    }
+
+    mutating func select(_ item: MeetingNoteItem) {
+        selectedItem = item
+        selectedTab = .summary
+        isPresented = true
+    }
+
+    mutating func selectTab(_ tab: MeetingNotePreviewTab) {
+        guard selectedTab != tab else { return }
+        selectedTab = tab
+    }
+
+    mutating func dismiss() {
+        selectedItem = nil
+        selectedTab = .summary
+        isPresented = false
+    }
+}

--- a/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -14,12 +14,7 @@ final class OnboardingViewModel: ObservableObject {
         case complete
     }
 
-    enum ModelsState: Equatable {
-        case checking
-        case ready
-        case needsDownload(message: String?)
-        case downloading(progress: ModelDownloadProgress?)
-    }
+    typealias ModelsState = ModelSetupLifecycleController.State
 
     @Published private(set) var currentStep: Step = .intro
     @Published private(set) var microphonePermissionGranted = false
@@ -30,42 +25,41 @@ final class OnboardingViewModel: ObservableObject {
         didSet {
             guard oldValue != selectedSummarizationModelID else { return }
             summarizationModelStore.setSelectedModelID(selectedSummarizationModelID)
-            scheduleModelsValidation()
+            modelLifecycleController.refresh()
         }
     }
     @Published var selectedTranscriptionBackendID: String {
         didSet {
             guard oldValue != selectedTranscriptionBackendID else { return }
             transcriptionBackendStore.setSelectedBackendID(selectedTranscriptionBackendID)
-            scheduleModelsValidation()
+            modelLifecycleController.refresh()
         }
     }
     @Published var selectedTranscriptionModelID: String {
         didSet {
             guard oldValue != selectedTranscriptionModelID else { return }
             transcriptionModelStore.setSelectedModelID(selectedTranscriptionModelID)
-            scheduleModelsValidation()
+            modelLifecycleController.refresh()
         }
     }
     @Published var selectedFluidAudioModelID: String {
         didSet {
             guard oldValue != selectedFluidAudioModelID else { return }
             fluidAudioModelStore.setSelectedModelID(selectedFluidAudioModelID)
-            scheduleModelsValidation()
+            modelLifecycleController.refresh()
         }
     }
 
-    private let modelManager: any ModelManaging
     private let defaults: UserDefaults
     private let summarizationModelStore: SummarizationModelSelectionStore
     private let transcriptionModelStore: TranscriptionModelSelectionStore
     private let transcriptionBackendStore: TranscriptionBackendSelectionStore
     private let fluidAudioModelStore: FluidAudioASRModelSelectionStore
+    private let modelLifecycleController: ModelSetupLifecycleController
 
     private var defaultsObserver: AnyCancellable?
     private var observedVaultBookmark: Data?
-    private var modelTask: Task<Void, Never>?
-    private var modelsValidationTask: Task<Void, Never>?
+    private var cancellables: Set<AnyCancellable> = []
 
     private enum DefaultsKey {
         static let didShowIntro = "didShowOnboardingIntro"
@@ -86,7 +80,7 @@ final class OnboardingViewModel: ObservableObject {
         let transcriptionStore = transcriptionModelStore ?? TranscriptionModelSelectionStore(defaults: defaults)
         let backendStore = transcriptionBackendStore ?? TranscriptionBackendSelectionStore(defaults: defaults)
         let fluidStore = fluidAudioModelStore ?? FluidAudioASRModelSelectionStore(defaults: defaults)
-        self.modelManager = modelManager ?? DefaultModelManager(
+        let resolvedModelManager = modelManager ?? DefaultModelManager(
             selectionStore: store,
             transcriptionSelectionStore: transcriptionStore,
             transcriptionBackendStore: backendStore,
@@ -97,6 +91,10 @@ final class OnboardingViewModel: ObservableObject {
         self.transcriptionModelStore = transcriptionStore
         self.transcriptionBackendStore = backendStore
         self.fluidAudioModelStore = fluidStore
+        self.modelLifecycleController = ModelSetupLifecycleController(
+            modelManager: resolvedModelManager,
+            displayName: Self.displayName(for:)
+        )
         let selectedModel = store.selectedModel()
         self.selectedSummarizationModelID = selectedModel.id
         if store.selectedModelID() != selectedModel.id {
@@ -134,11 +132,14 @@ final class OnboardingViewModel: ObservableObject {
             .sink { [weak self] _ in
                 self?.handleDefaultsDidChange()
             }
-    }
 
-    deinit {
-        modelTask?.cancel()
-        modelsValidationTask?.cancel()
+        modelLifecycleController.$state
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                self?.modelsState = state
+                self?.updateCurrentStepIfNeeded()
+            }
+            .store(in: &cancellables)
     }
 
     var permissionsReady: Bool {
@@ -213,7 +214,7 @@ final class OnboardingViewModel: ObservableObject {
     func refreshAll() {
         refreshPermissions()
         refreshVaultStatus()
-        scheduleModelsValidation()
+        modelLifecycleController.refresh()
         updateCurrentStepIfNeeded()
     }
 
@@ -234,31 +235,7 @@ final class OnboardingViewModel: ObservableObject {
     }
 
     func startModelDownload() {
-        modelTask?.cancel()
-        modelsState = .downloading(progress: ModelDownloadProgress(fractionCompleted: 0, label: "Starting download"))
-
-        modelTask = Task { [weak self] in
-            guard let self else { return }
-
-            do {
-                let validation = try await modelManager.validateModels()
-                if !validation.invalidModelIDs.isEmpty {
-                    try await modelManager.removeModels(withIDs: validation.invalidModelIDs)
-                }
-
-                try await modelManager.ensureModelsPresent { [weak self] update in
-                    Task { @MainActor [weak self] in
-                        self?.modelsState = .downloading(progress: update)
-                    }
-                }
-
-                modelsState = .checking
-                await refreshModelsStatus()
-            } catch {
-                let message = ErrorHandler.userMessage(for: error, fallback: "Failed to download models.")
-                modelsState = .needsDownload(message: message)
-            }
-        }
+        modelLifecycleController.startDownload()
     }
 
     func advance() {
@@ -318,67 +295,7 @@ final class OnboardingViewModel: ObservableObject {
         updateCurrentStepIfNeeded()
     }
 
-    private func refreshModelsStatus() async {
-        if case .downloading = modelsState {
-            return
-        }
-
-        guard !Task.isCancelled else { return }
-
-        let wasReady: Bool
-        if case .ready = modelsState {
-            wasReady = true
-        } else {
-            wasReady = false
-        }
-
-        if !wasReady {
-            modelsState = .checking
-        }
-
-        do {
-            let result = try await modelManager.validateModels()
-            guard !Task.isCancelled else { return }
-            if result.isReady {
-                modelsState = .ready
-            } else {
-                modelsState = .needsDownload(message: modelMessage(from: result))
-            }
-        } catch {
-            guard !Task.isCancelled else { return }
-            let message = ErrorHandler.userMessage(for: error, fallback: "Failed to check model status.")
-            modelsState = .needsDownload(message: message)
-        }
-
-        updateCurrentStepIfNeeded()
-    }
-
-    private func scheduleModelsValidation() {
-        modelsValidationTask?.cancel()
-        modelsValidationTask = Task { [weak self] in
-            guard let self else { return }
-            await refreshModelsStatus()
-        }
-    }
-
-    private func modelMessage(from result: ModelValidationResult) -> String {
-        if result.missingModelIDs.isEmpty && result.invalidModelIDs.isEmpty {
-            return "Models ready."
-        }
-
-        var parts: [String] = []
-        if !result.missingModelIDs.isEmpty {
-            let names = result.missingModelIDs.map(displayName(for:))
-            parts.append("Missing: \(names.joined(separator: ", "))")
-        }
-        if !result.invalidModelIDs.isEmpty {
-            let names = result.invalidModelIDs.map(displayName(for:))
-            parts.append("Invalid: \(names.joined(separator: ", "))")
-        }
-        return parts.joined(separator: " ")
-    }
-
-    private func displayName(for id: String) -> String {
+    private static func displayName(for id: String) -> String {
         if let summarization = SummarizationModelCatalog.model(for: id) {
             return summarization.displayName
         }
@@ -387,6 +304,9 @@ final class OnboardingViewModel: ObservableObject {
         }
         if let fluidAudio = FluidAudioASRModelCatalog.model(for: id) {
             return fluidAudio.displayName
+        }
+        if id.hasSuffix("-ctc-vocab") {
+            return "FluidAudio CTC Vocabulary"
         }
         return id
     }

--- a/Minute/Sources/Views/Pipeline/PipelineContentView.swift
+++ b/Minute/Sources/Views/Pipeline/PipelineContentView.swift
@@ -22,6 +22,7 @@ struct PipelineContentView: View {
     @State private var sessionDropErrorMessage: String?
     @State private var sidebarVisibility: NavigationSplitViewVisibility = .all
     @State private var dismissedStatusDrawerID: String?
+    private let statusPresenter = PipelineStatusPresenter()
 
     private let compactHeightThreshold: CGFloat = 620
     private let floatingBarHeight: CGFloat = 88
@@ -322,167 +323,53 @@ struct PipelineContentView: View {
     }
 
     private var statusDrawerModel: StatusDrawerModel? {
-        if let dismissibleID = dismissibleStatusDrawerID(for: model.state),
-           dismissibleID == dismissedStatusDrawerID {
-            return nil
-        }
-
-        if case .recording = model.state,
-           let warningDetail = recordingWarningDetailText() {
-            return StatusDrawerModel(
-                title: "Do you want to keep recording?",
-                detail: warningDetail,
-                progress: nil,
-                showsActivity: false,
-                isError: true,
-                actionTitle: "Keep Recording",
-                action: { model.keepRecordingFromWarning() },
-                secondaryActionTitle: nil,
-                secondaryAction: nil
-            )
-        }
-
-        if model.backgroundProcessingSnapshot.activeMeetingID != nil {
-            let stage = model.backgroundProcessingSnapshot.activeStage
-            let progress = model.backgroundProcessingSnapshot.activeProgress
-            let isDeferred = model.screenInferenceStatus?.isFirstInferenceDeferred == true
-            let hasPending = model.backgroundProcessingSnapshot.pendingMeetingID != nil
-
-            let title: String
-            switch stage {
-            case .downloadingModels:
-                title = "Downloading Models"
-            case .transcribing:
-                title = "Transcribing"
-            case .summarizing:
-                title = "Summarizing"
-            case .writing:
-                title = "Writing"
-            case nil:
-                title = "Processing"
-            }
-
-            let baseDetail = isDeferred
-                ? "Your recorded meeting is processing. Screen context disabled until processing is done."
-                : "Your recorded meeting is processing in the background."
-
-            let detail = hasPending
-                ? baseDetail + " Another meeting is pending next."
-                : baseDetail
-
-            return StatusDrawerModel(
-                title: title,
-                detail: detail,
-                progress: progress,
-                showsActivity: progress == nil,
-                isError: false,
-                actionTitle: "Cancel",
-                action: { model.cancelBackgroundProcessing(clearPending: true) },
-                secondaryActionTitle: nil,
-                secondaryAction: nil
-            )
-        }
-
-        if case .idle = model.state {
-            switch model.backgroundProcessingSnapshot.lastOutcome {
-            case .failed(let message):
-                return StatusDrawerModel(
-                    title: "Processing failed",
-                    detail: message,
-                    progress: nil,
-                    showsActivity: false,
-                    isError: true,
-                    actionTitle: "Retry",
-                    action: { model.retryBackgroundProcessing() },
-                    secondaryActionTitle: nil,
-                    secondaryAction: nil
-                )
-            case .canceled:
-                return StatusDrawerModel(
-                    title: "Processing was canceled",
-                    detail: "You can retry this meeting later.",
-                    progress: nil,
-                    showsActivity: false,
-                    isError: false,
-                    actionTitle: "Retry",
-                    action: { model.retryBackgroundProcessing() },
-                    secondaryActionTitle: nil,
-                    secondaryAction: nil
-                )
-            case .completed, nil:
-                break
-            }
-        }
-
-        if case .idle = model.state,
-           let recovery = model.recoverableRecordings.first {
-            let folderName = recovery.sessionURL.lastPathComponent
-            return StatusDrawerModel(
-                title: "Unfinished meeting found",
-                detail: "An unfinished meeting was found in \(folderName). Do you want to recover it?",
-                progress: nil,
-                showsActivity: false,
-                isError: false,
-                actionTitle: "Recover",
-                action: { model.recoverRecording(recovery) },
-                secondaryActionTitle: "Delete",
-                secondaryAction: { model.discardRecoverableRecording(recovery) }
-            )
-        }
-
-        switch model.state {
-        case .recorded:
-            return StatusDrawerModel(
-                title: "Recording ready",
-                detail: "This meeting is ready to process.",
-                progress: nil,
-                showsActivity: false,
-                isError: false,
-                actionTitle: "Process",
-                action: { model.send(.process) },
-                secondaryActionTitle: nil,
-                secondaryAction: nil
-            )
-        case .processing, .writing, .importing:
-            return StatusDrawerModel(
-                title: model.state.statusLabel,
-                detail: "Meeting is being processed.",
+        guard let presentation = statusPresenter.presentation(
+            for: PipelineStatusPresenter.Input(
+                state: model.state,
+                backgroundProcessingSnapshot: model.backgroundProcessingSnapshot,
+                isFirstScreenInferenceDeferred: model.screenInferenceStatus?.isFirstInferenceDeferred == true,
                 progress: model.progress,
-                showsActivity: model.progress == nil,
-                isError: false,
-                actionTitle: nil,
-                action: nil,
-                secondaryActionTitle: nil,
-                secondaryAction: nil
-            )
-        case .done(let noteURL, _):
-            return StatusDrawerModel(
-                title: "Meeting ready",
-                detail: "Your note, transcript, and audio are in the vault.",
-                progress: nil,
-                showsActivity: false,
-                isError: false,
-                actionTitle: "Reveal in Finder",
-                action: { model.revealInFinder(noteURL) },
-                secondaryActionTitle: nil,
-                secondaryAction: nil,
-                onClose: { dismissCurrentStatusDrawer() }
-            )
-        case .failed(let error, _):
-            return StatusDrawerModel(
-                title: "Processing failed",
-                detail: ErrorHandler.userMessage(for: error, fallback: "Processing failed."),
-                progress: nil,
-                showsActivity: false,
-                isError: true,
-                actionTitle: nil,
-                action: nil,
-                secondaryActionTitle: nil,
-                secondaryAction: nil,
-                onClose: { dismissCurrentStatusDrawer() }
-            )
-        default:
+                recoverableRecordings: model.recoverableRecordings,
+                recordingWarningDetail: recordingWarningDetailText()
+            ),
+            dismissedStatusDrawerID: dismissedStatusDrawerID
+        ) else {
             return nil
+        }
+
+        return StatusDrawerModel(
+            title: presentation.title,
+            detail: presentation.detail,
+            progress: presentation.progress,
+            showsActivity: presentation.showsActivity,
+            isError: presentation.isError,
+            actionTitle: presentation.primaryActionTitle,
+            action: statusAction(for: presentation.primaryAction),
+            secondaryActionTitle: presentation.secondaryActionTitle,
+            secondaryAction: statusAction(for: presentation.secondaryAction),
+            onClose: presentation.showsCloseButton ? { dismissCurrentStatusDrawer() } : nil
+        )
+    }
+
+    private func statusAction(for action: PipelineStatusPresenter.Action?) -> (() -> Void)? {
+        guard let action else { return nil }
+        return {
+            switch action {
+            case .keepRecording:
+                model.keepRecordingFromWarning()
+            case .cancelBackgroundProcessing(let clearPending):
+                model.cancelBackgroundProcessing(clearPending: clearPending)
+            case .retryBackgroundProcessing:
+                model.retryBackgroundProcessing()
+            case .recoverRecording(let recording):
+                model.recoverRecording(recording)
+            case .discardRecoverableRecording(let recording):
+                model.discardRecoverableRecording(recording)
+            case .process:
+                model.send(.process)
+            case .revealInFinder(let noteURL):
+                model.revealInFinder(noteURL)
+            }
         }
     }
 
@@ -514,25 +401,14 @@ struct PipelineContentView: View {
     }
 
     private func dismissCurrentStatusDrawer() {
-        guard let id = dismissibleStatusDrawerID(for: model.state) else { return }
+        guard let id = statusPresenter.dismissibleStatusDrawerID(for: model.state) else { return }
         dismissedStatusDrawerID = id
     }
 
     private func syncDismissedStatusDrawer(with state: MeetingPipelineState) {
         guard let dismissedStatusDrawerID else { return }
-        if dismissibleStatusDrawerID(for: state) != dismissedStatusDrawerID {
+        if statusPresenter.dismissibleStatusDrawerID(for: state) != dismissedStatusDrawerID {
             self.dismissedStatusDrawerID = nil
-        }
-    }
-
-    private func dismissibleStatusDrawerID(for state: MeetingPipelineState) -> String? {
-        switch state {
-        case .recorded(let audioTempURL, _, let startedAt, let stoppedAt):
-            return "recorded:\(audioTempURL.path):\(startedAt.timeIntervalSinceReferenceDate):\(stoppedAt.timeIntervalSinceReferenceDate)"
-        case .done(let noteURL, _):
-            return "done:\(noteURL.path)"
-        default:
-            return nil
         }
     }
 

--- a/Minute/Sources/Views/ScreenContextRecordingPickerView.swift
+++ b/Minute/Sources/Views/ScreenContextRecordingPickerView.swift
@@ -1,5 +1,4 @@
 import AppKit
-import CoreVideo
 import MinuteCore
 import ScreenCaptureKit
 import SwiftUI
@@ -522,17 +521,11 @@ struct ScreenContextWindowPickerPopover: View {
     }
 
     private func fetchShareableContent() async throws -> SCShareableContent {
-        try await withCheckedThrowingContinuation { continuation in
-            SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { content, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let content {
-                    continuation.resume(returning: content)
-                } else {
-                    continuation.resume(throwing: MinuteError.screenCaptureUnavailable)
-                }
-            }
-        }
+        try await ScreenCaptureKitAdapter.fetchShareableContent(
+            excludingDesktopWindows: true,
+            onScreenWindowsOnly: false,
+            fallbackError: MinuteError.screenCaptureUnavailable
+        )
     }
 
     private func captureWindowThumbnail(for window: SCWindow) async throws -> NSImage {
@@ -546,40 +539,22 @@ struct ScreenContextWindowPickerPopover: View {
         filter: SCContentFilter,
         configuration: SCStreamConfiguration
     ) async throws -> CGImage {
-        try await withCheckedThrowingContinuation { continuation in
-            SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration) { image, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let image {
-                    continuation.resume(returning: image)
-                } else {
-                    continuation.resume(throwing: MinuteError.screenCaptureUnavailable)
-                }
-            }
-        }
+        try await ScreenCaptureKitAdapter.captureImage(
+            contentFilter: filter,
+            configuration: configuration,
+            fallbackError: MinuteError.screenCaptureUnavailable
+        )
     }
 
     private func makeScreenshotConfiguration(for filter: SCContentFilter) -> SCStreamConfiguration {
-        let configuration = SCStreamConfiguration()
-        configuration.capturesAudio = false
-        configuration.pixelFormat = kCVPixelFormatType_32BGRA
-        configuration.showsCursor = false
-        configuration.scalesToFit = true
-
-        let rect = filter.contentRect
-        guard rect.width > 0, rect.height > 0 else {
-            return configuration
-        }
-
-        let scale = CGFloat(filter.pointPixelScale)
-        let sourceWidth = rect.width * scale
-        let sourceHeight = rect.height * scale
-        let maxDimension: CGFloat = 560
-        let fitRatio = min(1.0, maxDimension / max(sourceWidth, sourceHeight))
-
-        configuration.width = size_t(max(1, Int(sourceWidth * fitRatio)))
-        configuration.height = size_t(max(1, Int(sourceHeight * fitRatio)))
-        return configuration
+        ScreenCaptureKitAdapter.makeScreenshotConfiguration(
+            contentRect: filter.contentRect,
+            pointPixelScale: CGFloat(filter.pointPixelScale),
+            capturesAudio: false,
+            showsCursor: false,
+            scalesToFit: true,
+            maxDimension: 560
+        )
     }
 }
 

--- a/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
+++ b/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
@@ -4,12 +4,7 @@ import MinuteCore
 
 @MainActor
 final class ModelsSettingsViewModel: ObservableObject {
-    enum State: Equatable {
-        case checking
-        case ready
-        case needsDownload(message: String?)
-        case downloading(progress: ModelDownloadProgress?)
-    }
+    typealias State = ModelSetupLifecycleController.State
 
     @Published private(set) var state: State = .checking
     @Published var selectedSummarizationModelID: String {
@@ -59,14 +54,13 @@ final class ModelsSettingsViewModel: ObservableObject {
         }
     }
 
-    private let modelManager: any ModelManaging
     private let vocabularySettingsStore: any VocabularyBoostingSettingsStoring
     private let summarizationModelStore: SummarizationModelSelectionStore
     private let transcriptionModelStore: TranscriptionModelSelectionStore
     private let transcriptionBackendStore: TranscriptionBackendSelectionStore
     private let fluidAudioModelStore: FluidAudioASRModelSelectionStore
-    private var modelTask: Task<Void, Never>?
-    private var modelsValidationTask: Task<Void, Never>?
+    private let modelLifecycleController: ModelSetupLifecycleController
+    private var cancellables: Set<AnyCancellable> = []
     private var isRestoringVocabularySettings = false
     private var lastModelValidation = ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])
 
@@ -83,11 +77,15 @@ final class ModelsSettingsViewModel: ObservableObject {
         self.transcriptionBackendStore = transcriptionBackendStore
         self.fluidAudioModelStore = fluidAudioModelStore
         self.vocabularySettingsStore = vocabularySettingsStore ?? VocabularyBoostingSettingsStore()
-        self.modelManager = modelManager ?? DefaultModelManager(
+        let resolvedModelManager = modelManager ?? DefaultModelManager(
             selectionStore: summarizationModelStore,
             transcriptionSelectionStore: transcriptionModelStore,
             transcriptionBackendStore: transcriptionBackendStore,
             fluidAudioModelStore: fluidAudioModelStore
+        )
+        self.modelLifecycleController = ModelSetupLifecycleController(
+            modelManager: resolvedModelManager,
+            displayName: Self.displayName(for:)
         )
         let selectedModel = summarizationModelStore.selectedModel()
         self.selectedSummarizationModelID = selectedModel.id
@@ -113,104 +111,27 @@ final class ModelsSettingsViewModel: ObservableObject {
         self.vocabularyBoostingEnabled = vocabularySettings.enabled
         self.vocabularyBoostingTermsInput = vocabularySettings.editorInput
         self.vocabularyBoostingStrength = vocabularySettings.strength
+        modelLifecycleController.$state
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                self?.state = state
+            }
+            .store(in: &cancellables)
+        modelLifecycleController.$lastValidation
+            .receive(on: RunLoop.main)
+            .sink { [weak self] validation in
+                self?.lastModelValidation = validation
+            }
+            .store(in: &cancellables)
         refresh()
     }
 
-    deinit {
-        modelTask?.cancel()
-        modelsValidationTask?.cancel()
-    }
-
     func refresh() {
-        scheduleModelsValidation()
+        modelLifecycleController.refresh()
     }
 
     func startDownload() {
-        modelTask?.cancel()
-        state = .downloading(progress: ModelDownloadProgress(fractionCompleted: 0, label: "Starting download"))
-
-        modelTask = Task { [weak self] in
-            guard let self else { return }
-
-            do {
-                let validation = try await modelManager.validateModels()
-                if !validation.invalidModelIDs.isEmpty {
-                    try await modelManager.removeModels(withIDs: validation.invalidModelIDs)
-                }
-
-                try await modelManager.ensureModelsPresent { [weak self] update in
-                    Task { @MainActor [weak self] in
-                        self?.state = .downloading(progress: update)
-                    }
-                }
-
-                state = .checking
-                await refreshModelsStatus()
-            } catch {
-                let message = ErrorHandler.userMessage(for: error, fallback: "Failed to download models.")
-                state = .needsDownload(message: message)
-            }
-        }
-    }
-
-    private func refreshModelsStatus() async {
-        if case .downloading = state {
-            return
-        }
-
-        guard !Task.isCancelled else { return }
-
-        let wasReady: Bool
-        if case .ready = state {
-            wasReady = true
-        } else {
-            wasReady = false
-        }
-
-        if !wasReady {
-            state = .checking
-        }
-
-        do {
-            let result = try await modelManager.validateModels()
-            guard !Task.isCancelled else { return }
-            lastModelValidation = result
-            if result.isReady {
-                state = .ready
-            } else {
-                state = .needsDownload(message: modelMessage(from: result))
-            }
-        } catch {
-            guard !Task.isCancelled else { return }
-            lastModelValidation = ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])
-            let message = ErrorHandler.userMessage(for: error, fallback: "Failed to check model status.")
-            state = .needsDownload(message: message)
-        }
-    }
-
-    private func scheduleModelsValidation() {
-        modelsValidationTask?.cancel()
-        modelsValidationTask = Task { [weak self] in
-            guard let self else { return }
-            await refreshModelsStatus()
-        }
-    }
-
-    private func modelMessage(from result: ModelValidationResult) -> String {
-        if result.missingModelIDs.isEmpty && result.invalidModelIDs.isEmpty {
-            return "Models ready."
-        }
-
-        var parts: [String] = []
-        if !result.missingModelIDs.isEmpty {
-            let names = result.missingModelIDs.map(displayName(for:))
-            parts.append("Missing: \(names.joined(separator: ", "))")
-        }
-        if !result.invalidModelIDs.isEmpty {
-            let names = result.invalidModelIDs.map(displayName(for:))
-            parts.append("Invalid: \(names.joined(separator: ", "))")
-        }
-        return parts.joined(separator: " ")
+        modelLifecycleController.startDownload()
     }
 
     var summarizationModels: [SummarizationModel] {
@@ -256,7 +177,7 @@ final class ModelsSettingsViewModel: ObservableObject {
             $0.hasSuffix("-ctc-vocab")
         }
         if !vocabularyIDs.isEmpty {
-            let names = vocabularyIDs.map(displayName(for:))
+            let names = vocabularyIDs.map(Self.displayName(for:))
             return .missingModels(
                 backend: backend,
                 message: "Missing: \(names.joined(separator: ", "))"
@@ -291,7 +212,7 @@ final class ModelsSettingsViewModel: ObservableObject {
         vocabularySettingsStore.save(settings)
     }
 
-    private func displayName(for id: String) -> String {
+    private static func displayName(for id: String) -> String {
         if let summarization = SummarizationModelCatalog.model(for: id) {
             return summarization.displayName
         }

--- a/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
+++ b/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
@@ -207,7 +207,6 @@ public actor MeetingPipelineCoordinator {
                 let decoded = try decodeExtractionStrict(from: repaired)
                 return MeetingExtractionValidation.validated(decoded, recordingDate: meetingDate)
             } catch {
-                // Task 07: proceed with a fallback extraction rather than failing the entire pipeline.
                 logger.error("Extraction still invalid after repair; proceeding with fallback")
                 return MeetingExtractionValidation.fallback(recordingDate: meetingDate)
             }
@@ -292,7 +291,7 @@ public actor MeetingPipelineCoordinator {
             // Note
             try vaultWriter.writeAtomically(data: noteData, to: noteURL)
 
-            // Audio (temporary implementation reads into memory; task 08 will stream/copy atomically).
+            // Audio
             let audioURL: URL?
             if let audioRelativePath = resolvedPaths.audioRelativePath {
                 guard let audioData = originalAudioData else {
@@ -318,7 +317,9 @@ public actor MeetingPipelineCoordinator {
         let fileManager = FileManager.default
 
         func normalizeRelativePath(_ relativePath: String) -> String {
-            relativePath.hasPrefix("/") ? String(relativePath.dropFirst()) : relativePath
+            VaultPathNormalizer
+                .normalizedRelativeComponents(relativePath)
+                .joined(separator: "/")
         }
 
         let noteRelativePath = normalizeRelativePath(noteRelativePath)

--- a/MinuteCore/Sources/MinuteCore/Rendering/MeetingNoteParsing.swift
+++ b/MinuteCore/Sources/MinuteCore/Rendering/MeetingNoteParsing.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+public enum MeetingNoteParsing {
+    public struct SpeakerHeader: Equatable, Sendable {
+        public var speakerId: Int
+        public var detectedName: String?
+        public var suffix: String
+
+        public init(speakerId: Int, detectedName: String?, suffix: String) {
+            self.speakerId = speakerId
+            self.detectedName = detectedName
+            self.suffix = suffix
+        }
+    }
+
+    public enum TranscriptLine: Equatable, Sendable {
+        case speakerHeader(SpeakerHeader)
+        case text(String)
+    }
+
+    public static func parseSpeakerIDs(fromTranscriptMarkdown markdown: String?) -> [Int] {
+        guard let markdown else { return [] }
+
+        var ids: Set<Int> = []
+        for line in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.hasPrefix("Speaker ") else { continue }
+
+            let afterPrefix = trimmed.dropFirst("Speaker ".count)
+            let digits = afterPrefix.prefix { $0.isNumber }
+            if let id = Int(digits) {
+                ids.insert(id)
+            }
+        }
+
+        return ids.sorted()
+    }
+
+    public static func rewriteSpeakerHeadingsForDisplay(
+        transcriptMarkdown: String,
+        speakerDisplayNames: [Int: String]
+    ) -> String {
+        let lines = transcriptMarkdown.split(separator: "\n", omittingEmptySubsequences: false)
+        var out: [String] = []
+        out.reserveCapacity(lines.count)
+
+        for lineSub in lines {
+            let line = String(lineSub)
+            let leadingWhitespace = line.prefix { $0.isWhitespace }
+            let remainder = line.dropFirst(leadingWhitespace.count)
+            let trimmed = remainder.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("Speaker ") {
+                let afterPrefix = trimmed.dropFirst("Speaker ".count)
+                let digits = afterPrefix.prefix { $0.isNumber }
+                if let id = Int(digits),
+                   let name = speakerDisplayNames[id]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !name.isEmpty,
+                   let bracketRange = trimmed.range(of: " [") {
+                    let suffix = String(trimmed[bracketRange.lowerBound...])
+                    out.append(String(leadingWhitespace) + name + suffix)
+                    continue
+                }
+            }
+            out.append(line)
+        }
+
+        return out.joined(separator: "\n")
+    }
+
+    public static func parseTranscriptLines(_ transcript: String) -> [TranscriptLine] {
+        let lines = transcript.split(separator: "\n", omittingEmptySubsequences: false)
+        return lines.map { sub in
+            let line = String(sub)
+            if let header = parseSpeakerHeader(line) {
+                return .speakerHeader(header)
+            }
+            return .text(line)
+        }
+    }
+
+    public static func splitTranscriptHeaderAndBody(_ transcript: String) -> (header: String, body: String) {
+        let lines = transcript.split(separator: "\n", omittingEmptySubsequences: false)
+
+        var firstHeaderIndex: Int?
+        for (index, lineSub) in lines.enumerated() {
+            if parseSpeakerHeader(String(lineSub)) != nil {
+                firstHeaderIndex = index
+                break
+            }
+        }
+
+        guard let firstHeaderIndex else {
+            return (header: transcript, body: "")
+        }
+
+        let headerLines = lines.prefix(firstHeaderIndex)
+        let bodyLines = lines.suffix(from: firstHeaderIndex)
+        return (
+            header: headerLines.joined(separator: "\n"),
+            body: bodyLines.joined(separator: "\n")
+        )
+    }
+
+    public static func containsSpeakerHeader(_ transcript: String) -> Bool {
+        for lineSub in transcript.split(separator: "\n", omittingEmptySubsequences: false) {
+            if parseSpeakerHeader(String(lineSub)) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func parseSpeakerHeader(_ line: String) -> SpeakerHeader? {
+        let leadingWhitespace = line.prefix { $0.isWhitespace }
+        let remainder = line.dropFirst(leadingWhitespace.count)
+        let trimmed = remainder.trimmingCharacters(in: .whitespaces)
+
+        guard trimmed.hasPrefix("Speaker ") else { return nil }
+
+        let afterPrefix = trimmed.dropFirst("Speaker ".count)
+        let digits = afterPrefix.prefix { $0.isNumber }
+        guard let speakerId = Int(digits) else { return nil }
+
+        let afterDigits = afterPrefix.dropFirst(digits.count)
+        var detectedName: String?
+
+        let afterDigitsTrimmed = afterDigits.trimmingCharacters(in: .whitespaces)
+        if afterDigitsTrimmed.hasPrefix("("),
+           let closeIndex = afterDigitsTrimmed.firstIndex(of: ")") {
+            let nameRange = afterDigitsTrimmed.index(after: afterDigitsTrimmed.startIndex)..<closeIndex
+            let name = String(afterDigitsTrimmed[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !name.isEmpty {
+                detectedName = name
+            }
+        }
+
+        guard let bracketRange = trimmed.range(of: " [") else {
+            return nil
+        }
+
+        let suffix = String(trimmed[bracketRange.lowerBound...])
+        return SpeakerHeader(speakerId: speakerId, detectedName: detectedName, suffix: suffix)
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Services/DefaultModelManager.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/DefaultModelManager.swift
@@ -11,7 +11,7 @@ public protocol FluidAudioModelManaging: Sendable {
 extension FluidAudioASRModelManager: FluidAudioModelManaging {}
 
 /// Downloads and verifies required local model files under Application Support.
-///<
+///
 /// Networking must only be used for model downloads.
 public actor DefaultModelManager: ModelManaging {
     public struct ModelSpec: Sendable, Equatable {

--- a/MinuteCore/Sources/MinuteCore/Services/MockServices.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/MockServices.swift
@@ -13,7 +13,7 @@ public struct DefaultVaultWriter: VaultWriting {
     }
 }
 
-// MARK: - Mocks (used until tasks 04–09 replace them)
+// MARK: - Mocks
 
 @preconcurrency
 public final class MockAudioService: AudioServicing, AudioLevelMetering, AudioCaptureControlling, @unchecked Sendable {
@@ -33,7 +33,6 @@ public final class MockAudioService: AudioServicing, AudioLevelMetering, AudioCa
 
     public func stopRecording() async throws -> AudioCaptureResult {
         guard isRecording else {
-            // For now treat as generic failure.
             throw MinuteError.audioExportFailed
         }
 
@@ -42,13 +41,11 @@ public final class MockAudioService: AudioServicing, AudioLevelMetering, AudioCa
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("minute-capture-\(UUID().uuidString).wav")
 
-        // Placeholder data.
         try Data().write(to: url, options: [.atomic])
         return AudioCaptureResult(wavURL: url, duration: 0)
     }
 
     public func convertToContractWav(inputURL: URL, outputURL: URL) async throws {
-        // Placeholder: just copy bytes.
         let data = try Data(contentsOf: inputURL)
         try data.write(to: outputURL, options: [.atomic])
     }
@@ -202,7 +199,6 @@ public struct MockSummarizationService: SummarizationServicing {
     }
 
     public func repairJSON(_ invalidJSON: String) async throws -> String {
-        // Naive repair: return original. Task 07 will implement real validation/repair behavior.
         try await Task.sleep(nanoseconds: 200_000_000)
         return invalidJSON
     }
@@ -211,7 +207,6 @@ public struct MockSummarizationService: SummarizationServicing {
 public struct MockModelManager: ModelManaging {
     public init() {}
     public func ensureModelsPresent(progress: (@Sendable (ModelDownloadProgress) -> Void)?) async throws {
-        // No-op for now.
         _ = progress
     }
 

--- a/MinuteCore/Sources/MinuteCore/Services/ScreenCaptureKitAdapter.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ScreenCaptureKitAdapter.swift
@@ -1,0 +1,101 @@
+import CoreGraphics
+import CoreVideo
+import Foundation
+@preconcurrency import ScreenCaptureKit
+
+public enum ScreenCaptureKitAdapter {
+    public static func fetchShareableContent(
+        excludingDesktopWindows: Bool,
+        onScreenWindowsOnly: Bool,
+        fallbackError: Error
+    ) async throws -> SCShareableContent {
+        try await withCheckedThrowingContinuation { continuation in
+            SCShareableContent.getExcludingDesktopWindows(excludingDesktopWindows, onScreenWindowsOnly: onScreenWindowsOnly) {
+                content,
+                error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let content {
+                    continuation.resume(returning: content)
+                } else {
+                    continuation.resume(throwing: fallbackError)
+                }
+            }
+        }
+    }
+
+    public static func captureImage(
+        contentFilter: SCContentFilter,
+        configuration: SCStreamConfiguration,
+        fallbackError: Error
+    ) async throws -> CGImage {
+        try await withCheckedThrowingContinuation { continuation in
+            SCScreenshotManager.captureImage(contentFilter: contentFilter, configuration: configuration) { image, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let image {
+                    continuation.resume(returning: image)
+                } else {
+                    continuation.resume(throwing: fallbackError)
+                }
+            }
+        }
+    }
+
+    public static func startCapture(stream: SCStream) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stream.startCapture { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    public static func stopCapture(stream: SCStream) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stream.stopCapture { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    public static func makeScreenshotConfiguration(
+        contentRect: CGRect,
+        pointPixelScale: CGFloat,
+        capturesAudio: Bool,
+        showsCursor: Bool,
+        scalesToFit: Bool,
+        maxDimension: CGFloat? = nil
+    ) -> SCStreamConfiguration {
+        let configuration = SCStreamConfiguration()
+        configuration.capturesAudio = capturesAudio
+        configuration.pixelFormat = kCVPixelFormatType_32BGRA
+        configuration.showsCursor = showsCursor
+        configuration.scalesToFit = scalesToFit
+
+        guard contentRect.width > 0, contentRect.height > 0 else {
+            return configuration
+        }
+
+        let sourceWidth = contentRect.width * pointPixelScale
+        let sourceHeight = contentRect.height * pointPixelScale
+
+        let fitRatio: CGFloat
+        if let maxDimension {
+            fitRatio = min(1.0, maxDimension / max(sourceWidth, sourceHeight))
+        } else {
+            fitRatio = 1.0
+        }
+
+        configuration.width = size_t(max(1, Int(sourceWidth * fitRatio)))
+        configuration.height = size_t(max(1, Int(sourceHeight * fitRatio)))
+        return configuration
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift
@@ -1,5 +1,4 @@
 import CoreGraphics
-import CoreVideo
 import Foundation
 @preconcurrency import ScreenCaptureKit
 import os
@@ -385,36 +384,21 @@ private final class ScreenContextCaptureSession: @unchecked Sendable {
         filter: SCContentFilter,
         configuration: SCStreamConfiguration
     ) async throws -> CGImage {
-        try await withCheckedThrowingContinuation { continuation in
-            SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration) { image, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let image {
-                    continuation.resume(returning: image)
-                } else {
-                    continuation.resume(throwing: MinuteError.screenCaptureUnavailable)
-                }
-            }
-        }
+        try await ScreenCaptureKitAdapter.captureImage(
+            contentFilter: filter,
+            configuration: configuration,
+            fallbackError: MinuteError.screenCaptureUnavailable
+        )
     }
 
     private static func makeScreenshotConfiguration(for filter: SCContentFilter) -> SCStreamConfiguration {
-        let configuration = SCStreamConfiguration()
-        configuration.capturesAudio = false
-        configuration.pixelFormat = kCVPixelFormatType_32BGRA
-        configuration.showsCursor = false
-        configuration.scalesToFit = false
-
-        let rect = filter.contentRect
-        if rect.width > 0, rect.height > 0 {
-            let scale = CGFloat(filter.pointPixelScale)
-            let width = max(1, Int(rect.width * scale))
-            let height = max(1, Int(rect.height * scale))
-            configuration.width = size_t(width)
-            configuration.height = size_t(height)
-        }
-
-        return configuration
+        ScreenCaptureKitAdapter.makeScreenshotConfiguration(
+            contentRect: filter.contentRect,
+            pointPixelScale: CGFloat(filter.pointPixelScale),
+            capturesAudio: false,
+            showsCursor: false,
+            scalesToFit: false
+        )
     }
 
     static func resolveWindows(for selections: [ScreenContextWindowSelection]) async throws -> [ResolvedWindow] {
@@ -453,17 +437,11 @@ private final class ScreenContextCaptureSession: @unchecked Sendable {
     }
 
     private static func fetchShareableContent() async throws -> SCShareableContent {
-        try await withCheckedThrowingContinuation { continuation in
-            SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { content, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let content {
-                    continuation.resume(returning: content)
-                } else {
-                    continuation.resume(throwing: MinuteError.screenCaptureUnavailable)
-                }
-            }
-        }
+        try await ScreenCaptureKitAdapter.fetchShareableContent(
+            excludingDesktopWindows: true,
+            onScreenWindowsOnly: false,
+            fallbackError: MinuteError.screenCaptureUnavailable
+        )
     }
 }
 

--- a/MinuteCore/Sources/MinuteCore/Services/SystemAudioCapture.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/SystemAudioCapture.swift
@@ -62,41 +62,19 @@ final class SystemAudioCapture: @unchecked Sendable {
 
 private extension SystemAudioCapture {
     static func fetchShareableContent() async throws -> SCShareableContent {
-        try await withCheckedThrowingContinuation { continuation in
-            SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) { content, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let content {
-                    continuation.resume(returning: content)
-                } else {
-                    continuation.resume(throwing: MinuteError.audioExportFailed)
-                }
-            }
-        }
+        try await ScreenCaptureKitAdapter.fetchShareableContent(
+            excludingDesktopWindows: false,
+            onScreenWindowsOnly: true,
+            fallbackError: MinuteError.audioExportFailed
+        )
     }
 
     static func startCapture(_ stream: SCStream) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            stream.startCapture { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: ())
-                }
-            }
-        }
+        try await ScreenCaptureKitAdapter.startCapture(stream: stream)
     }
 
     static func stopCapture(_ stream: SCStream) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            stream.stopCapture { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: ())
-                }
-            }
-        }
+        try await ScreenCaptureKitAdapter.stopCapture(stream: stream)
     }
 }
 

--- a/MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift
@@ -188,26 +188,11 @@ public struct VaultMeetingNotesBrowser: MeetingNotesBrowsing, @unchecked Sendabl
     }
 
     private static func meetingsRootURL(from vaultRootURL: URL, meetingsRelativePath: String) -> URL {
-        let components = normalizedRelative(meetingsRelativePath)
-        return components.reduce(vaultRootURL) { partial, component in
-            partial.appendingPathComponent(component, isDirectory: true)
-        }
+        VaultPathNormalizer.directoryURL(from: vaultRootURL, relativePath: meetingsRelativePath)
     }
 
     private static func directoryURL(from vaultRootURL: URL, relativePath: String) -> URL {
-        let components = normalizedRelative(relativePath)
-        return components.reduce(vaultRootURL) { partial, component in
-            partial.appendingPathComponent(component, isDirectory: true)
-        }
-    }
-
-    private static func normalizedRelative(_ path: String) -> [String] {
-        path
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-            .split(separator: "/")
-            .map(String.init)
-            .filter { !$0.isEmpty && $0 != "." && $0 != ".." }
+        VaultPathNormalizer.directoryURL(from: vaultRootURL, relativePath: relativePath)
     }
 
     private static func isExcludedDirectory(_ url: URL) -> Bool {
@@ -216,14 +201,7 @@ public struct VaultMeetingNotesBrowser: MeetingNotesBrowsing, @unchecked Sendabl
     }
 
     private static func relativePath(from vaultRootURL: URL, to fileURL: URL) -> String {
-        let rootPath = vaultRootURL.standardizedFileURL.path
-        let filePath = fileURL.standardizedFileURL.path
-        if filePath.hasPrefix(rootPath) {
-            var suffix = String(filePath.dropFirst(rootPath.count))
-            if suffix.hasPrefix("/") { suffix.removeFirst() }
-            return suffix
-        }
-        return fileURL.lastPathComponent
+        VaultPathNormalizer.relativePath(from: vaultRootURL, to: fileURL)
     }
 
     private struct ParsedFilename {

--- a/MinuteCore/Sources/MinuteCore/Vault/VaultPathNormalizer.swift
+++ b/MinuteCore/Sources/MinuteCore/Vault/VaultPathNormalizer.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public enum VaultPathNormalizer {
+    public static func normalizedRelativeComponents(_ path: String) -> [String] {
+        path
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            .split(separator: "/")
+            .map(String.init)
+            .filter { !$0.isEmpty && $0 != "." && $0 != ".." }
+    }
+
+    public static func directoryURL(from vaultRootURL: URL, relativePath: String) -> URL {
+        normalizedRelativeComponents(relativePath).reduce(vaultRootURL) { partial, component in
+            partial.appendingPathComponent(component, isDirectory: true)
+        }
+    }
+
+    public static func relativePath(from vaultRootURL: URL, to fileURL: URL) -> String {
+        let rootPath = vaultRootURL.standardizedFileURL.path
+        let filePath = fileURL.standardizedFileURL.path
+        if filePath.hasPrefix(rootPath) {
+            var suffix = String(filePath.dropFirst(rootPath.count))
+            if suffix.hasPrefix("/") {
+                suffix.removeFirst()
+            }
+            return suffix
+        }
+        return fileURL.lastPathComponent
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/ScreenCaptureKitAdapterTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/ScreenCaptureKitAdapterTests.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+@preconcurrency import ScreenCaptureKit
+import Testing
+@testable import MinuteCore
+
+struct ScreenCaptureKitAdapterTests {
+    @Test
+    func makeScreenshotConfiguration_appliesPixelScale() {
+        let configuration = ScreenCaptureKitAdapter.makeScreenshotConfiguration(
+            contentRect: CGRect(x: 0, y: 0, width: 100, height: 50),
+            pointPixelScale: 2,
+            capturesAudio: false,
+            showsCursor: false,
+            scalesToFit: false
+        )
+
+        #expect(configuration.width == 200)
+        #expect(configuration.height == 100)
+        #expect(configuration.capturesAudio == false)
+        #expect(configuration.showsCursor == false)
+        #expect(configuration.scalesToFit == false)
+    }
+
+    @Test
+    func makeScreenshotConfiguration_respectsMaxDimensionFit() {
+        let configuration = ScreenCaptureKitAdapter.makeScreenshotConfiguration(
+            contentRect: CGRect(x: 0, y: 0, width: 1600, height: 800),
+            pointPixelScale: 1,
+            capturesAudio: false,
+            showsCursor: false,
+            scalesToFit: true,
+            maxDimension: 560
+        )
+
+        #expect(configuration.width == 560)
+        #expect(configuration.height == 280)
+        #expect(configuration.scalesToFit)
+    }
+
+    @Test
+    func makeScreenshotConfiguration_zeroRect_keepsDefaultDimensions() {
+        let baseline = SCStreamConfiguration()
+        let configuration = ScreenCaptureKitAdapter.makeScreenshotConfiguration(
+            contentRect: .zero,
+            pointPixelScale: 2,
+            capturesAudio: false,
+            showsCursor: false,
+            scalesToFit: false
+        )
+
+        #expect(configuration.width == baseline.width)
+        #expect(configuration.height == baseline.height)
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/TestSupport/PipelineCoordinatorFixture.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/TestSupport/PipelineCoordinatorFixture.swift
@@ -1,0 +1,28 @@
+import Foundation
+@testable import MinuteCore
+
+enum PipelineCoordinatorFixture {
+    static func makeCoordinator(vaultRootURL: URL) throws -> MeetingPipelineCoordinator {
+        let vaultAccess = try RefactorParityTestSupport.makeVaultAccess(vaultRootURL: vaultRootURL)
+        return MeetingPipelineCoordinator(
+            transcriptionService: MockTranscriptionService(),
+            diarizationService: MockDiarizationService(),
+            summarizationServiceProvider: { MockSummarizationService() },
+            modelManager: MockModelManager(),
+            vaultAccess: vaultAccess,
+            vaultWriter: DefaultVaultWriter()
+        )
+    }
+
+    static func makeRecordingArtifacts(
+        in directory: URL,
+        basename: String = "fixture-recording"
+    ) throws -> (audioTempURL: URL, workingDirectoryURL: URL) {
+        let workingDirectory = directory.appendingPathComponent("working-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+
+        let audioURL = workingDirectory.appendingPathComponent("\(basename).wav")
+        try Data([0x00, 0x01, 0x02]).write(to: audioURL, options: [.atomic])
+        return (audioTempURL: audioURL, workingDirectoryURL: workingDirectory)
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/TestSupport/RefactorParityTestSupport.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/TestSupport/RefactorParityTestSupport.swift
@@ -1,0 +1,56 @@
+import Foundation
+@testable import MinuteCore
+
+enum RefactorParityTestSupport {
+    static func makeTemporaryDirectory(prefix: String = "minute-refactor-parity") throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    static func makeVaultAccess(vaultRootURL: URL) throws -> VaultAccess {
+        let bookmark = try VaultAccess.makeBookmarkData(forVaultRootURL: vaultRootURL)
+        return VaultAccess(bookmarkStore: RefactorParityBookmarkStore(bookmark: bookmark))
+    }
+
+    static func makePipelineContext(
+        audioTempURL: URL,
+        workingDirectoryURL: URL,
+        startedAt: Date = Date(timeIntervalSince1970: 1_708_000_000),
+        stoppedAt: Date = Date(timeIntervalSince1970: 1_708_000_180),
+        saveAudio: Bool = true,
+        saveTranscript: Bool = true
+    ) -> PipelineContext {
+        PipelineContext(
+            vaultFolders: MeetingFileContract.VaultFolders(),
+            audioTempURL: audioTempURL,
+            audioDurationSeconds: stoppedAt.timeIntervalSince(startedAt),
+            startedAt: startedAt,
+            stoppedAt: stoppedAt,
+            workingDirectoryURL: workingDirectoryURL,
+            saveAudio: saveAudio,
+            saveTranscript: saveTranscript
+        )
+    }
+}
+
+final class RefactorParityBookmarkStore: VaultBookmarkStoring {
+    private var bookmark: Data?
+
+    init(bookmark: Data?) {
+        self.bookmark = bookmark
+    }
+
+    func loadVaultRootBookmark() -> Data? {
+        bookmark
+    }
+
+    func saveVaultRootBookmark(_ bookmark: Data) {
+        self.bookmark = bookmark
+    }
+
+    func clearVaultRootBookmark() {
+        bookmark = nil
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/VaultPathNormalizerTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/VaultPathNormalizerTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import MinuteCore
+
+struct VaultPathNormalizerTests {
+    @Test
+    func normalizedRelativeComponents_stripsUnsafeTokens() {
+        let components = VaultPathNormalizer.normalizedRelativeComponents(" /Meetings//./2026/../02/ ")
+        #expect(components == ["Meetings", "2026", "02"])
+    }
+
+    @Test
+    func directoryURL_buildsPathFromNormalizedComponents() {
+        let root = URL(fileURLWithPath: "/tmp/Vault", isDirectory: true)
+        let url = VaultPathNormalizer.directoryURL(from: root, relativePath: "Meetings/_transcripts")
+
+        #expect(url.path == "/tmp/Vault/Meetings/_transcripts")
+    }
+
+    @Test
+    func relativePath_returnsPathInsideVaultRoot() {
+        let root = URL(fileURLWithPath: "/tmp/Vault", isDirectory: true)
+        let fileURL = URL(fileURLWithPath: "/tmp/Vault/Meetings/2026/02/Note.md")
+
+        let relative = VaultPathNormalizer.relativePath(from: root, to: fileURL)
+        #expect(relative == "Meetings/2026/02/Note.md")
+    }
+}

--- a/MinuteTests/MeetingNotesBrowserViewModelSpeakerDraftIsolationTests.swift
+++ b/MinuteTests/MeetingNotesBrowserViewModelSpeakerDraftIsolationTests.swift
@@ -2,44 +2,43 @@ import Testing
 @testable import Minute
 
 struct MeetingNotesBrowserViewModelSpeakerDraftIsolationTests {
-	@Test
-	func parseSpeakerIDs_parsesUniqueSortedIDs() {
-		let transcript = """
-		Speaker 2 [00:00]
-		Hello
+    @Test
+    func parseSpeakerIDs_parsesUniqueSortedIDs() {
+        let transcript = """
+        Speaker 2 [00:00]
+        Hello
 
-		Speaker 10 [00:05]
-		Hi
+        Speaker 10 [00:05]
+        Hi
 
-		Speaker 2 [00:06]
-		Again
-		"""
+        Speaker 2 [00:06]
+        Again
+        """
 
-		let ids = MeetingNotesBrowserViewModel.parseSpeakerIDs(fromTranscriptMarkdown: transcript)
-		#expect(ids == [2, 10])
-	}
+        let ids = MeetingNoteParsing.parseSpeakerIDs(fromTranscriptMarkdown: transcript)
+        #expect(ids == [2, 10])
+    }
 
-	@Test
-	func rewriteSpeakerHeadingsForDisplay_replacesNamedHeadingsOnly() {
-		let transcript = """
-			Speaker 1 [00:00]
-			Hello
+    @Test
+    func rewriteSpeakerHeadingsForDisplay_replacesNamedHeadingsOnly() {
+        let transcript = """
+            Speaker 1 [00:00]
+            Hello
 
-		Speaker 2 [00:05]
-			Hi
+        Speaker 2 [00:05]
+            Hi
 
-		Speaker 3
-		Unchanged
-		"""
+        Speaker 3
+        Unchanged
+        """
 
-		let rewritten = MeetingNotesBrowserViewModel.rewriteSpeakerHeadingsForDisplay(
-			transcriptMarkdown: transcript,
-			speakerDisplayNames: [1: "Alice", 2: " Bob "]
-		)
+        let rewritten = MeetingNoteParsing.rewriteSpeakerHeadingsForDisplay(
+            transcriptMarkdown: transcript,
+            speakerDisplayNames: [1: "Alice", 2: " Bob "]
+        )
 
-		#expect(rewritten.contains("            Alice [00:00]"))
-		#expect(rewritten.contains("Bob [00:05]"))
-		#expect(rewritten.contains("Speaker 3"))
-	}
+        #expect(rewritten.contains("Alice [00:00]"))
+        #expect(rewritten.contains("Bob [00:05]"))
+        #expect(rewritten.contains("Speaker 3"))
+    }
 }
-

--- a/MinuteTests/MeetingPipelineViewModelCancelSessionTests.swift
+++ b/MinuteTests/MeetingPipelineViewModelCancelSessionTests.swift
@@ -9,36 +9,20 @@ struct MeetingPipelineViewModelCancelSessionTests {
         let audioService = TestAudioService()
 
         let suiteName = "MeetingPipelineViewModelCancelSessionTests"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-        stagePreferencesStore.clear()
-
-        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-        let coordinator = MeetingPipelineCoordinator(
-            transcriptionService: MockTranscriptionService(),
-            diarizationService: MockDiarizationService(),
-            summarizationServiceProvider: summarizationServiceProvider,
-            modelManager: MockModelManager(),
-            vaultAccess: coordinatorVaultAccess,
-            vaultWriter: DefaultVaultWriter()
-        )
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
         var model: MeetingPipelineViewModel? = await MainActor.run {
             return MeetingPipelineViewModel(
                 audioService: audioService,
                 mediaImportService: MockMediaImportService(),
                 recoveryService: MockRecordingRecoveryService(),
-                pipelineCoordinator: coordinator,
+                pipelineCoordinator: dependencies.coordinator,
                 screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
                 screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
                 screenContextSettingsStore: ScreenContextSettingsStore(),
-                vaultAccess: viewModelVaultAccess,
+                vaultAccess: dependencies.viewModelVaultAccess,
                 recordingPermissions: .alwaysGranted(),
-                stagePreferencesStore: stagePreferencesStore
+                stagePreferencesStore: dependencies.stagePreferencesStore
             )
         }
         #expect(model != nil)
@@ -89,24 +73,7 @@ struct MeetingPipelineViewModelCancelSessionTests {
         let permissionsProbe = RecordingPermissionProbe()
 
         let suiteName = "MeetingPipelineViewModelAudioOnlyPermissionTests"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-
-        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-        stagePreferencesStore.clear()
-
-        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-        let coordinator = MeetingPipelineCoordinator(
-            transcriptionService: MockTranscriptionService(),
-            diarizationService: MockDiarizationService(),
-            summarizationServiceProvider: summarizationServiceProvider,
-            modelManager: MockModelManager(),
-            vaultAccess: coordinatorVaultAccess,
-            vaultWriter: DefaultVaultWriter()
-        )
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
         let permissions = MeetingPipelineViewModel.RecordingPermissions(
             requestMicrophonePermission: {
@@ -122,13 +89,13 @@ struct MeetingPipelineViewModelCancelSessionTests {
                 audioService: audioService,
                 mediaImportService: MockMediaImportService(),
                 recoveryService: MockRecordingRecoveryService(),
-                pipelineCoordinator: coordinator,
+                pipelineCoordinator: dependencies.coordinator,
                 screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
                 screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
                 screenContextSettingsStore: ScreenContextSettingsStore(),
-                vaultAccess: viewModelVaultAccess,
+                vaultAccess: dependencies.viewModelVaultAccess,
                 recordingPermissions: permissions,
-                stagePreferencesStore: stagePreferencesStore
+                stagePreferencesStore: dependencies.stagePreferencesStore
             )
         }
         #expect(model != nil)
@@ -180,36 +147,20 @@ struct MeetingPipelineViewModelCancelSessionTests {
         let importService = BlockingMediaImportService()
 
         let suiteName = "MeetingPipelineViewModelImportingStartRecordingTests"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-        stagePreferencesStore.clear()
-
-        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-        let coordinator = MeetingPipelineCoordinator(
-            transcriptionService: MockTranscriptionService(),
-            diarizationService: MockDiarizationService(),
-            summarizationServiceProvider: summarizationServiceProvider,
-            modelManager: MockModelManager(),
-            vaultAccess: coordinatorVaultAccess,
-            vaultWriter: DefaultVaultWriter()
-        )
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
         var model: MeetingPipelineViewModel? = await MainActor.run {
             MeetingPipelineViewModel(
                 audioService: audioService,
                 mediaImportService: importService,
                 recoveryService: MockRecordingRecoveryService(),
-                pipelineCoordinator: coordinator,
+                pipelineCoordinator: dependencies.coordinator,
                 screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
                 screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
                 screenContextSettingsStore: ScreenContextSettingsStore(),
-                vaultAccess: viewModelVaultAccess,
+                vaultAccess: dependencies.viewModelVaultAccess,
                 recordingPermissions: .alwaysGranted(),
-                stagePreferencesStore: stagePreferencesStore
+                stagePreferencesStore: dependencies.stagePreferencesStore
             )
         }
 
@@ -281,37 +232,20 @@ struct MeetingPipelineViewModelCancelSessionTests {
         let audioService = TestAudioService()
 
         let suiteName = "MeetingPipelineViewModelScreenContextSelectionSwitchTests"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-
-        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-        stagePreferencesStore.clear()
-
-        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-        let coordinator = MeetingPipelineCoordinator(
-            transcriptionService: MockTranscriptionService(),
-            diarizationService: MockDiarizationService(),
-            summarizationServiceProvider: summarizationServiceProvider,
-            modelManager: MockModelManager(),
-            vaultAccess: coordinatorVaultAccess,
-            vaultWriter: DefaultVaultWriter()
-        )
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
         var model: MeetingPipelineViewModel? = await MainActor.run {
             MeetingPipelineViewModel(
                 audioService: audioService,
                 mediaImportService: MockMediaImportService(),
                 recoveryService: MockRecordingRecoveryService(),
-                pipelineCoordinator: coordinator,
+                pipelineCoordinator: dependencies.coordinator,
                 screenContextCaptureService: captureService,
                 screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
                 screenContextSettingsStore: ScreenContextSettingsStore(),
-                vaultAccess: viewModelVaultAccess,
+                vaultAccess: dependencies.viewModelVaultAccess,
                 recordingPermissions: .alwaysGranted(),
-                stagePreferencesStore: stagePreferencesStore
+                stagePreferencesStore: dependencies.stagePreferencesStore
             )
         }
 
@@ -358,36 +292,20 @@ struct MeetingPipelineViewModelCancelSessionTests {
         let audioService = SlowStopAudioService(stopDelayNanoseconds: 700_000_000)
 
         let suiteName = "MeetingPipelineViewModelStoppingStateTests"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-        stagePreferencesStore.clear()
-
-        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-        let coordinator = MeetingPipelineCoordinator(
-            transcriptionService: MockTranscriptionService(),
-            diarizationService: MockDiarizationService(),
-            summarizationServiceProvider: summarizationServiceProvider,
-            modelManager: MockModelManager(),
-            vaultAccess: coordinatorVaultAccess,
-            vaultWriter: DefaultVaultWriter()
-        )
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
         var model: MeetingPipelineViewModel? = await MainActor.run {
             MeetingPipelineViewModel(
                 audioService: audioService,
                 mediaImportService: MockMediaImportService(),
                 recoveryService: MockRecordingRecoveryService(),
-                pipelineCoordinator: coordinator,
+                pipelineCoordinator: dependencies.coordinator,
                 screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
                 screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
                 screenContextSettingsStore: ScreenContextSettingsStore(),
-                vaultAccess: viewModelVaultAccess,
+                vaultAccess: dependencies.viewModelVaultAccess,
                 recordingPermissions: .alwaysGranted(),
-                stagePreferencesStore: stagePreferencesStore
+                stagePreferencesStore: dependencies.stagePreferencesStore
             )
         }
 
@@ -430,36 +348,20 @@ struct MeetingPipelineViewModelCancelSessionTests {
         let audioService = MeteringAudioService()
 
         let suiteName = "MeetingPipelineViewModelAudioLevelVisualizerTests"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-        stagePreferencesStore.clear()
-
-        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-        let coordinator = MeetingPipelineCoordinator(
-            transcriptionService: MockTranscriptionService(),
-            diarizationService: MockDiarizationService(),
-            summarizationServiceProvider: summarizationServiceProvider,
-            modelManager: MockModelManager(),
-            vaultAccess: coordinatorVaultAccess,
-            vaultWriter: DefaultVaultWriter()
-        )
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
         var model: MeetingPipelineViewModel? = await MainActor.run {
             MeetingPipelineViewModel(
                 audioService: audioService,
                 mediaImportService: MockMediaImportService(),
                 recoveryService: MockRecordingRecoveryService(),
-                pipelineCoordinator: coordinator,
+                pipelineCoordinator: dependencies.coordinator,
                 screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
                 screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
                 screenContextSettingsStore: ScreenContextSettingsStore(),
-                vaultAccess: viewModelVaultAccess,
+                vaultAccess: dependencies.viewModelVaultAccess,
                 recordingPermissions: .alwaysGranted(),
-                stagePreferencesStore: stagePreferencesStore
+                stagePreferencesStore: dependencies.stagePreferencesStore
             )
         }
 
@@ -849,23 +751,7 @@ private func makeSilenceBehaviorModel(
     silenceDetectionPolicy: SilenceDetectionPolicy? = nil
 ) async throws -> MeetingPipelineViewModel {
     let suiteName = "MeetingPipelineViewModelSilenceBehaviorTests-\(UUID().uuidString)"
-    let defaults = try #require(UserDefaults(suiteName: suiteName))
-    defaults.removePersistentDomain(forName: suiteName)
-    let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-    stagePreferencesStore.clear()
-
-    let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-    let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-    let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-    let coordinator = MeetingPipelineCoordinator(
-        transcriptionService: MockTranscriptionService(),
-        diarizationService: MockDiarizationService(),
-        summarizationServiceProvider: summarizationServiceProvider,
-        modelManager: MockModelManager(),
-        vaultAccess: coordinatorVaultAccess,
-        vaultWriter: DefaultVaultWriter()
-    )
+    let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
     let alertNotifier = await MainActor.run { MockRecordingAlertNotifier() }
     let defaultPolicy = SilenceDetectionPolicy(
@@ -881,13 +767,13 @@ private func makeSilenceBehaviorModel(
             audioService: audioService,
             mediaImportService: MockMediaImportService(),
             recoveryService: MockRecordingRecoveryService(),
-            pipelineCoordinator: coordinator,
+            pipelineCoordinator: dependencies.coordinator,
             screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
             screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
             screenContextSettingsStore: ScreenContextSettingsStore(),
-            vaultAccess: viewModelVaultAccess,
+            vaultAccess: dependencies.viewModelVaultAccess,
             recordingPermissions: .alwaysGranted(),
-            stagePreferencesStore: stagePreferencesStore,
+            stagePreferencesStore: dependencies.stagePreferencesStore,
             silenceDetectionPolicy: effectivePolicy,
             recordingAlertNotifier: alertNotifier
         )

--- a/MinuteTests/MeetingPipelineViewModelKeepRecordingTests.swift
+++ b/MinuteTests/MeetingPipelineViewModelKeepRecordingTests.swift
@@ -9,23 +9,7 @@ struct MeetingPipelineViewModelKeepRecordingTests {
         let audioService = AutoSilenceAudioService()
 
         let suiteName = "MeetingPipelineViewModelKeepRecordingTests"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
-        stagePreferencesStore.clear()
-
-        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
-        let summarizationServiceProvider: @Sendable () -> any SummarizationServicing = { MockSummarizationService() }
-
-        let coordinator = MeetingPipelineCoordinator(
-            transcriptionService: MockTranscriptionService(),
-            diarizationService: MockDiarizationService(),
-            summarizationServiceProvider: summarizationServiceProvider,
-            modelManager: MockModelManager(),
-            vaultAccess: coordinatorVaultAccess,
-            vaultWriter: DefaultVaultWriter()
-        )
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
 
         let alertNotifier = await MainActor.run { MockRecordingAlertNotifier() }
         let shortPolicy = SilenceDetectionPolicy(
@@ -40,13 +24,13 @@ struct MeetingPipelineViewModelKeepRecordingTests {
                 audioService: audioService,
                 mediaImportService: MockMediaImportService(),
                 recoveryService: MockRecordingRecoveryService(),
-                pipelineCoordinator: coordinator,
+                pipelineCoordinator: dependencies.coordinator,
                 screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
                 screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
                 screenContextSettingsStore: ScreenContextSettingsStore(),
-                vaultAccess: viewModelVaultAccess,
+                vaultAccess: dependencies.viewModelVaultAccess,
                 recordingPermissions: .alwaysGranted(),
-                stagePreferencesStore: stagePreferencesStore,
+                stagePreferencesStore: dependencies.stagePreferencesStore,
                 silenceDetectionPolicy: shortPolicy,
                 recordingAlertNotifier: alertNotifier
             )

--- a/MinuteTests/MinuteTests.swift
+++ b/MinuteTests/MinuteTests.swift
@@ -11,6 +11,172 @@ struct MinuteTests {
 }
 
 @MainActor
+struct ArchitectureDeadCodeParityTests {
+    @Test
+    func defaultsObserver_sameSnapshot_reportsNoChanges() {
+        let suite = "ArchitectureDeadCodeParityTests.defaults.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = GlobalVocabularyBoostingSettings.default
+        let snapshot = PipelineDefaultsObserver.makeSnapshot(
+            defaults: defaults,
+            transcriptionBackendID: TranscriptionBackend.whisper.id,
+            vocabularySettings: settings
+        )
+
+        let changed = PipelineDefaultsObserver.changedDomains(previous: snapshot, current: snapshot)
+        #expect(changed.hasChanges == false)
+    }
+
+    @Test
+    func meetingNoteParsing_withoutSpeakerHeaders_keepsBodyInHeaderSection() {
+        let transcript = """
+        Intro line
+        Another line
+        """
+        let split = MeetingNoteParsing.splitTranscriptHeaderAndBody(transcript)
+
+        #expect(split.header == transcript)
+        #expect(split.body.isEmpty)
+    }
+}
+
+@MainActor
+struct PipelineStatusPresenterParityTests {
+    @Test
+    func recordedState_returnsProcessAction() {
+        let presenter = PipelineStatusPresenter()
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let stoppedAt = startedAt.addingTimeInterval(120)
+        let state = MeetingPipelineState.recorded(
+            audioTempURL: URL(fileURLWithPath: "/tmp/input.wav"),
+            durationSeconds: stoppedAt.timeIntervalSince(startedAt),
+            startedAt: startedAt,
+            stoppedAt: stoppedAt
+        )
+
+        let presentation = presenter.presentation(
+            for: PipelineStatusPresenter.Input(
+                state: state,
+                backgroundProcessingSnapshot: BackgroundProcessingSnapshot(),
+                isFirstScreenInferenceDeferred: false,
+                progress: nil,
+                recoverableRecordings: [],
+                recordingWarningDetail: nil
+            ),
+            dismissedStatusDrawerID: nil
+        )
+
+        #expect(presentation?.primaryAction == .process)
+    }
+}
+
+@MainActor
+struct PipelineDefaultsObserverParityTests {
+    @Test
+    func changedDomains_whenTranscriptionBackendChanges_marksDomainOnly() {
+        let suite = "PipelineDefaultsObserverParityTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let baseline = PipelineDefaultsObserver.makeSnapshot(
+            defaults: defaults,
+            transcriptionBackendID: TranscriptionBackend.whisper.id,
+            vocabularySettings: .default
+        )
+        let changed = PipelineDefaultsObserver.makeSnapshot(
+            defaults: defaults,
+            transcriptionBackendID: TranscriptionBackend.fluidAudio.id,
+            vocabularySettings: .default
+        )
+
+        let domains = PipelineDefaultsObserver.changedDomains(previous: baseline, current: changed)
+        #expect(domains.transcriptionBackendChanged)
+        #expect(domains.vaultStatusChanged == false)
+        #expect(domains.outputLanguageChanged == false)
+    }
+}
+
+@MainActor
+struct MeetingNotesOverlayStateParityTests {
+    @Test
+    func selectAndDismiss_transitionsAreDeterministic() {
+        var state = MeetingNotesOverlayState()
+        let item = MeetingNoteItem(
+            title: "Test",
+            date: Date(timeIntervalSince1970: 0),
+            relativePath: "Meetings/test.md",
+            fileURL: URL(fileURLWithPath: "/tmp/test.md"),
+            hasTranscript: false,
+            transcriptURL: nil
+        )
+
+        state.select(item)
+        #expect(state.isPresented)
+        #expect(state.selectedItem == item)
+
+        state.selectTab(.transcription)
+        #expect(state.selectedTab == .transcription)
+
+        state.dismiss()
+        #expect(state.isPresented == false)
+        #expect(state.selectedItem == nil)
+        #expect(state.selectedTab == .summary)
+    }
+}
+
+@MainActor
+struct ModelSetupLifecycleParityCoverageTests {
+    @Test
+    func refresh_whenModelsReady_setsReadyState() async throws {
+        let manager = LifecycleModelManagerStub(
+            validations: [ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])]
+        )
+        let controller = ModelSetupLifecycleController(
+            modelManager: manager,
+            displayName: { $0 }
+        )
+
+        controller.refresh()
+
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run {
+                if case .ready = controller.state {
+                    return true
+                }
+                return false
+            }
+        }
+    }
+}
+
+private actor LifecycleModelManagerStub: ModelManaging {
+    private var validations: [ModelValidationResult]
+
+    init(validations: [ModelValidationResult]) {
+        self.validations = validations
+    }
+
+    func ensureModelsPresent(progress: (@Sendable (ModelDownloadProgress) -> Void)?) async throws {
+        progress?(ModelDownloadProgress(fractionCompleted: 1, label: "done"))
+    }
+
+    func validateModels() async throws -> ModelValidationResult {
+        if validations.count > 1 {
+            return validations.removeFirst()
+        }
+        return validations.first ?? ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])
+    }
+
+    func removeModels(withIDs ids: [String]) async throws {
+        _ = ids
+    }
+}
+
+@MainActor
 struct SettingsWorkspaceRoutingCoverageTests {
     @Test
     func settingsOpensInSingleWindowRoute() {
@@ -150,7 +316,7 @@ struct MeetingNotesBrowserViewModelSpeakerDraftIsolationTests {
         Again
         """
 
-        let ids = MeetingNotesBrowserViewModel.parseSpeakerIDs(fromTranscriptMarkdown: transcript)
+        let ids = MeetingNoteParsing.parseSpeakerIDs(fromTranscriptMarkdown: transcript)
         #expect(ids == [2, 10])
     }
 
@@ -167,7 +333,7 @@ struct MeetingNotesBrowserViewModelSpeakerDraftIsolationTests {
         Unchanged
         """
 
-        let rewritten = MeetingNotesBrowserViewModel.rewriteSpeakerHeadingsForDisplay(
+        let rewritten = MeetingNoteParsing.rewriteSpeakerHeadingsForDisplay(
             transcriptMarkdown: transcript,
             speakerDisplayNames: [1: "Alice", 2: " Bob "]
         )
@@ -175,6 +341,86 @@ struct MeetingNotesBrowserViewModelSpeakerDraftIsolationTests {
         #expect(rewritten.contains("Alice [00:00]"))
         #expect(rewritten.contains("Bob [00:05]"))
         #expect(rewritten.contains("Speaker 3"))
+    }
+
+    @MainActor
+    @Test
+    func selectingDifferentNotes_resetsSpeakerDraftState() async throws {
+        let first = MeetingNoteItem(
+            title: "First",
+            date: Date(timeIntervalSince1970: 0),
+            relativePath: "Meetings/2026/02/first.md",
+            fileURL: URL(fileURLWithPath: "/tmp/first.md"),
+            hasTranscript: true,
+            transcriptURL: URL(fileURLWithPath: "/tmp/first.transcript.md")
+        )
+        let second = MeetingNoteItem(
+            title: "Second",
+            date: Date(timeIntervalSince1970: 1),
+            relativePath: "Meetings/2026/02/second.md",
+            fileURL: URL(fileURLWithPath: "/tmp/second.md"),
+            hasTranscript: true,
+            transcriptURL: URL(fileURLWithPath: "/tmp/second.transcript.md")
+        )
+
+        let browser = SpeakerDraftIsolationBrowserStub(
+            notes: [first, second],
+            noteByID: [
+                first.id: "# First\n\n",
+                second.id: "# Second\n\n",
+            ],
+            transcriptByID: [
+                first.id: "Speaker 1 [00:00]\nHello",
+                second.id: "Speaker 2 [00:00]\nHi",
+            ]
+        )
+        let model = MeetingNotesBrowserViewModel(browserProvider: { browser })
+
+        model.refresh()
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run { model.notes.count == 2 && !model.isRefreshing }
+        }
+
+        model.select(first)
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run { model.speakerIDs == [1] }
+        }
+        model.setSpeakerName("Alice", for: 1)
+        #expect(model.speakerName(for: 1) == "Alice")
+
+        model.select(second)
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run { model.speakerIDs == [2] }
+        }
+        #expect(model.speakerName(for: 1).isEmpty)
+    }
+}
+
+private actor SpeakerDraftIsolationBrowserStub: MeetingNotesBrowsing {
+    private let notes: [MeetingNoteItem]
+    private let noteByID: [String: String]
+    private let transcriptByID: [String: String]
+
+    init(notes: [MeetingNoteItem], noteByID: [String: String], transcriptByID: [String: String]) {
+        self.notes = notes
+        self.noteByID = noteByID
+        self.transcriptByID = transcriptByID
+    }
+
+    func listNotes() async throws -> [MeetingNoteItem] {
+        notes
+    }
+
+    func loadNoteContent(for item: MeetingNoteItem) async throws -> String {
+        noteByID[item.id] ?? ""
+    }
+
+    func loadTranscriptContent(for item: MeetingNoteItem) async throws -> String {
+        transcriptByID[item.id] ?? ""
+    }
+
+    func deleteNoteFiles(for item: MeetingNoteItem) async throws {
+        _ = item
     }
 }
 

--- a/MinuteTests/TestSupport/SilenceAutoStopTestSupport.swift
+++ b/MinuteTests/TestSupport/SilenceAutoStopTestSupport.swift
@@ -1,5 +1,7 @@
 import Foundation
 import MinuteCore
+import Testing
+@testable import Minute
 
 actor AutoSilenceAudioService: AudioServicing, AudioLevelMetering, AudioCaptureControlling {
     private var levelHandler: (@Sendable (Float) -> Void)?
@@ -89,3 +91,47 @@ func eventually(
 }
 
 private struct EventuallyTimeoutError: Error {}
+
+struct PipelineViewModelFixtureDependencies {
+    var defaults: UserDefaults
+    var stagePreferencesStore: StagePreferencesStore
+    var coordinator: MeetingPipelineCoordinator
+    var viewModelVaultAccess: VaultAccess
+}
+
+enum PipelineViewModelFixtureBuilder {
+    static func makeDependencies(
+        suiteName: String,
+        summarizationServiceProvider: @escaping @Sendable () -> any SummarizationServicing = {
+            MockSummarizationService()
+        }
+    ) throws -> PipelineViewModelFixtureDependencies {
+        let defaults = try makeIsolatedDefaults(suiteName: suiteName)
+        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
+        stagePreferencesStore.clear()
+
+        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
+        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
+        let coordinator = MeetingPipelineCoordinator(
+            transcriptionService: MockTranscriptionService(),
+            diarizationService: MockDiarizationService(),
+            summarizationServiceProvider: summarizationServiceProvider,
+            modelManager: MockModelManager(),
+            vaultAccess: coordinatorVaultAccess,
+            vaultWriter: DefaultVaultWriter()
+        )
+
+        return PipelineViewModelFixtureDependencies(
+            defaults: defaults,
+            stagePreferencesStore: stagePreferencesStore,
+            coordinator: coordinator,
+            viewModelVaultAccess: viewModelVaultAccess
+        )
+    }
+
+    static func makeIsolatedDefaults(suiteName: String) throws -> UserDefaults {
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/docs/architecture/ownership-map.md
+++ b/docs/architecture/ownership-map.md
@@ -1,0 +1,47 @@
+# Ownership Map
+
+## Purpose
+
+This document defines canonical ownership boundaries for core workflow areas.
+Each source path should have one primary workflow owner.
+
+## Workflow Areas
+
+| Area ID | Area Name | Scope | Primary Entry Points | Owner Modules | Status |
+|---------|-----------|-------|----------------------|---------------|--------|
+| WA-PIPELINE | Pipeline Session & Processing | Recording lifecycle, processing orchestration, status progression | `Minute/Sources/ViewModels/MeetingPipelineViewModel.swift`, `Minute/Sources/ViewModels/PipelineStatusPresenter.swift`, `Minute/Sources/ViewModels/PipelineDefaultsObserver.swift`, `MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift` | `Minute/Sources/ViewModels/`, `MinuteCore/Sources/MinuteCore/Pipeline/` | stabilized |
+| WA-NOTES | Meeting Notes Browsing & Editing | Notes list/load actions, speaker naming workflows, transcript viewing transforms | `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift`, `Minute/Sources/Views/MeetingNotes/MeetingNotesOverlayState.swift`, `Minute/Sources/Views/MeetingNotes/MarkdownViewerOverlay.swift`, `MinuteCore/Sources/MinuteCore/Rendering/MeetingNoteParsing.swift` | `Minute/Sources/Views/MeetingNotes/`, `MinuteCore/Sources/MinuteCore/Rendering/` | stabilized |
+| WA-MODELS | Model Setup & Validation | Model selection, validation, download lifecycle across onboarding/settings | `Minute/Sources/Views/Onboarding/OnboardingViewModel.swift`, `Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift`, `Minute/Sources/ViewModels/ModelSetupLifecycleController.swift`, `MinuteCore/Sources/MinuteCore/Services/DefaultModelManager.swift` | `Minute/Sources/Views/Onboarding/`, `Minute/Sources/Views/Settings/`, `Minute/Sources/ViewModels/`, `MinuteCore/Sources/MinuteCore/Services/` | stabilized |
+| WA-VAULT | Vault Pathing & File Contract Access | Relative-path normalization and vault path resolution for notes/audio/transcripts | `MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift`, `MinuteCore/Sources/MinuteCore/Vault/VaultPathNormalizer.swift` | `MinuteCore/Sources/MinuteCore/Vault/`, `MinuteCore/Sources/MinuteCore/Services/` | stabilized |
+| WA-SCREENCAP | Screen Capture Integration | Window discovery, screenshot/capture wrappers, screen context capture flows | `Minute/Sources/Views/ScreenContextRecordingPickerView.swift`, `MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift`, `MinuteCore/Sources/MinuteCore/Services/SystemAudioCapture.swift`, `MinuteCore/Sources/MinuteCore/Services/ScreenCaptureKitAdapter.swift` | `Minute/Sources/Views/`, `MinuteCore/Sources/MinuteCore/Services/` | stabilized |
+
+## Baseline Ownership Detail
+
+| Area ID | Stateful Owner | Pure-Transform Owner | Integration Boundary | Baseline Parity Checkpoints |
+|---------|----------------|----------------------|----------------------|-----------------------------|
+| WA-PIPELINE | `Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` + `Minute/Sources/ViewModels/PipelineDefaultsObserver.swift` | `Minute/Sources/ViewModels/PipelineStatusPresenter.swift` + `MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift` | Audio capture + vault writes | `CP-001`, `CP-002` |
+| WA-NOTES | `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift` + `Minute/Sources/Views/MeetingNotes/MeetingNotesOverlayState.swift` | `MinuteCore/Sources/MinuteCore/Rendering/MeetingNoteParsing.swift` | Vault note/transcript reads | `CP-003`, `CP-004` |
+| WA-MODELS | `Minute/Sources/ViewModels/ModelSetupLifecycleController.swift` | `MinuteCore/Sources/MinuteCore/Services/DefaultModelManager.swift` | Local model validation/download | `CP-005` |
+| WA-VAULT | `MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift` | `MinuteCore/Sources/MinuteCore/Vault/VaultPathNormalizer.swift` | Path normalization + relative contract paths | `CP-006` |
+| WA-SCREENCAP | `MinuteCore/Sources/MinuteCore/Services/ScreenCaptureKitAdapter.swift` | `MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift` | ScreenCaptureKit wrappers + lifecycle events | `CP-007` |
+
+## Consolidation Records
+
+| Unit ID | Behavior | Canonical Owner | Replaced Sources | Evidence |
+|---------|----------|-----------------|------------------|----------|
+| CB-013-001 | Model setup lifecycle state and downloads | `Minute/Sources/ViewModels/ModelSetupLifecycleController.swift` | `Minute/Sources/Views/Onboarding/OnboardingViewModel.swift`, `Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift` | `CP-005` |
+| CB-013-002 | Vault relative path normalization | `MinuteCore/Sources/MinuteCore/Vault/VaultPathNormalizer.swift` | `MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift`, `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift` | `CP-006` |
+| CB-013-003 | ScreenCaptureKit async wrappers/configuration | `MinuteCore/Sources/MinuteCore/Services/ScreenCaptureKitAdapter.swift` | `Minute/Sources/Views/ScreenContextRecordingPickerView.swift`, `MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift`, `MinuteCore/Sources/MinuteCore/Services/SystemAudioCapture.swift` | `CP-007` |
+| CB-013-004 | Meeting note speaker/transcript parsing transforms | `MinuteCore/Sources/MinuteCore/Rendering/MeetingNoteParsing.swift` | `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift`, `Minute/Sources/Views/MeetingNotes/MarkdownViewerOverlay.swift` | `CP-003`, `CP-004` |
+
+## Ownership Rules
+
+- A source path must have one primary workflow owner.
+- Shared behavior must have one canonical implementation owner.
+- Temporary migration adapters must be documented and removed before refactor completion.
+
+## Review Protocol
+
+- Update this document in every refactor slice that moves ownership.
+- Add migration-note entries for moved, deleted, renamed, or consolidated surfaces.
+- Confirm parity checkpoints are passed before marking a workflow area as stabilized.

--- a/docs/architecture/refactor-migration.md
+++ b/docs/architecture/refactor-migration.md
@@ -1,0 +1,52 @@
+# Refactor Migration Note
+
+## Purpose
+
+Tracks contributor-facing migration entries for moved, renamed, deleted, and consolidated surfaces introduced by architecture simplification.
+
+## Entry Schema
+
+Each entry should include:
+
+- `note_id`: Stable identifier (for example `MN-001`).
+- `change_type`: `moved` | `renamed` | `deleted` | `consolidated`.
+- `old_location`: Previous path/symbol location (if applicable).
+- `new_location`: New path/symbol location (if applicable).
+- `impact_summary`: Plain-language impact for contributors.
+- `effective_version`: Version or milestone tag.
+- `parity_checkpoint_ids`: Related parity checkpoints that validate behavior parity.
+- `reviewed_by`: Contributor approving parity evidence.
+- `follow_up_required`: `yes` | `no` (and issue link when `yes`).
+- `sunset_condition`: Condition required before any temporary shim removal.
+
+## Entries
+
+| Note ID | Change Type | Old Location | New Location | Impact Summary | Effective Version | Parity Checkpoints |
+|---------|-------------|--------------|--------------|----------------|-------------------|--------------------|
+| MN-013-001 | consolidated | `Minute/Sources/Views/Pipeline/PipelineContentView.swift` status drawer mapping section | `Minute/Sources/ViewModels/PipelineStatusPresenter.swift` | Status drawer mapping logic is centralized and testable; UI file now focuses on view wiring and action dispatch. | 013-us1 | `CP-001`, `CP-002` |
+| MN-013-002 | consolidated | `Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` defaults snapshot/change detection section | `Minute/Sources/ViewModels/PipelineDefaultsObserver.swift` | Defaults observation now uses an explicit snapshot/change policy object, reducing hidden branching in the pipeline view model. | 013-us1 | `CP-001`, `CP-005` |
+| MN-013-003 | consolidated | `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift` overlay selection/tab/dismiss fields | `Minute/Sources/Views/MeetingNotes/MeetingNotesOverlayState.swift` | Notes overlay presentation state transitions are now isolated from I/O and speaker naming behavior. | 013-us1 | `CP-003`, `CP-004` |
+| MN-013-004 | consolidated | duplicated model setup lifecycle in onboarding/settings view models | `Minute/Sources/ViewModels/ModelSetupLifecycleController.swift` | Shared model validation/download lifecycle now has one owner used by both onboarding and settings surfaces. | 013-us2 | `CP-005` |
+| MN-013-005 | consolidated | ad-hoc vault-relative path helpers in notes/browser surfaces | `MinuteCore/Sources/MinuteCore/Vault/VaultPathNormalizer.swift` | Vault-relative path normalization now routes through a single canonical utility. | 013-us2 | `CP-006` |
+| MN-013-006 | consolidated | duplicated ScreenCaptureKit continuation and screenshot configuration helpers | `MinuteCore/Sources/MinuteCore/Services/ScreenCaptureKitAdapter.swift` | ScreenCaptureKit integration behavior now has one adapter used across picker and capture services. | 013-us2 | `CP-007` |
+| MN-013-007 | consolidated | speaker/transcript parsing helpers in notes view-model and overlay | `MinuteCore/Sources/MinuteCore/Rendering/MeetingNoteParsing.swift` | Meeting note parsing/rewriting logic now lives in one shared rendering utility. | 013-us2 | `CP-003`, `CP-004` |
+| MN-013-008 | deleted | `Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` private `FailingTranscriptionService` shim | removed | Obsolete fallback helper removed after resilience path ownership stabilized in `ResilientWhisperTranscriptionService`. | 013-us3 | `CP-001`, `CP-002` |
+| MN-013-009 | deleted | `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift` parser pass-through wrappers | removed | Redundant wrapper layer removed; callers use `MeetingNoteParsing` directly. | 013-us3 | `CP-003`, `CP-004` |
+| MN-013-010 | deleted | stale migration-task comments in `MinuteCore/Sources/MinuteCore/Services/MockServices.swift` and `MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift` | removed | Temporary migration scaffolding comments removed to keep current ownership/documentation accurate. | 013-us3 | `CP-005`, `CP-006`, `CP-007` |
+
+## Dead Code Findings
+
+| Finding ID | Path | Finding | Resolution | Evidence |
+|------------|------|---------|------------|----------|
+| DCF-013-001 | `Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` | Unused fallback shim type | Removed | `xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` |
+| DCF-013-002 | `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift` | Redundant parser wrapper methods | Removed and replaced with direct `MeetingNoteParsing` calls | `xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` |
+| DCF-013-003 | `MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift` | Local relative-path normalization shim | Consolidated into `VaultPathNormalizer` usage | `xcodebuild -workspace Minute.xcworkspace -scheme MinuteCore -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` |
+
+## Update Protocol
+
+1. Add an entry in the same pull request that moves, renames, deletes, or consolidates code.
+2. Populate `parity_checkpoint_ids` with concrete IDs from `specs/013-simplify-architecture/checklists/parity-checkpoints.md`.
+3. Keep entries append-only during active migration; do not rewrite prior change rows.
+4. Mark `follow_up_required` as `yes` for any temporary adapter and include tracking issue text in `impact_summary`.
+5. Set `sunset_condition` for compatibility shims (for example: "remove after CP-003 and CP-004 pass").
+6. Remove temporary scaffolding only after matching `sunset_condition` is satisfied and parity checkpoints are marked passed.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -87,6 +87,18 @@ UI stays thin; business logic lives in MinuteCore. The pipeline is a single
 source-of-truth state machine. Models only emit JSON; Markdown is rendered
 deterministically.
 
+Ownership highlights (013 simplification)
+- Pipeline status presentation and defaults observation are isolated in
+  `PipelineStatusPresenter` and `PipelineDefaultsObserver`.
+- Shared model validation/download lifecycle is centralized in
+  `ModelSetupLifecycleController`.
+- Meeting-note parsing/transforms are centralized in
+  `MinuteCore/Rendering/MeetingNoteParsing`.
+- Vault path normalization is centralized in
+  `MinuteCore/Vault/VaultPathNormalizer`.
+- ScreenCaptureKit async wrappers are centralized in
+  `MinuteCore/Services/ScreenCaptureKitAdapter`.
+
 Core module boundaries (MinuteCore)
 - Domain/types: schemas, file contracts, errors
 - Services: audio, transcription, summarization, vault access, model management

--- a/specs/013-simplify-architecture/checklists/parity-checkpoints.md
+++ b/specs/013-simplify-architecture/checklists/parity-checkpoints.md
@@ -1,0 +1,28 @@
+# Parity Checkpoints: Architecture Simplification Refactor
+
+Track before/after parity for critical workflows during each refactor slice.
+
+## Critical Flows
+
+- [x] Recording start/stop/cancel behavior parity verified
+- [x] Pipeline processing stage progression parity verified
+- [x] Background processing retry/cancel behavior parity verified
+- [x] Meeting notes list/select/load parity verified
+- [x] Speaker naming and transcript rewrite parity verified
+- [x] Onboarding model setup flow parity verified
+- [x] Settings model validation/download flow parity verified
+- [x] Recovery/discard recording behavior parity verified
+- [x] Screen context capture selection and lifecycle parity verified
+- [x] Output contract remains unchanged (exact 3 files) verified
+
+## Regression Matrix
+
+| Checkpoint ID | Workflow Area | Scenario | Before Result | After Result | Status | Evidence |
+|---------------|---------------|----------|---------------|--------------|--------|----------|
+| CP-001 | WA-PIPELINE | Recording start/stop/cancel | pass | pass | passed | `MinuteTests/MeetingPipelineViewModelCancelSessionTests.swift` + `xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` |
+| CP-002 | WA-PIPELINE | Processing stage progression | pass | pass | passed | `MinuteCore/Tests/MinuteCoreTests/MeetingProcessingOrchestratorTests.swift` + `xcodebuild -workspace Minute.xcworkspace -scheme MinuteCore -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` |
+| CP-003 | WA-NOTES | Notes load and overlay behavior | pass | pass | passed | `MinuteTests/MinuteTests.swift` (`MeetingNotesBrowserViewModelSpeakerDraftIsolationTests`) |
+| CP-004 | WA-NOTES | Speaker naming/transcript rewrite | pass | pass | passed | `MinuteCore/Tests/MinuteCoreTests/MeetingSpeakerNamingServiceTests.swift` + `MinuteCore/Tests/MinuteCoreTests/TranscriptSpeakerHeadingRewriterTests.swift` |
+| CP-005 | WA-MODELS | Onboarding + settings model lifecycle | pass | pass | passed | `MinuteTests/MinuteTests.swift` (`ModelSetupLifecycleParityCoverageTests`) + `MinuteTests/ModelsSettingsViewModelVocabularyGatingTests.swift` |
+| CP-006 | WA-VAULT | Path normalization and contract paths | pass | pass | passed | `MinuteCore/Tests/MinuteCoreTests/VaultPathNormalizerTests.swift` + `MinuteCore/Tests/MinuteCoreTests/VaultMeetingNotesBrowserTests.swift` |
+| CP-007 | WA-SCREENCAP | Capture wrappers and window lifecycle | pass | pass | passed | `MinuteCore/Tests/MinuteCoreTests/ScreenCaptureKitAdapterTests.swift` + `MinuteCore/Tests/MinuteCoreTests/ScreenContextCaptureServiceWindowLifecycleTests.swift` |

--- a/specs/013-simplify-architecture/checklists/requirements.md
+++ b/specs/013-simplify-architecture/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Architecture Simplification Refactor
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-02-23  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed.
+- No blocking issues found.
+- Specification is ready for `/speckit.plan`.

--- a/specs/013-simplify-architecture/contracts/openapi.yaml
+++ b/specs/013-simplify-architecture/contracts/openapi.yaml
@@ -1,0 +1,466 @@
+openapi: 3.0.3
+info:
+  title: Minute Architecture Simplification Contract (Abstract)
+  version: 0.2.0
+  description: |
+    This OpenAPI document models planning and verification contracts for
+    architecture simplification work. Minute is not exposed as an HTTP service;
+    endpoints represent app/documentation workflow boundaries used to track
+    ownership, consolidation, dead-code removal, parity checks, and migration notes.
+    Version 0.2.0 reflects stabilized ownership boundaries and closed dead-code findings.
+
+servers:
+  - url: http://localhost
+
+paths:
+  /architecture/workflow-areas:
+    get:
+      summary: List defined workflow areas and ownership status
+      responses:
+        '200':
+          description: Workflow areas with ownership metadata
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkflowArea'
+
+  /architecture/ownership-map:
+    put:
+      summary: Publish or update ownership map entries
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/OwnershipMapEntry'
+      responses:
+        '200':
+          description: Ownership map accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OwnershipMapResult'
+        '409':
+          description: Ownership conflicts detected
+
+  /architecture/shared-behaviors/consolidate:
+    post:
+      summary: Register consolidation of duplicated behavior into a canonical owner
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SharedBehaviorConsolidationRequest'
+      responses:
+        '200':
+          description: Consolidation state updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SharedBehaviorUnit'
+
+  /architecture/dead-code/findings:
+    post:
+      summary: Create dead-code finding for review and removal workflow
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeadCodeFinding'
+      responses:
+        '201':
+          description: Dead-code finding created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeadCodeFinding'
+
+  /architecture/dead-code/findings/{findingId}/remove:
+    post:
+      summary: Mark dead-code finding removed after parity checkpoints pass
+      parameters:
+        - in: path
+          name: findingId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeadCodeRemovalRequest'
+      responses:
+        '200':
+          description: Dead-code finding moved to removed state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeadCodeFinding'
+        '412':
+          description: Required parity checkpoints have not passed
+
+  /architecture/parity-checkpoints:
+    get:
+      summary: Retrieve behavior parity checkpoint statuses
+      responses:
+        '200':
+          description: List of parity checkpoints
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BehaviorParityCheckpoint'
+
+  /architecture/parity-checkpoints/{checkpointId}/verify:
+    post:
+      summary: Record before/after parity verification result for a checkpoint
+      parameters:
+        - in: path
+          name: checkpointId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParityVerificationRequest'
+      responses:
+        '200':
+          description: Checkpoint verification recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BehaviorParityCheckpoint'
+
+  /architecture/migration-note:
+    post:
+      summary: Publish migration note entries for contributor navigation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/MigrationNoteEntry'
+      responses:
+        '200':
+          description: Migration notes published
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MigrationNotePublishResult'
+
+components:
+  schemas:
+    WorkflowArea:
+      type: object
+      required:
+        - areaId
+        - name
+        - scope
+        - entryPoints
+        - ownerModules
+        - status
+      properties:
+        areaId:
+          type: string
+        name:
+          type: string
+        scope:
+          type: string
+        entryPoints:
+          type: array
+          items:
+            type: string
+        ownerModules:
+          type: array
+          items:
+            type: string
+        outOfScopeModules:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum:
+            - baseline
+            - refactoring
+            - stabilized
+
+    OwnershipMapEntry:
+      type: object
+      required:
+        - entryId
+        - workflowAreaId
+        - ownedPath
+        - responsibility
+        - lastReviewedAt
+        - reviewStatus
+      properties:
+        entryId:
+          type: string
+        workflowAreaId:
+          type: string
+        ownedPath:
+          type: string
+        responsibility:
+          type: string
+        allowedDependencies:
+          type: array
+          items:
+            type: string
+        lastReviewedAt:
+          type: string
+          format: date-time
+        reviewStatus:
+          type: string
+          enum:
+            - draft
+            - approved
+            - superseded
+
+    OwnershipMapResult:
+      type: object
+      required:
+        - acceptedCount
+        - conflictCount
+      properties:
+        acceptedCount:
+          type: integer
+          minimum: 0
+        conflictCount:
+          type: integer
+          minimum: 0
+        conflicts:
+          type: array
+          items:
+            type: string
+
+    SharedBehaviorUnit:
+      type: object
+      required:
+        - unitId
+        - behaviorName
+        - canonicalOwnerPath
+        - consumers
+        - replacedSources
+        - state
+      properties:
+        unitId:
+          type: string
+        behaviorName:
+          type: string
+        canonicalOwnerPath:
+          type: string
+        consumers:
+          type: array
+          items:
+            type: string
+        replacedSources:
+          type: array
+          items:
+            type: string
+        state:
+          type: string
+          enum:
+            - identified
+            - consolidating
+            - consolidated
+            - verified
+
+    SharedBehaviorConsolidationRequest:
+      type: object
+      required:
+        - unitId
+        - behaviorName
+        - canonicalOwnerPath
+        - consumers
+        - replacedSources
+      properties:
+        unitId:
+          type: string
+        behaviorName:
+          type: string
+        canonicalOwnerPath:
+          type: string
+        consumers:
+          type: array
+          items:
+            type: string
+        replacedSources:
+          type: array
+          items:
+            type: string
+
+    DeadCodeFinding:
+      type: object
+      required:
+        - findingId
+        - path
+        - category
+        - evidence
+        - removalScope
+        - parityCheckpointIds
+        - status
+      properties:
+        findingId:
+          type: string
+        path:
+          type: string
+        category:
+          type: string
+          enum:
+            - unused
+            - unreachable
+            - redundant_duplicate
+            - obsolete_scaffold
+        evidence:
+          type: array
+          items:
+            type: string
+        removalScope:
+          type: string
+        parityCheckpointIds:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum:
+            - open
+            - approved_for_removal
+            - removed
+            - rejected
+
+    DeadCodeRemovalRequest:
+      type: object
+      required:
+        - parityCheckpointIds
+        - removalSummary
+      properties:
+        parityCheckpointIds:
+          type: array
+          items:
+            type: string
+        removalSummary:
+          type: string
+
+    BehaviorParityCheckpoint:
+      type: object
+      required:
+        - checkpointId
+        - workflowAreaId
+        - scenario
+        - verificationType
+        - beforeResult
+        - afterResult
+        - status
+      properties:
+        checkpointId:
+          type: string
+        workflowAreaId:
+          type: string
+        scenario:
+          type: string
+        verificationType:
+          type: string
+          enum:
+            - automated_test
+            - manual_regression
+            - both
+        beforeResult:
+          type: string
+          enum:
+            - pass
+            - fail
+            - not_run
+        afterResult:
+          type: string
+          enum:
+            - pass
+            - fail
+            - not_run
+        status:
+          type: string
+          enum:
+            - pending
+            - in_progress
+            - passed
+            - failed
+        notes:
+          type: string
+          nullable: true
+
+    ParityVerificationRequest:
+      type: object
+      required:
+        - beforeResult
+        - afterResult
+      properties:
+        beforeResult:
+          type: string
+          enum:
+            - pass
+            - fail
+            - not_run
+        afterResult:
+          type: string
+          enum:
+            - pass
+            - fail
+            - not_run
+        notes:
+          type: string
+          nullable: true
+
+    MigrationNoteEntry:
+      type: object
+      required:
+        - noteId
+        - changeType
+        - impactSummary
+        - effectiveVersion
+      properties:
+        noteId:
+          type: string
+        changeType:
+          type: string
+          enum:
+            - moved
+            - renamed
+            - deleted
+            - consolidated
+        oldLocation:
+          type: string
+          nullable: true
+        newLocation:
+          type: string
+          nullable: true
+        impactSummary:
+          type: string
+        effectiveVersion:
+          type: string
+
+    MigrationNotePublishResult:
+      type: object
+      required:
+        - publishedCount
+      properties:
+        publishedCount:
+          type: integer
+          minimum: 0
+        warnings:
+          type: array
+          items:
+            type: string

--- a/specs/013-simplify-architecture/data-model.md
+++ b/specs/013-simplify-architecture/data-model.md
@@ -1,0 +1,140 @@
+# Data Model: Architecture Simplification Refactor
+
+## Entities
+
+### 1. WorkflowArea
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `areaId` | String | Yes | Stable identifier for a major workflow domain. |
+| `name` | String | Yes | Human-readable workflow area name. |
+| `scope` | String | Yes | Business scope covered by this area. |
+| `entryPoints` | Array<String> | Yes | Main contributor entry points for this area. |
+| `ownerModules` | Array<String> | Yes | Canonical modules that own behavior in this area. |
+| `outOfScopeModules` | Array<String> | No | Adjacent modules explicitly not owned by this area. |
+| `status` | Enum | Yes | `baseline`, `refactoring`, `stabilized`. |
+
+### 2. OwnershipMapEntry
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `entryId` | String | Yes | Unique identifier for one ownership declaration. |
+| `workflowAreaId` | String | Yes | Reference to `WorkflowArea.areaId`. |
+| `ownedPath` | String | Yes | Source path owned by the workflow area. |
+| `responsibility` | String | Yes | Plain-language statement of what this path owns. |
+| `allowedDependencies` | Array<String> | No | Explicitly allowed collaboration boundaries. |
+| `lastReviewedAt` | DateTime | Yes | Most recent ownership review timestamp. |
+| `reviewStatus` | Enum | Yes | `draft`, `approved`, `superseded`. |
+
+### 3. SharedBehaviorUnit
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `unitId` | String | Yes | Stable shared-behavior identifier. |
+| `behaviorName` | String | Yes | Name of consolidated behavior. |
+| `canonicalOwnerPath` | String | Yes | Canonical implementation location. |
+| `consumers` | Array<String> | Yes | Paths consuming this behavior. |
+| `replacedSources` | Array<String> | Yes | Prior duplicate implementations replaced by canonical owner. |
+| `state` | Enum | Yes | `identified`, `consolidating`, `consolidated`, `verified`. |
+
+### 4. DeadCodeFinding
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `findingId` | String | Yes | Unique finding identifier. |
+| `path` | String | Yes | Candidate dead code path. |
+| `category` | Enum | Yes | `unused`, `unreachable`, `redundant_duplicate`, `obsolete_scaffold`. |
+| `evidence` | Array<String> | Yes | Supporting evidence for dead-code status. |
+| `removalScope` | String | Yes | Scope summary for planned removal. |
+| `parityCheckpointIds` | Array<String> | Yes | Required parity checks before closure. |
+| `status` | Enum | Yes | `open`, `approved_for_removal`, `removed`, `rejected`. |
+
+### 5. BehaviorParityCheckpoint
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `checkpointId` | String | Yes | Unique checkpoint identifier. |
+| `workflowAreaId` | String | Yes | Reference to covered workflow area. |
+| `scenario` | String | Yes | Behavior scenario to validate. |
+| `verificationType` | Enum | Yes | `automated_test`, `manual_regression`, `both`. |
+| `beforeResult` | Enum | Yes | `pass`, `fail`, `not_run`. |
+| `afterResult` | Enum | Yes | `pass`, `fail`, `not_run`. |
+| `status` | Enum | Yes | `pending`, `in_progress`, `passed`, `failed`. |
+| `notes` | String | No | Optional evidence and context. |
+
+### 6. RefactorWorkItem
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `workItemId` | String | Yes | Unique work-slice identifier. |
+| `title` | String | Yes | Work-slice title. |
+| `workflowAreaId` | String | Yes | Target workflow area. |
+| `changes` | Array<String> | Yes | Planned structural/code changes. |
+| `sharedBehaviorUnitIds` | Array<String> | No | Shared behavior units affected by this work item. |
+| `deadCodeFindingIds` | Array<String> | No | Dead-code findings addressed by this work item. |
+| `checkpointIds` | Array<String> | Yes | Required parity checkpoints. |
+| `status` | Enum | Yes | `planned`, `in_progress`, `blocked`, `ready_for_review`, `completed`. |
+
+### 7. MigrationNoteEntry
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `noteId` | String | Yes | Unique migration-note entry identifier. |
+| `changeType` | Enum | Yes | `moved`, `renamed`, `deleted`, `consolidated`. |
+| `oldLocation` | String | No | Prior location for moved/renamed/deleted elements. |
+| `newLocation` | String | No | New location for moved/renamed/consolidated elements. |
+| `impactSummary` | String | Yes | Contributor-facing impact summary. |
+| `effectiveVersion` | String | Yes | Version/tag tied to this migration entry. |
+
+## Relationships
+
+- A `WorkflowArea` has many `OwnershipMapEntry` records.
+- A `WorkflowArea` has many `BehaviorParityCheckpoint` records.
+- A `RefactorWorkItem` targets one `WorkflowArea` and references zero or more `SharedBehaviorUnit` and `DeadCodeFinding` records.
+- A `DeadCodeFinding` references one or more `BehaviorParityCheckpoint` records that must pass before closure.
+- A `MigrationNoteEntry` is produced by one or more completed `RefactorWorkItem` records.
+
+## Validation Rules
+
+- Every active `WorkflowArea` MUST have at least one `OwnershipMapEntry` with `reviewStatus = approved`.
+- Each `OwnershipMapEntry.ownedPath` MUST belong to one primary `WorkflowArea` only.
+- A `SharedBehaviorUnit` can be marked `verified` only if all listed consumer paths use the canonical owner.
+- A `DeadCodeFinding` can move to `removed` only when all linked `BehaviorParityCheckpoint` records are `passed`.
+- A `RefactorWorkItem` can move to `completed` only when all its `checkpointIds` are `passed`.
+- A `MigrationNoteEntry` MUST include an `impactSummary` and at least one location field (`oldLocation` or `newLocation`).
+
+## State Transitions
+
+### WorkflowArea
+
+| Current State | Trigger | Next State |
+|--------------|---------|------------|
+| `baseline` | First approved refactor work item starts | `refactoring` |
+| `refactoring` | All scoped work items complete and parity checkpoints pass | `stabilized` |
+| `stabilized` | New simplification slice opened | `refactoring` |
+
+### SharedBehaviorUnit
+
+| Current State | Trigger | Next State |
+|--------------|---------|------------|
+| `identified` | Canonical owner selected | `consolidating` |
+| `consolidating` | Duplicate paths removed and consumers switched | `consolidated` |
+| `consolidated` | Parity checkpoints pass | `verified` |
+
+### DeadCodeFinding
+
+| Current State | Trigger | Next State |
+|--------------|---------|------------|
+| `open` | Review confirms dead-code evidence | `approved_for_removal` |
+| `approved_for_removal` | Code removed + required checkpoints pass | `removed` |
+| `open` or `approved_for_removal` | Review disproves dead-code status | `rejected` |
+
+### RefactorWorkItem
+
+| Current State | Trigger | Next State |
+|--------------|---------|------------|
+| `planned` | Implementation begins | `in_progress` |
+| `in_progress` | External dependency or parity issue blocks progress | `blocked` |
+| `blocked` | Blocker resolved | `in_progress` |
+| `in_progress` | Changes complete and checkpoints pass | `ready_for_review` |
+| `ready_for_review` | Review approved and migration note updated | `completed` |

--- a/specs/013-simplify-architecture/plan.md
+++ b/specs/013-simplify-architecture/plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: Architecture Simplification Refactor
+
+**Branch**: `013-simplify-architecture` | **Date**: 2026-02-23 | **Spec**: [/Users/roblibob/Projects/FLX/Minute/Minute/specs/013-simplify-architecture/spec.md](spec.md)
+**Input**: Feature specification from `/Users/roblibob/Projects/FLX/Minute/Minute/specs/013-simplify-architecture/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Refactor the project for navigation clarity and reduced accidental complexity by decomposing oversized mixed-responsibility modules, consolidating duplicated domain logic into single owners, removing dead code paths, and publishing an ownership map plus migration note.
+
+The plan prioritizes behavior parity for recording, processing, notes, settings, and recovery while keeping abstractions shallow and removing temporary scaffolding after migration.
+
+## Technical Context
+
+**Language/Version**: Swift 5.9+ (Xcode 15.x), Swift tools 6.2 for `MinuteCore` package  
+**Primary Dependencies**: SwiftUI, Combine, AVFoundation, ScreenCaptureKit, UserNotifications, MinuteCore package modules  
+**Storage**: Local files (vault outputs and temporary session artifacts) + local preferences in `UserDefaults`  
+**Testing**: Swift Testing in `MinuteCore/Tests/MinuteCoreTests` and app-level tests in `MinuteTests`  
+**Target Platform**: macOS 14+ (Apple Silicon focus)  
+**Project Type**: Native macOS app target (`Minute`) with supporting Swift package modules (`MinuteCore`, `MinuteWhisper`, `MinuteLlama`)  
+**Performance Goals**: No regression in recording/processing responsiveness; cancellation behavior for long-running tasks remains immediate from user perspective; contributor navigation time aligns with spec success criteria  
+**Constraints**: Preserve local-only processing and three-file output contract; avoid deep abstraction layers; remove dead code and migration scaffolding before completion  
+**Scale/Scope**: Refactor-focused work across high-complexity hotspots in view models, core services, shared utilities, and repeated test setup patterns
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Output contract unchanged or updated docs/tests included.
+- Local-only processing preserved; no outbound network calls beyond model downloads.
+- Deterministic Markdown rendering maintained for any note changes.
+- MinuteCore tests added/updated for new behavior (renderer, file contracts, JSON validation).
+- Pipeline state machine and cancellation support respected for long-running work.
+
+**Gate evaluation (pre-design)**: PASS
+
+- Output contract: unchanged; this effort restructures ownership and code paths, not vault artifact shape.
+- Local-only/privacy: unchanged; no new network behavior is introduced.
+- Determinism: markdown/file-contract behavior remains stable; tests/docs are required for any touched boundary behavior.
+- Tests: refactor requires updates to affected test suites and fixture consolidation while preserving behavior coverage.
+- Pipeline/cancellation: decomposition must keep existing cancellation and state-machine semantics intact.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-simplify-architecture/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+Minute/
+├── Sources/
+│   ├── App/
+│   ├── ViewModels/
+│   └── Views/
+│       ├── MeetingNotes/
+│       ├── Onboarding/
+│       ├── Pipeline/
+│       └── Settings/
+
+MinuteCore/
+├── Sources/
+│   ├── MinuteCore/
+│   │   ├── Configuration/
+│   │   ├── Contracts/
+│   │   ├── Domain/
+│   │   ├── Pipeline/
+│   │   ├── Rendering/
+│   │   ├── Services/
+│   │   ├── Utilities/
+│   │   └── Vault/
+│   ├── MinuteLlama/
+│   └── MinuteWhisper/
+└── Tests/MinuteCoreTests/
+
+MinuteTests/
+```
+
+**Structure Decision**: Keep existing app/package split and simplify within those boundaries using direct, domain-owned modules rather than introducing new layering frameworks. Consolidate shared logic in the nearest existing domain owner (`MinuteCore`) and keep app target modules focused on presentation wiring.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |
+
+## Phase 0 — Research (complete)
+
+Outputs:
+- [/Users/roblibob/Projects/FLX/Minute/Minute/specs/013-simplify-architecture/research.md](research.md)
+
+Research tasks executed:
+- Define decomposition strategy for oversized mixed-responsibility modules without adding abstraction layers.
+- Define consolidation strategy for duplicated logic and utility normalization.
+- Define dead-code identification/removal policy with parity safeguards.
+- Define migration sequencing and documentation approach that preserves contributor navigability.
+
+## Phase 1 — Design & Contracts (complete)
+
+Outputs:
+- [/Users/roblibob/Projects/FLX/Minute/Minute/specs/013-simplify-architecture/data-model.md](data-model.md)
+- [/Users/roblibob/Projects/FLX/Minute/Minute/specs/013-simplify-architecture/contracts/openapi.yaml](contracts/openapi.yaml)
+- [/Users/roblibob/Projects/FLX/Minute/Minute/specs/013-simplify-architecture/quickstart.md](quickstart.md)
+
+Design focus:
+- Define explicit ownership and lifecycle entities for refactor execution.
+- Model parity checkpoints so behavior protection is first-class.
+- Create abstract contracts for ownership-map publication, consolidation actions, dead-code handling, parity verification, and migration-note publication.
+
+## Phase 1 — Agent Context Update
+
+Run:
+- `.specify/scripts/bash/update-agent-context.sh codex`
+
+## Constitution Check (post-design)
+
+- Output contract: unchanged; design artifacts target architecture workflow and documentation boundaries.
+- Local-only/privacy: preserved; no added outbound communication.
+- Determinism: rendering/contract determinism explicitly retained as gated parity checkpoints.
+- Tests: design requires targeted test updates plus fixture consolidation for repeated setup patterns.
+- Pipeline/cancellation: parity checkpoints require cancellation/state behavior verification before completion.
+
+**Gate evaluation (post-design)**: PASS
+
+## Phase 2 — Implementation Planning (next step)
+
+Proceed with `/speckit.tasks` to create implementation tasks grouped by:
+- Ownership-map definition and hotspot decomposition.
+- Shared behavior consolidation and utility centralization.
+- Dead-code removal with parity checkpoint validation.
+- Test fixture consolidation and migration-note publication.

--- a/specs/013-simplify-architecture/quickstart.md
+++ b/specs/013-simplify-architecture/quickstart.md
@@ -1,0 +1,78 @@
+# Quickstart: Architecture Simplification Refactor
+
+## Goal
+
+Implement the architecture simplification backlog so the system is easier to understand and navigate, avoids multi-layered abstractions, and removes dead code while preserving product behavior and output contracts.
+
+## Prerequisites
+
+- macOS 14+ development machine.
+- Clean build/test environment for app target and package tests.
+- Familiarity with current hotspots called out in the specification (pipeline flow, meeting notes flow, model setup flow, shared utility duplication, repeated test setup).
+
+## Recommended Implementation Sequence (TDD-first)
+
+1. Baseline ownership map and parity checkpoints.
+2. Add failing parity tests for target workflows before structural changes.
+3. Refactor one workflow slice at a time:
+   - split mixed-responsibility modules by ownership,
+   - consolidate duplicated behavior into canonical owner,
+   - remove replaced and dead paths.
+4. After each slice, run parity checks and update ownership map.
+5. Consolidate repeated test fixtures in high-volume suites.
+6. Publish migration note entries for moved/renamed/deleted surfaces.
+7. Remove temporary migration scaffolding before completion.
+
+## Suggested Work Slices
+
+1. **Pipeline and status ownership slice**
+   - Separate session lifecycle logic, status presentation mapping, and defaults synchronization responsibilities.
+2. **Meeting notes ownership slice**
+   - Separate note IO, speaker naming operations, and transcript/frontmatter transformations.
+3. **Model setup ownership slice**
+   - Consolidate duplicated model download/validation lifecycle between onboarding and settings.
+4. **Shared utility consolidation slice**
+   - Centralize repeated path normalization and capture wrapper behavior.
+5. **Test architecture slice**
+   - Introduce shared fixture builders for repetitive setup while keeping scenario assertions explicit.
+
+## Validation Scenarios
+
+1. **Contributor navigation scenario**
+   - Locate owners for recording lifecycle, processing orchestration, notes editing, and model setup from ownership map and source structure.
+2. **Behavior parity scenario**
+   - Verify recording, processing, notes, settings, and recovery flows behave identically before and after each slice.
+3. **Duplicate consolidation scenario**
+   - Change one shared behavior and confirm it is updated in only one canonical location.
+4. **Dead code removal scenario**
+   - Confirm removed paths have parity evidence and no remaining references.
+5. **Migration note scenario**
+   - Confirm contributors can map old locations to new locations using migration entries.
+
+## Suggested Commands
+
+```bash
+cd /Users/roblibob/Projects/FLX/Minute/Minute
+xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug build
+xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug test
+xcodebuild -workspace Minute.xcworkspace -scheme MinuteCore -configuration Debug test -destination 'platform=macOS'
+```
+
+## Completion Criteria
+
+- Ownership map is complete and approved for all targeted workflow areas.
+- All required parity checkpoints are passed.
+- Duplicated behaviors in scoped areas are consolidated to canonical owners.
+- Dead-code findings in scoped areas are removed or explicitly rejected with rationale.
+- Migration note is published and temporary scaffolding is absent.
+
+## Execution Evidence (2026-02-23)
+
+- `xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO` passed.
+- `xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` passed (`48` tests, `0` failures).
+- `xcodebuild -workspace Minute.xcworkspace -scheme MinuteCore -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` passed (`203` tests, `0` failures).
+- Consolidation checkpoints:
+  - model lifecycle owner: `ModelSetupLifecycleController`
+  - vault path owner: `VaultPathNormalizer`
+  - ScreenCaptureKit wrapper owner: `ScreenCaptureKitAdapter`
+  - meeting-note parsing owner: `MeetingNoteParsing`

--- a/specs/013-simplify-architecture/research.md
+++ b/specs/013-simplify-architecture/research.md
@@ -1,0 +1,61 @@
+# Phase 0 Research: Architecture Simplification Refactor
+
+## Research Task 1: Decompose Oversized Modules Without Multi-Layer Abstractions
+
+**Decision**: Decompose oversized modules by workflow responsibility (session lifecycle, status presentation, note loading/editing, model-setup lifecycle) and keep one orchestration entry point per workflow.
+
+**Rationale**: The goal is easier navigation, so contributors need clear ownership boundaries while preserving direct call paths. This keeps architecture shallow and discoverable.
+
+**Alternatives considered**:
+- Introduce generic abstraction frameworks for all workflows: rejected because this increases indirection and harms navigability.
+- Keep large files and rely on comments/regions only: rejected because logical boundaries remain unclear and coupling persists.
+
+## Research Task 2: Consolidate Duplicated Logic Into Single Domain Owners
+
+**Decision**: Consolidate duplicated path normalization, defaults observation, and shared capture/wrapper behavior into canonical domain owners in `MinuteCore`, with app-layer modules consuming them directly.
+
+**Rationale**: Duplication is a key source of accidental complexity and inconsistent behavior. Canonical ownership reduces edit scatter and behavioral drift.
+
+**Alternatives considered**:
+- Leave duplicates and enforce consistency via review checklists: rejected because manual consistency does not scale.
+- Create multiple adapters around duplicated logic per feature area: rejected because it preserves duplication under new names.
+
+## Research Task 3: Dead Code Identification and Safe Removal Policy
+
+**Decision**: Treat code as removable only when it is unreachable, unused, or replaced by a canonical owner, and require parity checks for critical user flows before/after deletion.
+
+**Rationale**: The feature requires no dead code, but removals must not regress behavior. Pairing deletion with parity checkpoints prevents accidental loss of edge-path behavior.
+
+**Alternatives considered**:
+- Defer dead code removal until after refactor completion: rejected because stale code remains and confuses ownership during migration.
+- Remove aggressively without parity checkpoints: rejected due to regression risk in recording/recovery/cancellation paths.
+
+## Research Task 4: Behavior Parity During Incremental Refactor
+
+**Decision**: Use incremental vertical slices, each ending with explicit parity checkpoints for recording, processing, note browsing/editing, settings/model setup, and recovery/cancellation semantics.
+
+**Rationale**: Refactoring high-coupling areas safely requires frequent validation. Vertical slices keep changes reviewable and isolate rollback scope.
+
+**Alternatives considered**:
+- Big-bang refactor in one merge: rejected because risk concentration is too high.
+- Refactor-only branch with delayed tests: rejected because breakages surface too late.
+
+## Research Task 5: Documentation Strategy for Navigability
+
+**Decision**: Produce and maintain an Ownership Map and Refactor Migration Note as first-class artifacts, updated in lockstep with code moves and deletions.
+
+**Rationale**: The specification explicitly targets understandability and navigation; static code changes alone are insufficient without updated contributor guidance.
+
+**Alternatives considered**:
+- Rely solely on commit history: rejected because it is not an efficient navigation aid.
+- Add extensive inline comments instead of ownership docs: rejected because comments drift and can obscure code intent.
+
+## Research Task 6: Test Structure Simplification
+
+**Decision**: Introduce shared fixture builders for repeated heavy setup in high-volume test suites, while preserving explicit scenario intent in each test.
+
+**Rationale**: Repeated setup contributes to noise and maintenance overhead. Shared fixtures improve readability and lower friction for adding parity tests.
+
+**Alternatives considered**:
+- Keep duplicated test setup for explicitness: rejected because repetition obscures scenario intent.
+- Centralize all assertions into helper methods: rejected because this hides behavior expectations.

--- a/specs/013-simplify-architecture/spec.md
+++ b/specs/013-simplify-architecture/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: Architecture Simplification Refactor
+
+**Feature Branch**: `013-simplify-architecture`  
+**Created**: 2026-02-23  
+**Status**: Draft  
+**Input**: User description: "Create a spec for implementing above refactorings. Main goals are a system that is easy to understand and navigate, no multilayered abstractions, no dead code."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Simplify Core Navigation (Priority: P1)
+
+As a contributor, I can find where major meeting workflow behaviors live without tracing through oversized or mixed-responsibility modules.
+
+**Why this priority**: Discoverability and comprehension are the foundation for all future maintenance and feature delivery.
+
+**Independent Test**: Can be tested by asking a contributor to locate and explain core recording, processing, and notes behaviors from the codebase structure alone, without prior project context.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor opening the project for the first time, **When** they inspect architecture documentation and module boundaries, **Then** they can identify ownership for each major workflow area in one pass.
+2. **Given** a contributor debugging a workflow behavior, **When** they navigate from the entry point to owning modules, **Then** they do not need to inspect unrelated modules to understand the behavior.
+
+---
+
+### User Story 2 - Remove Accidental Complexity (Priority: P2)
+
+As a contributor, I can change one workflow area without touching unrelated code paths caused by duplicated logic or wrapper layers.
+
+**Why this priority**: Reducing coupling and duplication lowers regression risk and speeds up safe iteration.
+
+**Independent Test**: Can be tested by implementing a targeted behavior change in one workflow area and verifying no parallel duplicated edits are required.
+
+**Acceptance Scenarios**:
+
+1. **Given** duplicated logic across multiple areas, **When** the simplification is complete, **Then** each shared behavior is implemented once in a clearly owned place.
+2. **Given** abstraction layers that only pass data through, **When** contributors read the flow, **Then** each layer has a distinct responsibility and direct value.
+
+---
+
+### User Story 3 - Eliminate Dead Code Paths (Priority: P3)
+
+As a maintainer, I can trust that inactive or unreachable code has been removed and behavior-preserving coverage remains.
+
+**Why this priority**: Dead code increases confusion and creates false paths during debugging and onboarding.
+
+**Independent Test**: Can be tested by running a dead-code audit and confirming that all removals are intentional, reviewed, and behavior-safe.
+
+**Acceptance Scenarios**:
+
+1. **Given** previously unused helpers, branches, or state pathways, **When** the refactor is complete, **Then** dead code is removed with no user-facing regression in core flows.
+2. **Given** simplification-related deletions, **When** the test suite and regression checks run, **Then** all critical flows still pass.
+
+---
+
+### Edge Cases
+
+- How does the refactor handle logic that appears duplicated but has subtle behavior differences across contexts?
+- What happens when a removed path was only exercised in rare recovery or cancellation scenarios?
+- How does the team proceed if simplification reveals hidden coupling between workflow areas?
+- How is behavior parity verified when reducing module boundaries in high-churn areas?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system documentation MUST define a clear ownership map for major workflow areas, including recording/session control, meeting processing, notes browsing/editing, model setup, and status presentation.
+- **FR-002**: The refactor MUST split mixed-responsibility modules so each resulting module has a single primary reason to change.
+- **FR-003**: The refactor MUST remove duplicate business logic by consolidating shared behavior into one owned location.
+- **FR-004**: The refactor MUST remove pass-through layers that do not add behavior, policy, validation, or boundary protection.
+- **FR-005**: The refactor MUST preserve existing user-visible behavior for recording, processing, notes access, settings flows, and recovery flows unless a behavior change is explicitly approved.
+- **FR-006**: The refactor MUST remove unreachable or unused code paths identified during implementation, including associated tests that only validate removed dead paths.
+- **FR-007**: The refactor MUST provide reusable test fixtures for repeated setup patterns in high-volume tests to reduce setup duplication.
+- **FR-008**: The refactor MUST centralize repeated path/normalization and shared utility behavior into one canonical owner per domain.
+- **FR-009**: The refactor MUST define explicit boundaries for workflow state updates versus pure transformation logic.
+- **FR-010**: The refactor MUST include a migration note summarizing what moved, what was deleted, and how contributors should navigate the new structure.
+
+### Non-Functional Requirements *(mandatory)*
+
+- **NFR-001**: Local-only processing guarantees MUST remain intact, including no outbound network access except model downloads.
+- **NFR-002**: Deterministic file contract and deterministic output rendering MUST be preserved.
+- **NFR-003**: Long-running operations MUST remain cancellable and responsive from a user perspective.
+- **NFR-004**: Simplified module boundaries MUST be understandable by a contributor without relying on implicit tribal knowledge.
+- **NFR-005**: Refactored code paths MUST avoid introducing new abstraction layers unless they reduce complexity and have explicit responsibility.
+- **NFR-006**: The final codebase MUST not retain deprecated compatibility shims or temporary scaffolding introduced solely for intermediate migration steps.
+
+### Key Entities *(include if feature involves data)*
+
+- **Workflow Area**: A functional domain of behavior (for example session control, processing, note management, model management) with explicit ownership and boundaries.
+- **Ownership Map**: A maintained artifact that maps each workflow area to its owning modules and entry points.
+- **Shared Behavior Unit**: Consolidated logic used by more than one workflow area and owned in exactly one location.
+- **Dead Code Finding**: A confirmed unused, unreachable, or redundant code path eligible for removal with regression-safe validation.
+- **Refactor Migration Note**: A release-facing summary of renamed/moved/deleted surfaces and updated navigation guidance.
+
+### Assumptions
+
+- Existing product requirements and output contracts remain unchanged during this refactor effort.
+- Simplification work is delivered incrementally so behavior parity can be validated at each step.
+- Existing tests are supplemented where needed to preserve confidence in cancellation, recovery, and processing flows.
+- Documentation updates are treated as required deliverables, not optional follow-up tasks.
+
+### Dependencies
+
+- Availability of maintainers for behavior-parity review in core workflows.
+- Agreement on the canonical ownership map before broad file moves begin.
+- Ability to run the existing automated and manual regression checks for core flows.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Contributors can locate the owning module for any major workflow behavior in under 5 minutes using the ownership map and project structure.
+- **SC-002**: At least 80% of previously identified duplicated workflow logic points are consolidated into single owned implementations.
+- **SC-003**: All refactor pull requests remove or reduce code volume in targeted areas with zero net increase in dead-code findings at completion.
+- **SC-004**: Critical-path regression checks for recording, processing, note output, and recovery pass at a 100% rate before merge.
+- **SC-005**: Contributor feedback from at least three reviewers confirms the refactored structure is easier to navigate than the prior structure.
+- **SC-006**: No temporary migration scaffolding remains in the codebase at refactor completion.

--- a/specs/013-simplify-architecture/tasks.md
+++ b/specs/013-simplify-architecture/tasks.md
@@ -1,0 +1,213 @@
+# Tasks: Architecture Simplification Refactor
+
+**Input**: Design documents from `/specs/013-simplify-architecture/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/openapi.yaml, quickstart.md
+
+**Tests**: Tests are REQUIRED for this refactor because the spec and constitution require behavior parity for critical workflows and updates to affected test suites.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no unresolved dependencies)
+- **[Story]**: User story label (`[US1]`, `[US2]`, `[US3]`) for story-phase tasks only
+- Each task includes concrete file path(s)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish refactor tracking artifacts and execution scaffolding used by all stories.
+
+- [X] T001 Create ownership map documentation scaffold in `docs/architecture/ownership-map.md`
+- [X] T002 Create migration note scaffold in `docs/architecture/refactor-migration.md`
+- [X] T003 [P] Create parity checkpoint tracker in `specs/013-simplify-architecture/checklists/parity-checkpoints.md`
+- [X] T004 [P] Add refactor fixture support file in `MinuteTests/TestSupport/RefactorFixtureBuilders.swift`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build shared foundations that block all user stories until complete.
+
+**⚠️ CRITICAL**: Do not start user-story implementation until this phase is complete.
+
+- [X] T005 Add baseline critical-flow parity smoke tests in `MinuteTests/ArchitectureParitySmokeTests.swift`
+- [X] T006 [P] Add MinuteCore parity test support helpers in `MinuteCore/Tests/MinuteCoreTests/TestSupport/RefactorParityTestSupport.swift`
+- [X] T007 [P] Add shared pipeline/coordinator fixture helpers in `MinuteCore/Tests/MinuteCoreTests/TestSupport/PipelineCoordinatorFixture.swift`
+- [X] T008 Populate baseline workflow ownership entries in `docs/architecture/ownership-map.md`
+- [X] T009 Define migration-note entry schema and update protocol in `docs/architecture/refactor-migration.md`
+
+**Checkpoint**: Foundation ready. User stories can proceed.
+
+---
+
+## Phase 3: User Story 1 - Simplify Core Navigation (Priority: P1) 🎯 MVP
+
+**Goal**: Make ownership and navigation of core workflow behavior obvious by decomposing mixed-responsibility surfaces.
+
+**Independent Test**: A contributor can locate and explain recording, processing, and notes ownership in one pass, and debug a workflow without traversing unrelated modules.
+
+### Tests for User Story 1
+
+- [X] T010 [P] [US1] Add status mapping unit tests in `MinuteTests/PipelineStatusPresenterTests.swift`
+- [X] T011 [P] [US1] Add defaults-observation behavior tests in `MinuteTests/PipelineDefaultsObserverTests.swift`
+- [X] T012 [P] [US1] Add notes-overlay state ownership tests in `MinuteTests/MeetingNotesOverlayStateTests.swift`
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Extract status-drawer mapping logic from `Minute/Sources/Views/Pipeline/PipelineContentView.swift` into `Minute/Sources/ViewModels/PipelineStatusPresenter.swift`
+- [X] T014 [US1] Extract defaults-change snapshot/refresh coordination from `Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` into `Minute/Sources/ViewModels/PipelineDefaultsObserver.swift`
+- [X] T015 [US1] Extract note overlay state orchestration from `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift` into `Minute/Sources/Views/MeetingNotes/MeetingNotesOverlayState.swift`
+- [X] T016 [US1] Update pipeline and notes ownership entries for new module boundaries in `docs/architecture/ownership-map.md`
+- [X] T017 [US1] Record moved/renamed module entries in `docs/architecture/refactor-migration.md`
+
+**Checkpoint**: US1 is independently functional and navigable.
+
+---
+
+## Phase 4: User Story 2 - Remove Accidental Complexity (Priority: P2)
+
+**Goal**: Consolidate duplicated behavior into canonical owners and remove pass-through layers.
+
+**Independent Test**: A targeted behavior change in one workflow area requires edits in only one canonical implementation location.
+
+### Tests for User Story 2
+
+- [X] T018 [P] [US2] Add shared model-lifecycle parity tests in `MinuteTests/MinuteTests.swift`
+- [X] T019 [P] [US2] Add shared path-normalization tests in `MinuteCore/Tests/MinuteCoreTests/VaultPathNormalizerTests.swift`
+- [X] T020 [P] [US2] Add ScreenCaptureKit adapter behavior tests in `MinuteCore/Tests/MinuteCoreTests/ScreenCaptureKitAdapterTests.swift`
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Consolidate onboarding/settings model setup lifecycle into `Minute/Sources/ViewModels/ModelSetupLifecycleController.swift` and refactor `Minute/Sources/Views/Onboarding/OnboardingViewModel.swift` and `Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift`
+- [X] T022 [US2] Consolidate vault relative-path normalization into `MinuteCore/Sources/MinuteCore/Vault/VaultPathNormalizer.swift` and refactor `MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift` and `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift`
+- [X] T023 [US2] Consolidate ScreenCaptureKit wrappers into `MinuteCore/Sources/MinuteCore/Services/ScreenCaptureKitAdapter.swift` and refactor `MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift`, `MinuteCore/Sources/MinuteCore/Services/SystemAudioCapture.swift`, and `Minute/Sources/Views/ScreenContextRecordingPickerView.swift`
+- [X] T024 [US2] Move shared meeting-note parsing/transform logic into `MinuteCore/Sources/MinuteCore/Rendering/MeetingNoteParsing.swift` and refactor `Minute/Sources/Views/MeetingNotes/MarkdownViewerOverlay.swift` and `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift`
+- [X] T025 [US2] Update shared behavior consolidation records in `docs/architecture/ownership-map.md` and `docs/architecture/refactor-migration.md`
+
+**Checkpoint**: US2 consolidation is complete and independently verifiable.
+
+---
+
+## Phase 5: User Story 3 - Eliminate Dead Code Paths (Priority: P3)
+
+**Goal**: Remove unreachable, obsolete, and redundant paths while preserving behavior parity.
+
+**Independent Test**: Dead-code audit findings are removed or explicitly rejected with parity evidence and no regression in critical flows.
+
+### Tests for User Story 3
+
+- [X] T026 [P] [US3] Add dead-code parity guard tests in `MinuteTests/MinuteTests.swift`
+- [X] T027 [P] [US3] Refactor repeated setup to shared fixtures in `MinuteTests/MeetingPipelineViewModelCancelSessionTests.swift` and validate via `MinuteTests/MeetingPipelineViewModelKeepRecordingTests.swift`
+- [X] T028 [P] [US3] Add dead-path regression checks for meeting notes flow in `MinuteTests/MeetingNotesBrowserViewModelSpeakerDraftIsolationTests.swift`
+
+### Implementation for User Story 3
+
+- [X] T029 [US3] Remove superseded branches/helpers in `Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` after extracted owners are wired
+- [X] T030 [US3] Remove superseded branches/helpers in `Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift` and `Minute/Sources/Views/MeetingNotes/MarkdownViewerOverlay.swift`
+- [X] T031 [US3] Remove temporary migration scaffolding and obsolete compatibility shims in `MinuteCore/Sources/MinuteCore/Services/DefaultModelManager.swift`, `MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift`, and `MinuteCore/Sources/MinuteCore/Services/MockServices.swift`
+- [X] T032 [US3] Update dead-code findings and closure evidence in `docs/architecture/refactor-migration.md` and `specs/013-simplify-architecture/checklists/parity-checkpoints.md`
+
+**Checkpoint**: US3 dead-code outcomes are complete and independently testable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final cross-story hardening, documentation alignment, and validation.
+
+- [X] T033 [P] Align architecture overview with final ownership boundaries in `docs/overview.md` and `docs/architecture/ownership-map.md`
+- [X] T034 Validate quickstart execution notes and finalize evidence in `specs/013-simplify-architecture/quickstart.md`
+- [X] T035 [P] Reconcile abstract contract and completed workflow states in `specs/013-simplify-architecture/contracts/openapi.yaml`
+- [X] T036 Run full regression test matrix and record final pass summary in `specs/013-simplify-architecture/checklists/parity-checkpoints.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies; start immediately.
+- **Phase 2 (Foundational)**: Depends on Phase 1; blocks all user stories.
+- **Phase 3 (US1)**: Depends on Phase 2 completion.
+- **Phase 4 (US2)**: Depends on Phase 2 completion; can overlap US1 only where file ownership does not conflict.
+- **Phase 5 (US3)**: Depends on completion of US1 and US2 refactor slices it cleans up.
+- **Phase 6 (Polish)**: Depends on all user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent after foundational phase.
+- **US2 (P2)**: Independent after foundational phase but may sequence after US1 to reduce merge conflicts in shared hotspots.
+- **US3 (P3)**: Depends on refactor outputs from US1 and US2 to safely remove superseded paths.
+
+### Dependency Graph (Story Order)
+
+- `US1 -> US2 -> US3` (recommended delivery order)
+- `US1` is MVP scope.
+- `US2` and `US3` extend and finalize simplification.
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1
+
+```bash
+# Parallel US1 test creation
+T010 MinuteTests/PipelineStatusPresenterTests.swift
+T011 MinuteTests/PipelineDefaultsObserverTests.swift
+T012 MinuteTests/MeetingNotesOverlayStateTests.swift
+```
+
+### User Story 2
+
+```bash
+# Parallel US2 test creation
+T018 MinuteTests/ModelSetupLifecycleParityTests.swift
+T019 MinuteCore/Tests/MinuteCoreTests/VaultPathNormalizerTests.swift
+T020 MinuteCore/Tests/MinuteCoreTests/ScreenCaptureKitAdapterTests.swift
+```
+
+### User Story 3
+
+```bash
+# Parallel US3 validation tests
+T026 MinuteTests/ArchitectureDeadCodeParityTests.swift
+T027 MinuteTests/MeetingPipelineViewModelCancelSessionTests.swift
+T028 MinuteTests/MeetingNotesBrowserViewModelSpeakerDraftIsolationTests.swift
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 (US1).
+3. Validate US1 independent test criteria and parity checks.
+4. Stop for review/demo before expanding scope.
+
+### Incremental Delivery
+
+1. Deliver US1 navigation simplification and ownership clarity.
+2. Deliver US2 consolidation of shared behavior and duplicated logic.
+3. Deliver US3 dead-code elimination and cleanup.
+4. Finish with cross-cutting polish and full regression validation.
+
+### Parallel Team Strategy
+
+1. Team completes Setup + Foundational phases together.
+2. Split by story after foundation:
+   - Engineer A: US1
+   - Engineer B: US2 (non-conflicting slices)
+   - Engineer C: US3 prep tests and parity instrumentation
+3. Merge in priority order with parity checkpoints enforced.
+
+---
+
+## Notes
+
+- `[P]` tasks are parallelizable by file and dependency boundaries.
+- Story labels map each story-phase task directly to user value.
+- Every task includes actionable file paths for immediate execution.
+- Keep abstractions shallow: avoid adding wrapper layers without explicit ownership value.


### PR DESCRIPTION
This pull request introduces several architectural and code organization improvements to the ViewModel and presenter layers, focusing on clearer separation of concerns, improved state handling, and code reuse. The main changes include extracting model setup and pipeline status logic into dedicated types, refactoring how pipeline defaults changes are detected, and updating transcript parsing to use a new utility. These changes help simplify the main ViewModel, improve maintainability, and enable easier testing and extension.

**ViewModel and State Handling Improvements:**

- Extracted model setup lifecycle management into a new `ModelSetupLifecycleController` class, encapsulating model validation, download, and state transitions. This moves related logic out of the main ViewModel for better separation of concerns.
- Moved pipeline status presentation logic into a new `PipelineStatusPresenter` struct, which provides a single entry point for mapping pipeline state to UI presentation. This improves clarity and makes the status logic more testable and reusable.

**Pipeline Defaults Change Detection:**

- Introduced a new `PipelineDefaultsObserver` struct to encapsulate snapshotting and change detection of pipeline-relevant user defaults, replacing the previous inline struct and manual comparison logic. This centralizes and standardizes how defaults changes are detected and responded to.
- Updated `MeetingPipelineViewModel` to use `PipelineDefaultsObserver.Snapshot` and the new change detection logic, simplifying the code and making it more robust to future changes in the observed defaults. [[1]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL70-L77) [[2]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL195-R187) [[3]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL487-R499)

**Transcript Parsing Refactor:**

- Updated transcript parsing in `MarkdownViewerOverlay` to use new methods from `MeetingNoteParsing` instead of the previous `TranscriptLineParser`, improving consistency and centralizing transcript parsing logic. [[1]](diffhunk://#diff-0ef69a1426a2adad5b77a2679ff2d84be3713924cd50b4a95ac1c61ec3a4bfb6L294-R295) [[2]](diffhunk://#diff-0ef69a1426a2adad5b77a2679ff2d84be3713924cd50b4a95ac1c61ec3a4bfb6L509-R516)
- Removed the now-unused `TranscriptLine` enum, as transcript line parsing is fully handled by the new utility.

**Other Cleanups:**

- Removed the unused `FailingTranscriptionService` from the ViewModel file, reducing clutter.
- Updated documentation in `AGENTS.md` to reflect new Swift and package requirements and clarify local file and preference usage.