### PR TITLE
Add NB-Whisper Norwegian transcription models

### DIFF
--- a/MinuteCore/Sources/MinuteCore/Domain/TranscriptionModels.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/TranscriptionModels.swift
@@ -75,8 +75,40 @@ public enum TranscriptionModelCatalog {
         encoderCoreMLExpectedFileSizeBytes: 1_173_393_014
     )
 
+    // MARK: - NB-Whisper (Norwegian)
+
+    private static let nbWhisperSmall = TranscriptionModel(
+        id: "nb-whisper/small",
+        displayName: "NB-Whisper Small (Norwegian)",
+        summary: "Norwegian-tuned model by NB AI-Lab. Fast with good accuracy for Norwegian.",
+        fileName: "nb-whisper-small.bin",
+        sourceURL: URL(string: "https://huggingface.co/NbAiLab/nb-whisper-small/resolve/main/ggml-model.bin")!,
+        expectedSHA256Hex: "a0fc1555f5bd51044b0ea88bb9b7891e1ee331a8087eddb0afc3a05839db48ab",
+        expectedFileSizeBytes: 487_601_984
+    )
+
+    private static let nbWhisperMedium = TranscriptionModel(
+        id: "nb-whisper/medium",
+        displayName: "NB-Whisper Medium (Norwegian)",
+        summary: "Norwegian-tuned model by NB AI-Lab. Better accuracy, larger download.",
+        fileName: "nb-whisper-medium.bin",
+        sourceURL: URL(string: "https://huggingface.co/NbAiLab/nb-whisper-medium/resolve/main/ggml-model.bin")!,
+        expectedSHA256Hex: "f73141401d203ee77fc7ddf7bf97926a8a85fe85faa6066a6920e4815f48a73d",
+        expectedFileSizeBytes: 1_533_763_076
+    )
+
+    private static let nbWhisperLarge = TranscriptionModel(
+        id: "nb-whisper/large",
+        displayName: "NB-Whisper Large (Norwegian)",
+        summary: "Norwegian-tuned model by NB AI-Lab. Best accuracy for Norwegian speech.",
+        fileName: "nb-whisper-large.bin",
+        sourceURL: URL(string: "https://huggingface.co/NbAiLab/nb-whisper-large/resolve/main/ggml-model.bin")!,
+        expectedSHA256Hex: "0f2f66f22e11a7c7da3c582d8e5c89cb2c0011753ba9c7c9731e320a4ba33e76",
+        expectedFileSizeBytes: 3_095_033_483
+    )
+
     public static var all: [TranscriptionModel] {
-        var models = [baseModel]
+        var models = [baseModel, nbWhisperSmall, nbWhisperMedium, nbWhisperLarge]
         if isLargeModelEnabled {
             models.append(largeV3Turbo)
         }

--- a/MinuteCore/Tests/MinuteCoreTests/TranscriptionModelCatalogTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/TranscriptionModelCatalogTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import Foundation
+@testable import MinuteCore
+
+struct TranscriptionModelCatalogTests {
+    @Test
+    func all_containsBaseModel() {
+        let ids = TranscriptionModelCatalog.all.map(\.id)
+        #expect(ids.contains("whisper/base"))
+    }
+
+    @Test
+    func all_containsNBWhisperModels() {
+        let ids = TranscriptionModelCatalog.all.map(\.id)
+        #expect(ids.contains("nb-whisper/small"))
+        #expect(ids.contains("nb-whisper/medium"))
+        #expect(ids.contains("nb-whisper/large"))
+    }
+
+    @Test
+    func nbWhisperModels_haveUniqueFileNames() {
+        let nbModels = TranscriptionModelCatalog.all.filter { $0.id.hasPrefix("nb-whisper/") }
+        let fileNames = Set(nbModels.map(\.fileName))
+        #expect(fileNames.count == nbModels.count)
+    }
+
+    @Test
+    func nbWhisperModels_haveExpectedFileSizes() {
+        for model in TranscriptionModelCatalog.all where model.id.hasPrefix("nb-whisper/") {
+            #expect(model.expectedFileSizeBytes != nil)
+            #expect(model.expectedFileSizeBytes! > 0)
+        }
+    }
+
+    @Test
+    func nbWhisperModels_haveHuggingFaceSourceURLs() {
+        for model in TranscriptionModelCatalog.all where model.id.hasPrefix("nb-whisper/") {
+            #expect(model.sourceURL.host?.contains("huggingface.co") == true)
+        }
+    }
+
+    @Test
+    func nbWhisperModels_doNotHaveCoreMLEncoders() {
+        for model in TranscriptionModelCatalog.all where model.id.hasPrefix("nb-whisper/") {
+            #expect(model.encoderCoreMLSourceURL == nil)
+            #expect(model.encoderCoreMLDestinationURL == nil)
+        }
+    }
+
+    @Test
+    func allModels_haveUniqueIDs() {
+        let ids = TranscriptionModelCatalog.all.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test
+    func allModels_haveUniqueFileNames() {
+        let fileNames = TranscriptionModelCatalog.all.map(\.fileName)
+        #expect(Set(fileNames).count == fileNames.count)
+    }
+
+    @Test
+    func model_looksUpNBWhisperByID() {
+        let model = TranscriptionModelCatalog.model(for: "nb-whisper/large")
+        #expect(model != nil)
+        #expect(model?.displayName == "NB-Whisper Large (Norwegian)")
+    }
+
+    @Test
+    func defaultModel_isWhisperBase() {
+        let model = TranscriptionModelCatalog.defaultModel
+        #expect(model.id == "whisper/base")
+    }
+}


### PR DESCRIPTION
## Summary

Adds [NB-Whisper](https://huggingface.co/NbAiLab/nb-whisper-large) models (Small, Medium, Large) to the transcription model catalog for improved Norwegian speech recognition.

NB-Whisper is developed by NB AI-Lab (National Library of Norway), fine-tuned on 66,000 hours of Norwegian speech data. The models use the standard GGML format, so no infrastructure changes are needed — the existing download, validation, and whisper.cpp transcription pipelines work as-is.

## Models added

| Model | Size | Parameters |
|-------|------|------------|
| NB-Whisper Small | ~465 MB | 244M |
| NB-Whisper Medium | ~1.4 GB | 769M |
| NB-Whisper Large | ~2.9 GB | 1550M |

## Changes

- **`TranscriptionModels.swift`**: Added 3 NB-Whisper model entries with pinned HuggingFace download URLs, SHA256 checksums, and file sizes. Models are always visible in settings (no feature flag).
- **`TranscriptionModelCatalogTests.swift`** (new): Tests for catalog presence, unique IDs/filenames, metadata validity, and lookup.

## Usage

Select an NB-Whisper model in Settings → Transcription Model, and set the language to **Norwegian** for best results.