### PR TITLE
018 lm studio support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Specification history: `specs/`
 ## Active Technologies
 - Swift 6.2 tools for `MinuteCore`; Swift/SwiftUI macOS app target on Xcode 15.x conventions + SwiftUI, Combine, `MinuteCore`, `MinuteLlama`, new `MinuteOllama` target, Foundation networking for localhost daemon calls, AVFoundation, ScreenCaptureKit, FluidAudio (017-ollama-summarization-option)
 - Local vault files, `UserDefaults`-backed app preferences, Application Support model artifacts for llama.cpp, and Ollama daemon state managed outside Minute (017-ollama-summarization-option)
+- Swift 6.2 tools for `MinuteCore`; Swift/SwiftUI macOS app target on Xcode 15.x conventions + SwiftUI, Combine, `MinuteCore`, `MinuteLlama`, `MinuteOllama`, new `MinuteLMStudio` target, Foundation networking for local server calls, AVFoundation, ScreenCaptureKit, FluidAudio (018-lm-studio-support)
+- Local vault files, `UserDefaults`-backed provider preferences and local server settings, Application Support model artifacts for built-in runtimes, and user-managed Ollama and LM Studio state outside Minute (018-lm-studio-support)
 
 ## Recent Changes
 - 017-ollama-summarization-option: Added Swift 6.2 tools for `MinuteCore`; Swift/SwiftUI macOS app target on Xcode 15.x conventions + SwiftUI, Combine, `MinuteCore`, `MinuteLlama`, new `MinuteOllama` target, Foundation networking for localhost daemon calls, AVFoundation, ScreenCaptureKit, FluidAudio

--- a/Minute.xcodeproj/project.pbxproj
+++ b/Minute.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0E0A182A0E8F4C1792A8B075 /* MinuteLlama in Frameworks */ = {isa = PBXBuildFile; productRef = B730481B2E3B4E5FB8E38D6E /* MinuteLlama */; };
 		13E6D74F51A2432B8FB8B1A1 /* MinuteOllama in Frameworks */ = {isa = PBXBuildFile; productRef = 13E6D74E51A2432B8FB8B1A1 /* MinuteOllama */; };
+		24A1B2C3D4E5F60718293A4B /* MinuteLMStudio in Frameworks */ = {isa = PBXBuildFile; productRef = 24A1B2C3D4E5F60718293A4A /* MinuteLMStudio */; };
 		1A2B3C4D5E6F7890ABCDEF12 /* StageDropValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E7D1B0A9B34B87B2E6A123 /* StageDropValidationTests.swift */; };
 		1DBD0C88C2F54CA78D084F61 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 3B3599BC65E149678727D1B7 /* Sparkle */; settings = {ATTRIBUTES = (Weak, ); }; };
 		2D3E4F5A6B7C8D9E0F1A2B3C /* MeetingTypesSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4F5A6B7C8D9E0F1A2B3C4D /* MeetingTypesSettingsViewModelTests.swift */; };
@@ -105,6 +106,7 @@
 				9C45E2A61F1D4A7A9E4C0B11 /* MinuteWhisper in Frameworks */,
 				0E0A182A0E8F4C1792A8B075 /* MinuteLlama in Frameworks */,
 				13E6D74F51A2432B8FB8B1A1 /* MinuteOllama in Frameworks */,
+				24A1B2C3D4E5F60718293A4B /* MinuteLMStudio in Frameworks */,
 				70055E391D7145CFA8509E54 /* MarkdownUI in Frameworks */,
 				1DBD0C88C2F54CA78D084F61 /* Sparkle in Frameworks */,
 			);
@@ -237,6 +239,7 @@
 				5A7F52132F1F0D0A00D8E124 /* MinuteWhisper */,
 				B730481B2E3B4E5FB8E38D6E /* MinuteLlama */,
 				13E6D74E51A2432B8FB8B1A1 /* MinuteOllama */,
+				24A1B2C3D4E5F60718293A4A /* MinuteLMStudio */,
 				0AF288CF7B9C4B81AEE5DD29 /* MarkdownUI */,
 				3B3599BC65E149678727D1B7 /* Sparkle */,
 			);
@@ -898,6 +901,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 58B6950A2EF600000068FAA7 /* XCLocalSwiftPackageReference "MinuteCore" */;
 			productName = MinuteOllama;
+		};
+		24A1B2C3D4E5F60718293A4A /* MinuteLMStudio */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 58B6950A2EF600000068FAA7 /* XCLocalSwiftPackageReference "MinuteCore" */;
+			productName = MinuteLMStudio;
 		};
 		3B3599BC65E149678727D1B7 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
+++ b/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
@@ -892,6 +892,15 @@ final class MeetingPipelineViewModel: ObservableObject {
         }
     }
 
+    func dismissCloseableStatus() {
+        switch state {
+        case .done, .failed:
+            send(.reset)
+        default:
+            break
+        }
+    }
+
     func cancelBackgroundProcessing(clearPending: Bool) {
         Task { [processingOrchestrator] in
             await processingOrchestrator.cancelActiveProcessing(clearPending: clearPending)
@@ -1711,8 +1720,17 @@ final class MeetingPipelineViewModel: ObservableObject {
 
     private func handleScreenContextLifecycleEvent(_ event: ScreenContextLifecycleEvent) {
         guard case .recording(let session) = state else { return }
-        guard event.type == .sharedWindowClosed else { return }
-        beginScreenContextAutoStopWarning(session: session, windowTitle: event.windowTitle)
+        switch event.type {
+        case .sharedWindowClosed:
+            beginScreenContextAutoStopWarning(session: session, windowTitle: event.windowTitle)
+        case .inferenceUnavailable:
+            Task { @MainActor [weak self] in
+                await self?.handleScreenContextInferenceUnavailable(
+                    session: session,
+                    message: event.message
+                )
+            }
+        }
     }
 
     func _testHandleScreenContextLifecycleEvent(_ event: ScreenContextLifecycleEvent) {
@@ -1834,11 +1852,32 @@ final class MeetingPipelineViewModel: ObservableObject {
         }
 
         do {
-            return try await screenContextVideoExtractor.inferEvents(from: sourceURL)
+            let result = try await screenContextVideoExtractor.inferEvents(from: sourceURL)
+            if let terminalFailureMessage = result?.terminalFailureMessage {
+                logger.info(
+                    "Video screen context stopped after terminal failure: \(terminalFailureMessage, privacy: .private(mask: .hash))"
+                )
+            }
+            return result
         } catch {
             logger.error("Video screen context failed: \(ErrorHandler.debugMessage(for: error), privacy: .private(mask: .hash))")
             return nil
         }
+    }
+
+    private func handleScreenContextInferenceUnavailable(
+        session: RecordingSession,
+        message: String?
+    ) async {
+        _ = await stopScreenContextCaptureAndAppend()
+        screenCaptureEnabled = false
+        latestScreenCaptureImage = nil
+        activeVisionBindingStore.set(nil)
+        await clearScreenContextAutoStopWarning()
+        await presentScreenContextConfigurationAlert(
+            sessionID: session.id,
+            message: message ?? "Screen context is unavailable for the selected vision configuration."
+        )
     }
 
     private func isVideoImportURL(_ url: URL) -> Bool {

--- a/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
+++ b/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
@@ -6,6 +6,7 @@ import Combine
 import Foundation
 import MinuteCore
 import MinuteLlama
+import MinuteLMStudio
 import MinuteOllama
 import MinuteWhisper
 import os
@@ -551,7 +552,7 @@ final class MeetingPipelineViewModel: ObservableObject {
     static func live() -> MeetingPipelineViewModel {
         let defaults = UserDefaults.standard
         let providerStore = InferenceProviderSelectionStore(defaults: defaults)
-        let ollamaEndpointStore = OllamaEndpointSettingsStore(defaults: defaults)
+        let connectionStore = ProviderConnectionSettingsStore(defaults: defaults)
         let selectionStore = SummarizationModelSelectionStore(defaults: defaults)
         let contextWindowStore = SummarizationContextWindowSelectionStore(defaults: defaults)
         let visionModelStore = VisionModelSelectionStore(defaults: defaults)
@@ -560,13 +561,20 @@ final class MeetingPipelineViewModel: ObservableObject {
         let transcriptionBackendStore = TranscriptionBackendSelectionStore(defaults: defaults)
         let fluidAudioModelStore = FluidAudioASRModelSelectionStore(defaults: defaults)
         let ollamaModelDiscovererProvider: @Sendable () -> (any OllamaModelDiscovering)? = {
-            guard let baseURL = ollamaEndpointStore.selectedBaseURL() else {
+            guard let baseURL = connectionStore.selectedBaseURL(for: .ollama) else {
                 return nil
             }
             return OllamaModelDiscoveryService(client: OllamaAPIClient(baseURL: baseURL))
         }
+        let lmStudioModelDiscovererProvider: @Sendable () -> (any LMStudioModelDiscovering)? = {
+            guard let baseURL = connectionStore.selectedBaseURL(for: .lmStudio) else {
+                return nil
+            }
+            return LMStudioModelDiscoveryService(client: LMStudioAPIClient(baseURL: baseURL))
+        }
         let runtimeFactory = InferenceRuntimeFactory(
             providerStore: providerStore,
+            connectionStore: connectionStore,
             summarizationModelStore: selectionStore,
             summarizationContextWindowStore: contextWindowStore,
             visionModelStore: visionModelStore,
@@ -578,8 +586,8 @@ final class MeetingPipelineViewModel: ObservableObject {
                     hardwareProfile: profile
                 )
             },
-            ollamaSummarizationBuilder: { tag in
-                guard let baseURL = ollamaEndpointStore.selectedBaseURL() else {
+            ollamaSummarizationBuilder: { tag, baseURL in
+                guard let baseURL else {
                     return ErrorSummarizationService(
                         error: .llamaFailed(exitCode: -1, output: "Invalid Ollama base URL")
                     )
@@ -587,6 +595,17 @@ final class MeetingPipelineViewModel: ObservableObject {
                 return OllamaSummarizationService(
                     modelTag: tag,
                     client: OllamaAPIClient(baseURL: baseURL)
+                )
+            },
+            lmStudioSummarizationBuilder: { identifier, baseURL in
+                guard let baseURL else {
+                    return ErrorSummarizationService(
+                        error: .llamaFailed(exitCode: -1, output: "Invalid LM Studio base URL")
+                    )
+                }
+                return LMStudioSummarizationService(
+                    modelIdentifier: identifier,
+                    client: LMStudioAPIClient(baseURL: baseURL)
                 )
             },
             builtInVisionBuilder: { store in
@@ -601,8 +620,8 @@ final class MeetingPipelineViewModel: ObservableObject {
                     )
                 )
             },
-            ollamaVisionBuilder: { tag in
-                guard let baseURL = ollamaEndpointStore.selectedBaseURL() else {
+            ollamaVisionBuilder: { tag, baseURL in
+                guard let baseURL else {
                     return ErrorScreenContextInferenceService(
                         error: .llamaMTMDFailed(exitCode: -1, output: "Invalid Ollama base URL")
                     )
@@ -612,7 +631,19 @@ final class MeetingPipelineViewModel: ObservableObject {
                     client: OllamaAPIClient(baseURL: baseURL)
                 )
             },
-            ollamaModelDiscoverer: ollamaModelDiscovererProvider()
+            lmStudioVisionBuilder: { identifier, baseURL in
+                guard let baseURL else {
+                    return ErrorScreenContextInferenceService(
+                        error: .llamaMTMDFailed(exitCode: -1, output: "Invalid LM Studio base URL")
+                    )
+                }
+                return LMStudioVisionInferenceService(
+                    modelIdentifier: identifier,
+                    client: LMStudioAPIClient(baseURL: baseURL)
+                )
+            },
+            ollamaModelDiscoverer: ollamaModelDiscovererProvider(),
+            lmStudioModelDiscoverer: lmStudioModelDiscovererProvider()
         )
         let activeVisionBindingStore = ActiveVisionBindingStore()
         let liveScreenContextInferencerProvider = makeLiveScreenContextInferencerProvider(
@@ -686,7 +717,7 @@ final class MeetingPipelineViewModel: ObservableObject {
                         ),
                         reservedOutputTokens: 1_024
                     )
-                case .ollama:
+                case .ollama, .lmStudio:
                     return .default
                 }
             }
@@ -718,6 +749,13 @@ final class MeetingPipelineViewModel: ObservableObject {
                     .trimmingCharacters(in: .whitespacesAndNewlines),
                    !tag.isEmpty {
                     return try await ollamaModelDiscoverer.validateModelTag(tag, for: .vision)
+                }
+                if let lmStudioModelDiscoverer = lmStudioModelDiscovererProvider(),
+                   providerStore.selectedProvider(for: .vision) == .lmStudio,
+                   let identifier = providerStore.selectedLMStudioModelIdentifier(for: .vision)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !identifier.isEmpty {
+                    return try await lmStudioModelDiscoverer.validateModelIdentifier(identifier, for: .vision)
                 }
                 return try await runtimeFactory.availability(for: .vision)
             },

--- a/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift
+++ b/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift
@@ -3,6 +3,7 @@ import Combine
 import Foundation
 import MinuteCore
 import MinuteLlama
+import MinuteLMStudio
 import MinuteOllama
 import MinuteWhisper
 
@@ -987,7 +988,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
     nonisolated private static func defaultReprocessRunner() -> @Sendable (ReprocessMeetingRequest) async throws -> PipelineResult {
         let defaults = UserDefaults.standard
         let providerStore = InferenceProviderSelectionStore(defaults: defaults)
-        let ollamaEndpointStore = OllamaEndpointSettingsStore(defaults: defaults)
+        let connectionStore = ProviderConnectionSettingsStore(defaults: defaults)
         let selectionStore = SummarizationModelSelectionStore(defaults: defaults)
         let contextWindowStore = SummarizationContextWindowSelectionStore(defaults: defaults)
         let visionModelStore = VisionModelSelectionStore(defaults: defaults)
@@ -997,6 +998,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
         let fluidAudioModelStore = FluidAudioASRModelSelectionStore(defaults: defaults)
         let runtimeFactory = InferenceRuntimeFactory(
             providerStore: providerStore,
+            connectionStore: connectionStore,
             summarizationModelStore: selectionStore,
             summarizationContextWindowStore: contextWindowStore,
             visionModelStore: visionModelStore,
@@ -1008,8 +1010,8 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
                     hardwareProfile: profile
                 )
             },
-            ollamaSummarizationBuilder: { tag in
-                guard let baseURL = ollamaEndpointStore.selectedBaseURL() else {
+            ollamaSummarizationBuilder: { tag, baseURL in
+                guard let baseURL else {
                     return ErrorSummarizationService(
                         error: .llamaFailed(exitCode: -1, output: "Invalid Ollama base URL")
                     )
@@ -1017,6 +1019,17 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
                 return OllamaSummarizationService(
                     modelTag: tag,
                     client: OllamaAPIClient(baseURL: baseURL)
+                )
+            },
+            lmStudioSummarizationBuilder: { identifier, baseURL in
+                guard let baseURL else {
+                    return ErrorSummarizationService(
+                        error: .llamaFailed(exitCode: -1, output: "Invalid LM Studio base URL")
+                    )
+                }
+                return LMStudioSummarizationService(
+                    modelIdentifier: identifier,
+                    client: LMStudioAPIClient(baseURL: baseURL)
                 )
             }
         )
@@ -1087,7 +1100,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
                         ),
                         reservedOutputTokens: 1_024
                     )
-                case .ollama:
+                case .ollama, .lmStudio:
                     return .default
                 }
             }

--- a/Minute/Sources/Views/Onboarding/OnboardingView.swift
+++ b/Minute/Sources/Views/Onboarding/OnboardingView.swift
@@ -375,11 +375,10 @@ private struct OnboardingHeader: View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(stepTitle)
-                    .font(.title2.bold())
+                    .minuteSettingsHeaderTitle()
                 if let stepSubtitle {
                     Text(stepSubtitle)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .minuteSettingsHeaderSubtitle()
                 }
             }
         }
@@ -428,7 +427,7 @@ private struct OnboardingProviderChoicePicker: View {
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
                     Text(title)
-                        .font(.headline)
+                        .minuteRowTitle()
                     Spacer()
                     if isSelected {
                         Image(systemName: "checkmark.circle.fill")
@@ -437,22 +436,20 @@ private struct OnboardingProviderChoicePicker: View {
                 }
 
                 Text(subtitle)
-                    .font(.callout.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .minuteCaption()
 
                 Text(provider.description)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .minuteFootnote()
                     .multilineTextAlignment(.leading)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(14)
             .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.secondary.opacity(0.08))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .stroke(isSelected ? Color.accentColor.opacity(0.7) : Color.secondary.opacity(0.12), lineWidth: 1)
             )
         }

--- a/Minute/Sources/Views/Onboarding/OnboardingView.swift
+++ b/Minute/Sources/Views/Onboarding/OnboardingView.swift
@@ -184,6 +184,18 @@ struct OnboardingView: View {
                 }
             }
 
+            if model.showsLMStudioEndpointConfigurationForSummarization {
+                SettingsFieldBlock(
+                    title: "LM Studio base URL",
+                    subtitle: "Use the full LM Studio endpoint, including protocol and port."
+                ) {
+                    SettingsSingleLineInput(
+                        text: $model.selectedLMStudioBaseURLString,
+                        placeholder: AppConfiguration.Defaults.defaultLMStudioBaseURL
+                    )
+                }
+            }
+
             if model.usesOllamaForSummarization {
                 SettingsFieldBlock(
                     title: "Ollama model tag",
@@ -198,7 +210,27 @@ struct OnboardingView: View {
                 InferenceCapabilityStatusView(
                     title: "Summarization validation",
                     state: model.summarizationAvailabilityState,
-                    discoveredModelTags: model.ollamaDiscoveredModelTags,
+                    discoveredModelReferences: model.ollamaDiscoveredModelTags,
+                    discoveredModelsTitle: "Downloaded in Ollama",
+                    isRefreshing: model.isRefreshingAvailability,
+                    onRefresh: { model.refreshAvailability() }
+                )
+            } else if model.usesLMStudioForSummarization {
+                SettingsFieldBlock(
+                    title: "LM Studio model",
+                    subtitle: "Use a summarization model that is already available in your local LM Studio server."
+                ) {
+                    SettingsSingleLineInput(
+                        text: $model.selectedSummarizationLMStudioModelIdentifier,
+                        placeholder: "e.g. qwen2.5-7b-instruct"
+                    )
+                }
+
+                InferenceCapabilityStatusView(
+                    title: "Summarization validation",
+                    state: model.summarizationAvailabilityState,
+                    discoveredModelReferences: model.lmStudioDiscoveredModelIdentifiers,
+                    discoveredModelsTitle: "Available in LM Studio",
                     isRefreshing: model.isRefreshingAvailability,
                     onRefresh: { model.refreshAvailability() }
                 )
@@ -256,6 +288,18 @@ struct OnboardingView: View {
                     }
                 }
 
+                if model.showsLMStudioEndpointConfigurationForScreenContext {
+                    SettingsFieldBlock(
+                        title: "LM Studio base URL",
+                        subtitle: "Use the full LM Studio endpoint, including protocol and port."
+                    ) {
+                        SettingsSingleLineInput(
+                            text: $model.selectedLMStudioBaseURLString,
+                            placeholder: AppConfiguration.Defaults.defaultLMStudioBaseURL
+                        )
+                    }
+                }
+
                 if model.usesOllamaForScreenContext {
                     SettingsFieldBlock(
                         title: "Ollama model tag",
@@ -270,7 +314,27 @@ struct OnboardingView: View {
                     InferenceCapabilityStatusView(
                         title: "Screen context validation",
                         state: model.visionAvailabilityState,
-                        discoveredModelTags: model.ollamaDiscoveredModelTags,
+                        discoveredModelReferences: model.ollamaDiscoveredModelTags,
+                        discoveredModelsTitle: "Downloaded in Ollama",
+                        isRefreshing: model.isRefreshingAvailability,
+                        onRefresh: { model.refreshAvailability() }
+                    )
+                } else if model.usesLMStudioForScreenContext {
+                    SettingsFieldBlock(
+                        title: "LM Studio model",
+                        subtitle: "Use a local LM Studio model that supports vision or screen-context input."
+                    ) {
+                        SettingsSingleLineInput(
+                            text: $model.selectedVisionLMStudioModelIdentifier,
+                            placeholder: "e.g. qwen2.5-vl-7b"
+                        )
+                    }
+
+                    InferenceCapabilityStatusView(
+                        title: "Screen context validation",
+                        state: model.visionAvailabilityState,
+                        discoveredModelReferences: model.lmStudioDiscoveredModelIdentifiers,
+                        discoveredModelsTitle: "Available in LM Studio",
                         isRefreshing: model.isRefreshingAvailability,
                         onRefresh: { model.refreshAvailability() }
                     )
@@ -341,6 +405,11 @@ private struct OnboardingProviderChoicePicker: View {
                     title: "Ollama",
                     subtitle: "Advanced",
                     provider: .ollama
+                )
+                optionButton(
+                    title: "LM Studio",
+                    subtitle: "Advanced",
+                    provider: .lmStudio
                 )
             }
         }

--- a/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -842,7 +842,7 @@ final class OnboardingViewModel: ObservableObject {
             message = "LM Studio is unavailable. Start the local server and refresh."
             status = .serverUnavailable
         }
-        CapabilityAvailabilityState(
+        return CapabilityAvailabilityState(
             capabilityID: capability,
             providerID: provider,
             isReady: false,
@@ -869,7 +869,7 @@ final class OnboardingViewModel: ObservableObject {
             message = "Enter a valid LM Studio base URL such as \(AppConfiguration.Defaults.defaultLMStudioBaseURL)."
             selectedReference = selectedLMStudioBaseURLString
         }
-        CapabilityAvailabilityState(
+        return CapabilityAvailabilityState(
             capabilityID: capability,
             providerID: provider,
             isReady: false,

--- a/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreGraphics
 import Foundation
 import MinuteCore
+import MinuteLMStudio
 import MinuteOllama
 
 @MainActor
@@ -57,6 +58,7 @@ final class OnboardingViewModel: ObservableObject {
         status: .ready
     )
     @Published private(set) var ollamaDiscoverySnapshot: OllamaDiscoverySnapshot? = nil
+    @Published private(set) var lmStudioDiscoverySnapshot: LMStudioDiscoverySnapshot? = nil
     @Published private(set) var isRefreshingAvailability = false
     @Published var selectedSummarizationProviderID: String {
         didSet {
@@ -82,10 +84,27 @@ final class OnboardingViewModel: ObservableObject {
             refreshAvailability()
         }
     }
+    @Published var selectedSummarizationLMStudioModelIdentifier: String {
+        didSet {
+            guard oldValue != selectedSummarizationLMStudioModelIdentifier else { return }
+            inferenceProviderStore.setSelectedLMStudioModelIdentifier(
+                selectedSummarizationLMStudioModelIdentifier,
+                for: .summarization
+            )
+            refreshAvailability()
+        }
+    }
     @Published var selectedOllamaBaseURLString: String {
         didSet {
             guard oldValue != selectedOllamaBaseURLString else { return }
-            ollamaEndpointStore.setSelectedBaseURLString(selectedOllamaBaseURLString)
+            connectionStore.setSelectedBaseURLString(selectedOllamaBaseURLString, for: .ollama)
+            refreshAvailability()
+        }
+    }
+    @Published var selectedLMStudioBaseURLString: String {
+        didSet {
+            guard oldValue != selectedLMStudioBaseURLString else { return }
+            connectionStore.setSelectedBaseURLString(selectedLMStudioBaseURLString, for: .lmStudio)
             refreshAvailability()
         }
     }
@@ -128,6 +147,16 @@ final class OnboardingViewModel: ObservableObject {
             refreshAvailability()
         }
     }
+    @Published var selectedVisionLMStudioModelIdentifier: String {
+        didSet {
+            guard oldValue != selectedVisionLMStudioModelIdentifier else { return }
+            inferenceProviderStore.setSelectedLMStudioModelIdentifier(
+                selectedVisionLMStudioModelIdentifier,
+                for: .vision
+            )
+            refreshAvailability()
+        }
+    }
     @Published var selectedTranscriptionBackendID: String {
         didSet {
             guard oldValue != selectedTranscriptionBackendID else { return }
@@ -152,7 +181,7 @@ final class OnboardingViewModel: ObservableObject {
 
     private let defaults: UserDefaults
     private let inferenceProviderStore: InferenceProviderSelectionStore
-    private let ollamaEndpointStore: OllamaEndpointSettingsStore
+    private let connectionStore: ProviderConnectionSettingsStore
     private let summarizationModelStore: SummarizationModelSelectionStore
     private let summarizationContextWindowStore: SummarizationContextWindowSelectionStore
     private let screenContextSettingsStore: ScreenContextSettingsStore
@@ -164,6 +193,7 @@ final class OnboardingViewModel: ObservableObject {
     private let availabilityProvider: any CapabilityAvailabilityProviding
     private let usesCustomAvailabilityProvider: Bool
     private let providedOllamaModelDiscoverer: (any OllamaModelDiscovering)?
+    private let providedLMStudioModelDiscoverer: (any LMStudioModelDiscovering)?
 
     private var defaultsObserver: AnyCancellable?
     private var observedVaultBookmark: Data?
@@ -180,7 +210,7 @@ final class OnboardingViewModel: ObservableObject {
         modelManager: (any ModelManaging)? = nil,
         defaults: UserDefaults = .standard,
         inferenceProviderStore: InferenceProviderSelectionStore? = nil,
-        ollamaEndpointStore: OllamaEndpointSettingsStore? = nil,
+        connectionStore: ProviderConnectionSettingsStore? = nil,
         summarizationModelStore: SummarizationModelSelectionStore? = nil,
         summarizationContextWindowStore: SummarizationContextWindowSelectionStore? = nil,
         screenContextSettingsStore: ScreenContextSettingsStore? = nil,
@@ -189,10 +219,11 @@ final class OnboardingViewModel: ObservableObject {
         transcriptionBackendStore: TranscriptionBackendSelectionStore? = nil,
         fluidAudioModelStore: FluidAudioASRModelSelectionStore? = nil,
         availabilityProvider: (any CapabilityAvailabilityProviding)? = nil,
-        ollamaModelDiscoverer: (any OllamaModelDiscovering)? = nil
+        ollamaModelDiscoverer: (any OllamaModelDiscovering)? = nil,
+        lmStudioModelDiscoverer: (any LMStudioModelDiscovering)? = nil
     ) {
         let providerStore = inferenceProviderStore ?? InferenceProviderSelectionStore(defaults: defaults)
-        let endpointStore = ollamaEndpointStore ?? OllamaEndpointSettingsStore(defaults: defaults)
+        let resolvedConnectionStore = connectionStore ?? ProviderConnectionSettingsStore(defaults: defaults)
         let store = summarizationModelStore ?? SummarizationModelSelectionStore(defaults: defaults)
         let contextStore = summarizationContextWindowStore ?? SummarizationContextWindowSelectionStore(defaults: defaults)
         let screenContextStore = screenContextSettingsStore ?? ScreenContextSettingsStore(defaults: defaults)
@@ -210,7 +241,7 @@ final class OnboardingViewModel: ObservableObject {
         )
         self.defaults = defaults
         self.inferenceProviderStore = providerStore
-        self.ollamaEndpointStore = endpointStore
+        self.connectionStore = resolvedConnectionStore
         self.summarizationModelStore = store
         self.summarizationContextWindowStore = contextStore
         self.screenContextSettingsStore = screenContextStore
@@ -219,9 +250,11 @@ final class OnboardingViewModel: ObservableObject {
         self.transcriptionBackendStore = backendStore
         self.fluidAudioModelStore = fluidStore
         self.providedOllamaModelDiscoverer = ollamaModelDiscoverer
+        self.providedLMStudioModelDiscoverer = lmStudioModelDiscoverer
         self.usesCustomAvailabilityProvider = availabilityProvider != nil
         self.availabilityProvider = availabilityProvider ?? InferenceRuntimeFactory(
             providerStore: providerStore,
+            connectionStore: resolvedConnectionStore,
             summarizationModelStore: store,
             summarizationContextWindowStore: contextStore,
             visionModelStore: visionStore
@@ -238,7 +271,9 @@ final class OnboardingViewModel: ObservableObject {
             store.setSelectedModelID(selectedModel.id)
         }
         self.selectedSummarizationOllamaModelTag = providerStore.selectedOllamaModelTag(for: .summarization) ?? ""
-        self.selectedOllamaBaseURLString = endpointStore.selectedBaseURLString()
+        self.selectedSummarizationLMStudioModelIdentifier = providerStore.selectedLMStudioModelIdentifier(for: .summarization) ?? ""
+        self.selectedOllamaBaseURLString = resolvedConnectionStore.selectedBaseURLString(for: .ollama)
+        self.selectedLMStudioBaseURLString = resolvedConnectionStore.selectedBaseURLString(for: .lmStudio)
         self.selectedSummarizationContextWindowPreset = contextStore.selectedPreset()
         self.screenContextEnabled = screenContextStore.isEnabled
         let selectedVisionProvider = providerStore.selectedProvider(for: .vision)
@@ -249,6 +284,7 @@ final class OnboardingViewModel: ObservableObject {
             visionStore.setSelectedModelID(selectedVisionModel.id)
         }
         self.selectedVisionOllamaModelTag = providerStore.selectedOllamaModelTag(for: .vision) ?? ""
+        self.selectedVisionLMStudioModelIdentifier = providerStore.selectedLMStudioModelIdentifier(for: .vision) ?? ""
         let selectedBackend = backendStore.selectedBackend()
         self.selectedTranscriptionBackendID = selectedBackend.id
         if backendStore.selectedBackendID() != selectedBackend.id {
@@ -347,12 +383,24 @@ final class OnboardingViewModel: ObservableObject {
         selectedSummarizationProviderID == InferenceProvider.ollama.rawValue
     }
 
+    var usesLMStudioForSummarization: Bool {
+        selectedSummarizationProviderID == InferenceProvider.lmStudio.rawValue
+    }
+
     var usesOllamaForScreenContext: Bool {
         selectedVisionProviderID == InferenceProvider.ollama.rawValue
     }
 
+    var usesLMStudioForScreenContext: Bool {
+        selectedVisionProviderID == InferenceProvider.lmStudio.rawValue
+    }
+
     var ollamaDiscoveredModelTags: [String] {
         ollamaDiscoverySnapshot?.models.map(\.tag) ?? []
+    }
+
+    var lmStudioDiscoveredModelIdentifiers: [String] {
+        lmStudioDiscoverySnapshot?.models.map(\.identifier) ?? []
     }
 
     var transcriptionSetupReady: Bool {
@@ -364,7 +412,7 @@ final class OnboardingViewModel: ObservableObject {
 
     var summarizationStageReady: Bool {
         guard summarizationConfigurationReady else { return false }
-        if usesOllamaForSummarization {
+        if usesOllamaForSummarization || usesLMStudioForSummarization {
             return summarizationAvailabilityState.isReady
         }
         return true
@@ -373,7 +421,7 @@ final class OnboardingViewModel: ObservableObject {
     var screenContextStageReady: Bool {
         guard screenContextEnabled else { return true }
         guard visionConfigurationReady else { return false }
-        if usesOllamaForScreenContext {
+        if usesOllamaForScreenContext || usesLMStudioForScreenContext {
             return visionAvailabilityState.isReady
         }
         return true
@@ -383,8 +431,16 @@ final class OnboardingViewModel: ObservableObject {
         usesOllamaForSummarization
     }
 
+    var showsLMStudioEndpointConfigurationForSummarization: Bool {
+        usesLMStudioForSummarization
+    }
+
     var showsOllamaEndpointConfigurationForScreenContext: Bool {
         usesOllamaForScreenContext
+    }
+
+    var showsLMStudioEndpointConfigurationForScreenContext: Bool {
+        usesLMStudioForScreenContext
     }
 
     var transcriptionBackends: [TranscriptionBackend] {
@@ -429,7 +485,7 @@ final class OnboardingViewModel: ObservableObject {
         case .transcription:
             return "Start by choosing your transcription backend and local transcription model."
         case .summarization:
-            return "Choose the summarization provider that fits your workflow: built-in for simplicity or Ollama for advanced control."
+            return "Choose the summarization provider that fits your workflow: built-in for simplicity, or Ollama and LM Studio for advanced local control."
         case .screenContext:
             return "Screen context is optional. Turn it on only if you want Minute to use selected window content while summarizing."
         default:
@@ -494,7 +550,10 @@ final class OnboardingViewModel: ObservableObject {
         availabilityTask?.cancel()
         let usesOllamaForSummarization = selectedSummarizationProviderID == InferenceProvider.ollama.rawValue
         let usesOllamaForVision = selectedVisionProviderID == InferenceProvider.ollama.rawValue
+        let usesLMStudioForSummarization = selectedSummarizationProviderID == InferenceProvider.lmStudio.rawValue
+        let usesLMStudioForVision = selectedVisionProviderID == InferenceProvider.lmStudio.rawValue
         let shouldDiscoverOllama = usesOllamaForSummarization || usesOllamaForVision
+        let shouldDiscoverLMStudio = usesLMStudioForSummarization || usesLMStudioForVision
         availabilityTask = Task { [weak self] in
             guard let self else { return }
             await MainActor.run {
@@ -510,6 +569,12 @@ final class OnboardingViewModel: ObservableObject {
             } else {
                 snapshot = nil
             }
+            let lmStudioSnapshot: LMStudioDiscoverySnapshot?
+            if shouldDiscoverLMStudio {
+                lmStudioSnapshot = try? await self.discoverLMStudioModels()
+            } else {
+                lmStudioSnapshot = nil
+            }
 
             do {
                 let summarizationState = try await summarization
@@ -519,6 +584,7 @@ final class OnboardingViewModel: ObservableObject {
                     self.summarizationAvailabilityState = summarizationState
                     self.visionAvailabilityState = visionState
                     self.ollamaDiscoverySnapshot = snapshot
+                    self.lmStudioDiscoverySnapshot = lmStudioSnapshot
                     self.isRefreshingAvailability = false
                     self.updateCurrentStepIfNeeded()
                 }
@@ -527,12 +593,19 @@ final class OnboardingViewModel: ObservableObject {
                 await MainActor.run {
                     self.isRefreshingAvailability = false
                     if usesOllamaForSummarization {
-                        self.summarizationAvailabilityState = Self.unavailableState(for: .summarization)
+                        self.summarizationAvailabilityState = Self.unavailableState(for: .summarization, provider: .ollama)
                     }
                     if usesOllamaForVision {
-                        self.visionAvailabilityState = Self.unavailableState(for: .vision)
+                        self.visionAvailabilityState = Self.unavailableState(for: .vision, provider: .ollama)
+                    }
+                    if usesLMStudioForSummarization {
+                        self.summarizationAvailabilityState = Self.unavailableState(for: .summarization, provider: .lmStudio)
+                    }
+                    if usesLMStudioForVision {
+                        self.visionAvailabilityState = Self.unavailableState(for: .vision, provider: .lmStudio)
                     }
                     self.ollamaDiscoverySnapshot = snapshot
+                    self.lmStudioDiscoverySnapshot = lmStudioSnapshot
                     self.updateCurrentStepIfNeeded()
                 }
             }
@@ -719,6 +792,8 @@ final class OnboardingViewModel: ObservableObject {
             return !selectedSummarizationModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case .ollama:
             return !selectedSummarizationOllamaModelTag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .lmStudio:
+            return !selectedSummarizationLMStudioModelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
 
@@ -730,6 +805,8 @@ final class OnboardingViewModel: ObservableObject {
             return !selectedVisionModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case .ollama:
             return !selectedVisionOllamaModelTag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .lmStudio:
+            return !selectedVisionLMStudioModelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
 
@@ -748,25 +825,57 @@ final class OnboardingViewModel: ObservableObject {
         defaults.set(true, forKey: DefaultsKey.didCompleteOnboarding)
     }
 
-    private static func unavailableState(for capability: InferenceCapability) -> CapabilityAvailabilityState {
+    private static func unavailableState(
+        for capability: InferenceCapability,
+        provider: InferenceProvider
+    ) -> CapabilityAvailabilityState {
+        let message: String
+        let status: CapabilityAvailabilityStatus
+        switch provider {
+        case .builtIn:
+            message = "Provider status is unavailable."
+            status = .unknown
+        case .ollama:
+            message = "Ollama is unavailable. Start the local daemon and refresh."
+            status = .daemonUnavailable
+        case .lmStudio:
+            message = "LM Studio is unavailable. Start the local server and refresh."
+            status = .serverUnavailable
+        }
         CapabilityAvailabilityState(
             capabilityID: capability,
-            providerID: .ollama,
+            providerID: provider,
             isReady: false,
-            status: .daemonUnavailable,
-            message: "Ollama is unavailable. Start the local daemon and refresh.",
+            status: status,
+            message: message,
             selectedReference: nil
         )
     }
 
-    private func invalidEndpointState(for capability: InferenceCapability) -> CapabilityAvailabilityState {
+    private func invalidEndpointState(
+        for capability: InferenceCapability,
+        provider: InferenceProvider
+    ) -> CapabilityAvailabilityState {
+        let message: String
+        let selectedReference: String
+        switch provider {
+        case .builtIn:
+            message = "Provider configuration is invalid."
+            selectedReference = ""
+        case .ollama:
+            message = "Enter a valid Ollama base URL such as \(AppConfiguration.Defaults.defaultOllamaBaseURL)."
+            selectedReference = selectedOllamaBaseURLString
+        case .lmStudio:
+            message = "Enter a valid LM Studio base URL such as \(AppConfiguration.Defaults.defaultLMStudioBaseURL)."
+            selectedReference = selectedLMStudioBaseURLString
+        }
         CapabilityAvailabilityState(
             capabilityID: capability,
-            providerID: .ollama,
+            providerID: provider,
             isReady: false,
             status: .needsConfiguration,
-            message: "Enter a valid Ollama base URL such as \(AppConfiguration.Defaults.defaultOllamaBaseURL).",
-            selectedReference: selectedOllamaBaseURLString
+            message: message,
+            selectedReference: selectedReference
         )
     }
 
@@ -780,10 +889,16 @@ final class OnboardingViewModel: ObservableObject {
             return try await availabilityProvider.availability(for: capability)
         case .ollama:
             guard let discoverer = makeOllamaModelDiscoverer() else {
-                return invalidEndpointState(for: capability)
+                return invalidEndpointState(for: capability, provider: .ollama)
             }
             let tag = inferenceProviderStore.selectedOllamaModelTag(for: capability) ?? ""
             return try await discoverer.validateModelTag(tag, for: capability)
+        case .lmStudio:
+            guard let discoverer = makeLMStudioModelDiscoverer() else {
+                return invalidEndpointState(for: capability, provider: .lmStudio)
+            }
+            let identifier = inferenceProviderStore.selectedLMStudioModelIdentifier(for: capability) ?? ""
+            return try await discoverer.validateModelIdentifier(identifier, for: capability)
         }
     }
 
@@ -801,9 +916,29 @@ final class OnboardingViewModel: ObservableObject {
         if let providedOllamaModelDiscoverer {
             return providedOllamaModelDiscoverer
         }
-        guard let baseURL = ollamaEndpointStore.selectedBaseURL() else {
+        guard let baseURL = connectionStore.selectedBaseURL(for: .ollama) else {
             return nil
         }
         return OllamaModelDiscoveryService(client: OllamaAPIClient(baseURL: baseURL))
+    }
+
+    private func discoverLMStudioModels() async throws -> LMStudioDiscoverySnapshot {
+        guard let discoverer = makeLMStudioModelDiscoverer() else {
+            return LMStudioDiscoverySnapshot(
+                serverReachable: false,
+                failureReason: "Enter a valid LM Studio base URL such as \(AppConfiguration.Defaults.defaultLMStudioBaseURL)."
+            )
+        }
+        return try await discoverer.discoverModels()
+    }
+
+    private func makeLMStudioModelDiscoverer() -> (any LMStudioModelDiscovering)? {
+        if let providedLMStudioModelDiscoverer {
+            return providedLMStudioModelDiscoverer
+        }
+        guard let baseURL = connectionStore.selectedBaseURL(for: .lmStudio) else {
+            return nil
+        }
+        return LMStudioModelDiscoveryService(client: LMStudioAPIClient(baseURL: baseURL))
     }
 }

--- a/Minute/Sources/Views/Pipeline/PipelineContentView.swift
+++ b/Minute/Sources/Views/Pipeline/PipelineContentView.swift
@@ -412,7 +412,7 @@ struct PipelineContentView: View {
             action: statusAction(for: presentation.primaryAction),
             secondaryActionTitle: presentation.secondaryActionTitle,
             secondaryAction: statusAction(for: presentation.secondaryAction),
-            onClose: presentation.showsCloseButton ? { dismissCurrentStatusDrawer() } : nil
+            onClose: presentation.showsCloseButton ? { closeCurrentStatusDrawer() } : nil
         )
     }
 
@@ -468,6 +468,15 @@ struct PipelineContentView: View {
     private func dismissCurrentStatusDrawer() {
         guard let id = statusPresenter.dismissibleStatusDrawerID(for: model.state) else { return }
         dismissedStatusDrawerID = id
+    }
+
+    private func closeCurrentStatusDrawer() {
+        switch model.state {
+        case .done, .failed:
+            model.dismissCloseableStatus()
+        default:
+            dismissCurrentStatusDrawer()
+        }
     }
 
     private func syncDismissedStatusDrawer(with state: MeetingPipelineState) {

--- a/Minute/Sources/Views/Settings/FluidAudioASRModelPicker.swift
+++ b/Minute/Sources/Views/Settings/FluidAudioASRModelPicker.swift
@@ -6,42 +6,15 @@ struct FluidAudioASRModelPicker: View {
     @Binding var selection: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("FluidAudio model")
-                .minuteRowTitle()
-
-            Menu {
-                ForEach(models) { model in
-                    Button {
-                        selection = model.id
-                    } label: {
-                        if model.id == selection {
-                            Label(model.displayName, systemImage: "checkmark")
-                        } else {
-                            Text(model.displayName)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selectedLabel)
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .minuteDropdownStyle()
-            }
-            .menuStyle(.borderlessButton)
-
-            if let selectedModel {
-                Text(selectedModel.summary)
-                    .minuteCaption()
-            }
-        }
+        SettingsMenuField(
+            title: "FluidAudio model",
+            subtitle: selectedModel?.summary,
+            options: models,
+            selectionLabel: selectedLabel,
+            optionLabel: { $0.displayName },
+            isSelected: { $0.id == selection },
+            onSelect: { selection = $0.id }
+        )
     }
 
     private var selectedModel: FluidAudioASRModel? {

--- a/Minute/Sources/Views/Settings/GeneralSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/GeneralSettingsSection.swift
@@ -47,18 +47,16 @@ struct GeneralSettingsSection: View {
             }
 
             Section("Language & Translation") {
-                Picker("Output language", selection: outputLanguageBinding) {
-                    ForEach(OutputLanguage.allCases, id: \.self) { language in
-                        Text(language.displayName).tag(language)
-                    }
-                }
-                .pickerStyle(.menu)
-
-                Text("Used when session language processing is set to Auto -> Picked language.")
-                    .minuteCaption()
+                SettingsMenuField(
+                    title: "Output language",
+                    subtitle: "Used when session language processing is set to Auto -> Picked language.",
+                    options: OutputLanguage.allCases,
+                    selectionLabel: outputLanguageBinding.wrappedValue.displayName,
+                    optionLabel: { $0.displayName },
+                    isSelected: { $0 == outputLanguageBinding.wrappedValue },
+                    onSelect: { outputLanguageBinding.wrappedValue = $0 }
+                )
             }
-
-            KnownSpeakersSettingsSection(mode: .toggleOnly)
         }
     }
 }

--- a/Minute/Sources/Views/Settings/InferenceCapabilityStatusView.swift
+++ b/Minute/Sources/Views/Settings/InferenceCapabilityStatusView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct InferenceCapabilityStatusView: View {
     let title: String
     let state: CapabilityAvailabilityState
-    let discoveredModelTags: [String]
+    let discoveredModelReferences: [String]
+    let discoveredModelsTitle: String
     let isRefreshing: Bool
     let onRefresh: () -> Void
 
@@ -31,8 +32,8 @@ struct InferenceCapabilityStatusView: View {
                     .minuteCaption()
             }
 
-            if !discoveredModelTags.isEmpty {
-                Text("Downloaded in Ollama: \(discoveredModelTags.joined(separator: ", "))")
+            if !discoveredModelReferences.isEmpty {
+                Text("\(discoveredModelsTitle): \(discoveredModelReferences.joined(separator: ", "))")
                     .minuteCaption()
             }
         }
@@ -46,8 +47,10 @@ struct InferenceCapabilityStatusView: View {
             return "Needs configuration"
         case .daemonUnavailable:
             return "Daemon unavailable"
+        case .serverUnavailable:
+            return "Server unavailable"
         case .modelMissing:
-            return "Model not downloaded"
+            return "Model unavailable"
         case .unsupported:
             return "Unsupported"
         case .visionUnsupported:
@@ -63,7 +66,7 @@ struct InferenceCapabilityStatusView: View {
             return "checkmark.circle.fill"
         case .needsConfiguration, .modelMissing, .visionUnsupported:
             return "exclamationmark.circle"
-        case .daemonUnavailable, .unsupported, .unknown:
+        case .daemonUnavailable, .serverUnavailable, .unsupported, .unknown:
             return "xmark.circle"
         }
     }
@@ -74,7 +77,7 @@ struct InferenceCapabilityStatusView: View {
             return .green
         case .needsConfiguration, .modelMissing, .visionUnsupported:
             return .orange
-        case .daemonUnavailable, .unsupported, .unknown:
+        case .daemonUnavailable, .serverUnavailable, .unsupported, .unknown:
             return .red
         }
     }

--- a/Minute/Sources/Views/Settings/KnownSpeakersSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/KnownSpeakersSettingsSection.swift
@@ -57,6 +57,7 @@ struct KnownSpeakersSettingsSection: View {
             }
         }
         .task {
+            guard knownSpeakerSuggestionsEnabled else { return }
             await refresh()
         }
         .onChange(of: knownSpeakerSuggestionsEnabled) { _, newValue in

--- a/Minute/Sources/Views/Settings/KnownSpeakersSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/KnownSpeakersSettingsSection.swift
@@ -2,13 +2,6 @@ import MinuteCore
 import SwiftUI
 
 struct KnownSpeakersSettingsSection: View {
-    enum Mode {
-        case toggleOnly
-        case manage
-    }
-
-    private let mode: Mode
-
     @AppStorage(AppDefaultsKey.knownSpeakerSuggestionsEnabled)
     private var knownSpeakerSuggestionsEnabled: Bool = AppConfiguration.Defaults.defaultKnownSpeakerSuggestionsEnabled
 
@@ -16,10 +9,6 @@ struct KnownSpeakersSettingsSection: View {
     @State private var loadError: String?
 
     private let store = SpeakerProfileStore()
-
-    init(mode: Mode = .manage) {
-        self.mode = mode
-    }
 
     var body: some View {
         Section("People & Speakers") {
@@ -29,56 +18,53 @@ struct KnownSpeakersSettingsSection: View {
                 isOn: $knownSpeakerSuggestionsEnabled
             )
 
-            if knownSpeakerSuggestionsEnabled, mode == .manage {
+            if knownSpeakerSuggestionsEnabled {
                 if let loadError {
-                    Text(loadError)
-                        .foregroundStyle(.red)
-                        .font(.caption)
+                    SettingsInlineMessage(text: loadError, tone: .error)
                 }
 
                 if profiles.isEmpty {
-                    Text("No speaker profiles yet.")
-                        .foregroundStyle(Color.minuteTextSecondary)
+                    SettingsInlineMessage(text: "No speaker profiles yet.")
                 } else {
                     ForEach(profiles) { profile in
-                        HStack(spacing: 8) {
-                            Text(profile.name)
-                                .lineLimit(1)
+                        SettingsCard {
+                            HStack(spacing: 8) {
+                                Text(profile.name)
+                                    .minuteControlValue()
+                                    .lineLimit(1)
 
-                            Spacer()
+                                Spacer()
 
-                            Button(role: .destructive) {
-                                Task { await delete(profileID: profile.id) }
-                            } label: {
-                                Text("Delete")
+                                Button(role: .destructive) {
+                                    Task { await delete(profileID: profile.id) }
+                                } label: {
+                                    Text("Delete")
+                                }
+                                .buttonStyle(.borderless)
                             }
-                            .buttonStyle(.borderless)
                         }
                     }
                 }
 
-                Button {
-                    Task { await refresh() }
-                } label: {
-                    Text("Refresh profiles")
+                SettingsActionRow {
+                    Button {
+                        Task { await refresh() }
+                    } label: {
+                        Text("Refresh profiles")
+                    }
+                    .buttonStyle(.bordered)
                 }
-                .buttonStyle(.plain)
-            } else if knownSpeakerSuggestionsEnabled, mode == .toggleOnly {
-                Text("Manage profiles in Settings → Speakers.")
-                    .foregroundStyle(Color.minuteTextSecondary)
             }
         }
         .task {
-            if mode == .manage {
-                await refresh()
-            }
+            await refresh()
         }
         .onChange(of: knownSpeakerSuggestionsEnabled) { _, newValue in
-            guard mode == .manage else { return }
             if newValue {
                 Task { await refresh() }
             } else {
                 loadError = nil
+                profiles = []
             }
         }
     }
@@ -107,7 +93,7 @@ struct KnownSpeakersSettingsSection: View {
 
 #Preview {
     Form {
-        KnownSpeakersSettingsSection(mode: .manage)
+        KnownSpeakersSettingsSection()
     }
     .frame(width: 520)
 }

--- a/Minute/Sources/Views/Settings/MainSettingsView.swift
+++ b/Minute/Sources/Views/Settings/MainSettingsView.swift
@@ -18,6 +18,7 @@ struct MainSettingsView: View {
             Divider()
             detail
         }
+        .background(MinuteTheme.windowBackground)
         .onAppear {
             selection = resolvedSelection(candidate: SettingsCategoryDefinition.ID(rawValue: lastCategoryIDRaw))
         }
@@ -47,7 +48,7 @@ struct MainSettingsView: View {
                         }
                     case .speakers:
                         Form {
-                            KnownSpeakersSettingsSection(mode: .manage)
+                            KnownSpeakersSettingsSection()
                         }
                     case .privacy:
                         Form {
@@ -77,11 +78,12 @@ struct MainSettingsView: View {
             }
             .formStyle(.grouped)
             .scrollContentBackground(.hidden)
-            .padding(.horizontal, 12)
-            .padding(.bottom, 8)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .padding(.top, 8)
+        .padding(.top, 12)
+        .background(MinuteTheme.windowBackground)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -95,17 +97,18 @@ struct MainSettingsView: View {
         .accessibilityLabel("Settings categories")
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)
-        .frame(width: 230)
+        .frame(width: 246)
+        .background(MinuteTheme.sidebarBackground)
     }
 
     private var settingsHeader: some View {
         HStack(alignment: .firstTextBaseline) {
             VStack(alignment: .leading, spacing: 4) {
                 Text(currentCategoryDefinition?.title ?? "Settings")
-                    .font(.title3.bold())
+                    .minuteSettingsHeaderTitle()
 
                 Text(currentCategoryDefinition?.description ?? "Adjust app preferences and behavior.")
-                    .minuteCaption()
+                    .minuteSettingsHeaderSubtitle()
             }
 
             Spacer()
@@ -121,8 +124,9 @@ struct MainSettingsView: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Close Settings")
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 6)
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
     }
 
     private var availableCategories: [SettingsCategoryDefinition] {

--- a/Minute/Sources/Views/Settings/MeetingTypesSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/MeetingTypesSettingsSection.swift
@@ -80,7 +80,7 @@ struct MeetingTypesSettingsSection: View {
                     title: "Objective",
                     subtitle: "What should this meeting summary optimize for?"
                 ) {
-                    MultilineInput(
+                    SettingsMultilineInput(
                         text: $model.draftObjective,
                         placeholder: "Summarize daily standup progress accurately.",
                         minHeight: 84
@@ -91,7 +91,7 @@ struct MeetingTypesSettingsSection: View {
                     title: "Summary Focus",
                     subtitle: "Which outcomes should be prioritized in this type of meeting?"
                 ) {
-                    MultilineInput(
+                    SettingsMultilineInput(
                         text: $model.draftSummaryFocus,
                         placeholder: "Highlight updates, blockers, decisions, and owners.",
                         minHeight: 96
@@ -187,7 +187,7 @@ struct MeetingTypesSettingsSection: View {
                             title: "Strong Signals",
                             subtitle: "Comma or newline separated cues. \(model.parsedClassifierSignalCount) signal(s)."
                         ) {
-                            MultilineInput(
+                            SettingsMultilineInput(
                                 text: $model.draftClassifierSignalsInput,
                                 placeholder: "daily update, blocker, sprint board",
                                 minHeight: 80
@@ -265,14 +265,11 @@ struct MeetingTypesSettingsSection: View {
                 }
 
                 if model.hasUnsavedChanges {
-                    Label("Unsaved changes", systemImage: "pencil")
-                        .minuteFootnote()
+                    SettingsInlineMessage(text: "Unsaved changes")
                 }
 
                 if let message = model.errorMessage, !message.isEmpty {
-                    Label(message, systemImage: "exclamationmark.triangle.fill")
-                        .font(.footnote.weight(.semibold))
-                        .foregroundStyle(.red)
+                    SettingsInlineMessage(text: message, tone: .error)
                 }
             }
         }
@@ -320,78 +317,36 @@ private struct PromptRuleBlock: View {
     let isToggleable: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .minuteRowTitle()
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(title)
+                            .minuteRowTitle()
 
-                    Text(subtitle)
-                        .minuteCaption()
-                        .fixedSize(horizontal: false, vertical: true)
+                        Text(subtitle)
+                            .minuteCaption()
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    if isToggleable {
+                        Toggle("", isOn: $isEnabled)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .accessibilityLabel(Text("\(title) enabled"))
+                    }
                 }
 
-                Spacer(minLength: 0)
-
-                if isToggleable {
-                    Toggle("", isOn: $isEnabled)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
-                        .accessibilityLabel(Text("\(title) enabled"))
+                if !isToggleable || isEnabled {
+                    SettingsMultilineInput(
+                        text: $text,
+                        placeholder: "Optional",
+                        minHeight: 74
+                    )
                 }
             }
-
-            if !isToggleable || isEnabled {
-                MultilineInput(
-                    text: $text,
-                    placeholder: "Optional",
-                    minHeight: 74
-                )
-            }
         }
-        .padding(12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.minuteSurface)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.minuteOutline, lineWidth: 1)
-        )
-    }
-}
-
-private struct MultilineInput: View {
-    @Binding var text: String
-    let placeholder: String
-    let minHeight: CGFloat
-
-    var body: some View {
-        ZStack(alignment: .topLeading) {
-            TextEditor(text: $text)
-                .font(.system(size: 13, weight: .medium))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 8)
-                .scrollContentBackground(.hidden)
-                .frame(minHeight: minHeight)
-
-            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Text(placeholder)
-                    .minuteCaption()
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 14)
-                    .allowsHitTesting(false)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color(nsColor: .textBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(Color.minuteOutline, lineWidth: 1)
-        )
     }
 }

--- a/Minute/Sources/Views/Settings/ModelsSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/ModelsSettingsSection.swift
@@ -30,7 +30,9 @@ struct ModelsSettingsSection: View {
                         selection: $model.selectedFluidAudioModelID
                     )
 
-                    VocabularyBoostingSection(model: model)
+                    if let message = model.vocabularyBoostingSupportMessage {
+                        SettingsInlineMessage(text: message, tone: .warning)
+                    }
                 } else {
                     TranscriptionModelPicker(
                         models: model.transcriptionModels,

--- a/Minute/Sources/Views/Settings/ModelsSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/ModelsSettingsSection.swift
@@ -9,30 +9,26 @@ struct ModelsSettingsSection: View {
     var body: some View {
         Group {
             transcriptionSection
-            ollamaSection
-            lmStudioSection
             summarizationSection
             screenContextSection
+            localProvidersSection
+            modelReadinessSection
         }
     }
 
     private var transcriptionSection: some View {
-        Section("Transcription") {
-            VStack(alignment: .leading, spacing: 12) {
+        Section("Transcription Setup") {
+            VStack(alignment: .leading, spacing: 14) {
                 TranscriptionBackendPicker(
                     backends: model.transcriptionBackends,
                     selection: $model.selectedTranscriptionBackendID
                 )
-
-                Divider()
 
                 if model.isFluidAudioSelected {
                     FluidAudioASRModelPicker(
                         models: model.fluidAudioModels,
                         selection: $model.selectedFluidAudioModelID
                     )
-
-                    Divider()
 
                     VocabularyBoostingSection(model: model)
                 } else {
@@ -41,35 +37,18 @@ struct ModelsSettingsSection: View {
                         selection: $model.selectedTranscriptionModelID
                     )
 
-                    Divider()
-
                     TranscriptionLanguagePicker(
                         languages: model.transcriptionLanguages,
                         selection: $model.selectedTranscriptionLanguage
                     )
                 }
-
-                Divider()
-
-                ModelDownloadStatusView(
-                    title: "\(model.selectedTranscriptionBackendDisplayName) models",
-                    detail: "Downloads the local transcription models required by the current transcription setup.",
-                    status: model.transcriptionDownloadStatusState,
-                    progress: model.activeDownloadProgress,
-                    showsSpinner: model.isCheckingModels,
-                    message: model.transcriptionDownloadMessage,
-                    buttonTitle: downloadButtonTitle,
-                    buttonEnabled: model.canStartModelDownload,
-                    style: .plain,
-                    action: { model.startDownload() }
-                )
             }
         }
     }
 
     private var summarizationSection: some View {
-        Section("Summarization") {
-            VStack(alignment: .leading, spacing: 12) {
+        Section("Summarization Setup") {
+            VStack(alignment: .leading, spacing: 14) {
                 SummarizationProviderPicker(
                     providers: model.inferenceProviders,
                     selection: $model.selectedSummarizationProviderID,
@@ -98,15 +77,118 @@ struct ModelsSettingsSection: View {
                 }
 
                 if model.isBuiltInSummarizationProviderSelected {
-                    Divider()
-
                     SummarizationModelPicker(
                         models: model.summarizationModels,
                         selection: $model.selectedSummarizationModelID
                     )
+                }
 
-                    Divider()
+                SummarizationContextWindowPicker(
+                    presets: model.summarizationContextWindowPresets,
+                    recommendedPreset: model.recommendedSummarizationContextWindowPreset,
+                    selection: $model.selectedSummarizationContextWindowPreset
+                )
+            }
+        }
+    }
 
+    private var screenContextSection: some View {
+        Section("Screen Context Setup") {
+            VStack(alignment: .leading, spacing: 14) {
+                SettingsToggleRow(
+                    "Enhance notes with selected screen context",
+                    detail: "Choose a window each time you start recording. No video is stored.",
+                    isOn: $screenContextEnabled
+                )
+
+                VStack(alignment: .leading, spacing: 12) {
+                    VisionProviderPicker(
+                        providers: model.inferenceProviders,
+                        builtInModels: model.visionModels,
+                        selection: $model.selectedVisionProviderID,
+                        builtInModelSelection: $model.selectedVisionModelID,
+                        ollamaModelTag: $model.selectedVisionOllamaModelTag,
+                        lmStudioModelIdentifier: $model.selectedVisionLMStudioModelIdentifier
+                    )
+
+                    if model.selectedVisionProviderID == InferenceProvider.ollama.rawValue {
+                        InferenceCapabilityStatusView(
+                            title: "Screen context validation",
+                            state: model.visionAvailabilityState,
+                            discoveredModelReferences: model.ollamaDiscoveredModelTags,
+                            discoveredModelsTitle: "Downloaded in Ollama",
+                            isRefreshing: model.isRefreshingAvailability,
+                            onRefresh: { model.refreshAvailability() }
+                        )
+                    } else if model.selectedVisionProviderID == InferenceProvider.lmStudio.rawValue {
+                        InferenceCapabilityStatusView(
+                            title: "Screen context validation",
+                            state: model.visionAvailabilityState,
+                            discoveredModelReferences: model.lmStudioDiscoveredModelIdentifiers,
+                            discoveredModelsTitle: "Available in LM Studio",
+                            isRefreshing: model.isRefreshingAvailability,
+                            onRefresh: { model.refreshAvailability() }
+                        )
+                    }
+
+                    ScreenContextSettingsSection(title: nil, showsMasterToggle: false)
+                }
+                .disabled(!screenContextEnabled)
+                .opacity(screenContextEnabled ? 1 : 0.55)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var localProvidersSection: some View {
+        if model.showsOllamaEndpointConfiguration || model.showsLMStudioEndpointConfiguration {
+            Section("Local Provider Connections") {
+                VStack(alignment: .leading, spacing: 14) {
+                    if model.showsOllamaEndpointConfiguration {
+                        SettingsFieldBlock(
+                            title: "Ollama base URL",
+                            subtitle: "Use the full Ollama endpoint, including protocol and port."
+                        ) {
+                            SettingsSingleLineInput(
+                                text: $model.selectedOllamaBaseURLString,
+                                placeholder: AppConfiguration.Defaults.defaultOllamaBaseURL
+                            )
+                        }
+                    }
+
+                    if model.showsLMStudioEndpointConfiguration {
+                        SettingsFieldBlock(
+                            title: "LM Studio base URL",
+                            subtitle: "Use the full LM Studio endpoint, including protocol and port."
+                        ) {
+                            SettingsSingleLineInput(
+                                text: $model.selectedLMStudioBaseURLString,
+                                placeholder: AppConfiguration.Defaults.defaultLMStudioBaseURL
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var modelReadinessSection: some View {
+        Section("Model Readiness & Downloads") {
+            VStack(alignment: .leading, spacing: 14) {
+                ModelDownloadStatusView(
+                    title: "\(model.selectedTranscriptionBackendDisplayName) models",
+                    detail: "Downloads the local transcription models required by the current transcription setup.",
+                    status: model.transcriptionDownloadStatusState,
+                    progress: model.activeDownloadProgress,
+                    showsSpinner: model.isCheckingModels,
+                    message: model.transcriptionDownloadMessage,
+                    buttonTitle: downloadButtonTitle,
+                    buttonEnabled: model.canStartModelDownload,
+                    style: .plain,
+                    action: { model.startDownload() }
+                )
+
+                if model.isBuiltInSummarizationProviderSelected {
                     ModelDownloadStatusView(
                         title: "Built-in summarization model",
                         detail: "Downloads the selected local summarization model when you use the built-in provider.",
@@ -121,95 +203,7 @@ struct ModelsSettingsSection: View {
                     )
                 }
 
-                Divider()
-
-                SummarizationContextWindowPicker(
-                    presets: model.summarizationContextWindowPresets,
-                    recommendedPreset: model.recommendedSummarizationContextWindowPreset,
-                    selection: $model.selectedSummarizationContextWindowPreset
-                )
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var ollamaSection: some View {
-        if model.showsOllamaEndpointConfiguration {
-            Section("Ollama") {
-                SettingsFieldBlock(
-                    title: "Ollama base URL",
-                    subtitle: "Use the full Ollama endpoint, including protocol and port."
-                ) {
-                    SettingsSingleLineInput(
-                        text: $model.selectedOllamaBaseURLString,
-                        placeholder: AppConfiguration.Defaults.defaultOllamaBaseURL
-                    )
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var lmStudioSection: some View {
-        if model.showsLMStudioEndpointConfiguration {
-            Section("LM Studio") {
-                SettingsFieldBlock(
-                    title: "LM Studio base URL",
-                    subtitle: "Use the full LM Studio endpoint, including protocol and port."
-                ) {
-                    SettingsSingleLineInput(
-                        text: $model.selectedLMStudioBaseURLString,
-                        placeholder: AppConfiguration.Defaults.defaultLMStudioBaseURL
-                    )
-                }
-            }
-        }
-    }
-
-    private var screenContextSection: some View {
-        Section("Screen Context") {
-            VStack(alignment: .leading, spacing: 12) {
-                SettingsToggleRow(
-                    "Enhance notes with selected screen context",
-                    detail: "Choose a window each time you start recording. No video is stored.",
-                    isOn: $screenContextEnabled
-                )
-
-                Divider()
-
-                VStack(alignment: .leading, spacing: 12) {
-                VisionProviderPicker(
-                    providers: model.inferenceProviders,
-                    builtInModels: model.visionModels,
-                    selection: $model.selectedVisionProviderID,
-                    builtInModelSelection: $model.selectedVisionModelID,
-                    ollamaModelTag: $model.selectedVisionOllamaModelTag,
-                    lmStudioModelIdentifier: $model.selectedVisionLMStudioModelIdentifier
-                )
-
-                if model.selectedVisionProviderID == InferenceProvider.ollama.rawValue {
-                    InferenceCapabilityStatusView(
-                        title: "Screen context validation",
-                        state: model.visionAvailabilityState,
-                        discoveredModelReferences: model.ollamaDiscoveredModelTags,
-                        discoveredModelsTitle: "Downloaded in Ollama",
-                        isRefreshing: model.isRefreshingAvailability,
-                        onRefresh: { model.refreshAvailability() }
-                    )
-                } else if model.selectedVisionProviderID == InferenceProvider.lmStudio.rawValue {
-                    InferenceCapabilityStatusView(
-                        title: "Screen context validation",
-                        state: model.visionAvailabilityState,
-                        discoveredModelReferences: model.lmStudioDiscoveredModelIdentifiers,
-                        discoveredModelsTitle: "Available in LM Studio",
-                        isRefreshing: model.isRefreshingAvailability,
-                        onRefresh: { model.refreshAvailability() }
-                    )
-                }
-
                 if model.isBuiltInVisionProviderSelected {
-                    Divider()
-
                     ModelDownloadStatusView(
                         title: "Built-in screen context model",
                         detail: "Downloads the selected local screen-context model when you use the built-in provider.",
@@ -223,13 +217,6 @@ struct ModelsSettingsSection: View {
                         action: { model.startDownload() }
                     )
                 }
-
-                Divider()
-
-                ScreenContextSettingsSection(title: nil, showsMasterToggle: false)
-                }
-                .disabled(!screenContextEnabled)
-                .opacity(screenContextEnabled ? 1 : 0.55)
             }
         }
     }

--- a/Minute/Sources/Views/Settings/ModelsSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/ModelsSettingsSection.swift
@@ -10,6 +10,7 @@ struct ModelsSettingsSection: View {
         Group {
             transcriptionSection
             ollamaSection
+            lmStudioSection
             summarizationSection
             screenContextSection
         }
@@ -72,14 +73,25 @@ struct ModelsSettingsSection: View {
                 SummarizationProviderPicker(
                     providers: model.inferenceProviders,
                     selection: $model.selectedSummarizationProviderID,
-                    ollamaModelTag: $model.selectedSummarizationOllamaModelTag
+                    ollamaModelTag: $model.selectedSummarizationOllamaModelTag,
+                    lmStudioModelIdentifier: $model.selectedSummarizationLMStudioModelIdentifier
                 )
 
                 if model.selectedSummarizationProviderID == InferenceProvider.ollama.rawValue {
                     InferenceCapabilityStatusView(
                         title: "Summarization validation",
                         state: model.summarizationAvailabilityState,
-                        discoveredModelTags: model.ollamaDiscoveredModelTags,
+                        discoveredModelReferences: model.ollamaDiscoveredModelTags,
+                        discoveredModelsTitle: "Downloaded in Ollama",
+                        isRefreshing: model.isRefreshingAvailability,
+                        onRefresh: { model.refreshAvailability() }
+                    )
+                } else if model.selectedSummarizationProviderID == InferenceProvider.lmStudio.rawValue {
+                    InferenceCapabilityStatusView(
+                        title: "Summarization validation",
+                        state: model.summarizationAvailabilityState,
+                        discoveredModelReferences: model.lmStudioDiscoveredModelIdentifiers,
+                        discoveredModelsTitle: "Available in LM Studio",
                         isRefreshing: model.isRefreshingAvailability,
                         onRefresh: { model.refreshAvailability() }
                     )
@@ -137,6 +149,23 @@ struct ModelsSettingsSection: View {
         }
     }
 
+    @ViewBuilder
+    private var lmStudioSection: some View {
+        if model.showsLMStudioEndpointConfiguration {
+            Section("LM Studio") {
+                SettingsFieldBlock(
+                    title: "LM Studio base URL",
+                    subtitle: "Use the full LM Studio endpoint, including protocol and port."
+                ) {
+                    SettingsSingleLineInput(
+                        text: $model.selectedLMStudioBaseURLString,
+                        placeholder: AppConfiguration.Defaults.defaultLMStudioBaseURL
+                    )
+                }
+            }
+        }
+    }
+
     private var screenContextSection: some View {
         Section("Screen Context") {
             VStack(alignment: .leading, spacing: 12) {
@@ -154,14 +183,25 @@ struct ModelsSettingsSection: View {
                     builtInModels: model.visionModels,
                     selection: $model.selectedVisionProviderID,
                     builtInModelSelection: $model.selectedVisionModelID,
-                    ollamaModelTag: $model.selectedVisionOllamaModelTag
+                    ollamaModelTag: $model.selectedVisionOllamaModelTag,
+                    lmStudioModelIdentifier: $model.selectedVisionLMStudioModelIdentifier
                 )
 
                 if model.selectedVisionProviderID == InferenceProvider.ollama.rawValue {
                     InferenceCapabilityStatusView(
                         title: "Screen context validation",
                         state: model.visionAvailabilityState,
-                        discoveredModelTags: model.ollamaDiscoveredModelTags,
+                        discoveredModelReferences: model.ollamaDiscoveredModelTags,
+                        discoveredModelsTitle: "Downloaded in Ollama",
+                        isRefreshing: model.isRefreshingAvailability,
+                        onRefresh: { model.refreshAvailability() }
+                    )
+                } else if model.selectedVisionProviderID == InferenceProvider.lmStudio.rawValue {
+                    InferenceCapabilityStatusView(
+                        title: "Screen context validation",
+                        state: model.visionAvailabilityState,
+                        discoveredModelReferences: model.lmStudioDiscoveredModelIdentifiers,
+                        discoveredModelsTitle: "Available in LM Studio",
                         isRefreshing: model.isRefreshingAvailability,
                         onRefresh: { model.refreshAvailability() }
                     )

--- a/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
+++ b/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
@@ -429,6 +429,11 @@ final class ModelsSettingsViewModel: ObservableObject {
         "Use for names, acronyms, product terms."
     }
 
+    var vocabularyBoostingSupportMessage: String? {
+        guard isFluidAudioSelected else { return nil }
+        return "Vocabulary boosting is currently unavailable for the selected FluidAudio backend."
+    }
+
     var vocabularyBoostingTerms: [String] {
         VocabularyTermEntry.parseFromEditorInput(vocabularyBoostingTermsInput, source: .global)
             .map(\.displayText)

--- a/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
+++ b/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
@@ -566,7 +566,7 @@ final class ModelsSettingsViewModel: ObservableObject {
             message = "LM Studio is unavailable. Start the local server and refresh."
             status = .serverUnavailable
         }
-        CapabilityAvailabilityState(
+        return CapabilityAvailabilityState(
             capabilityID: capability,
             providerID: provider,
             isReady: false,
@@ -593,7 +593,7 @@ final class ModelsSettingsViewModel: ObservableObject {
             message = "Enter a valid LM Studio base URL such as \(AppConfiguration.Defaults.defaultLMStudioBaseURL)."
             selectedReference = selectedLMStudioBaseURLString
         }
-        CapabilityAvailabilityState(
+        return CapabilityAvailabilityState(
             capabilityID: capability,
             providerID: provider,
             isReady: false,

--- a/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
+++ b/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import MinuteCore
+import MinuteLMStudio
 import MinuteOllama
 
 @MainActor
@@ -21,6 +22,7 @@ final class ModelsSettingsViewModel: ObservableObject {
         status: .ready
     )
     @Published private(set) var ollamaDiscoverySnapshot: OllamaDiscoverySnapshot? = nil
+    @Published private(set) var lmStudioDiscoverySnapshot: LMStudioDiscoverySnapshot? = nil
     @Published private(set) var isRefreshingAvailability = false
     @Published var selectedSummarizationProviderID: String {
         didSet {
@@ -44,10 +46,27 @@ final class ModelsSettingsViewModel: ObservableObject {
             refreshAvailability()
         }
     }
+    @Published var selectedSummarizationLMStudioModelIdentifier: String {
+        didSet {
+            guard oldValue != selectedSummarizationLMStudioModelIdentifier else { return }
+            inferenceProviderStore.setSelectedLMStudioModelIdentifier(
+                selectedSummarizationLMStudioModelIdentifier,
+                for: .summarization
+            )
+            refreshAvailability()
+        }
+    }
     @Published var selectedOllamaBaseURLString: String {
         didSet {
             guard oldValue != selectedOllamaBaseURLString else { return }
-            ollamaEndpointStore.setSelectedBaseURLString(selectedOllamaBaseURLString)
+            connectionStore.setSelectedBaseURLString(selectedOllamaBaseURLString, for: .ollama)
+            refreshAvailability()
+        }
+    }
+    @Published var selectedLMStudioBaseURLString: String {
+        didSet {
+            guard oldValue != selectedLMStudioBaseURLString else { return }
+            connectionStore.setSelectedBaseURLString(selectedLMStudioBaseURLString, for: .lmStudio)
             refreshAvailability()
         }
     }
@@ -76,6 +95,16 @@ final class ModelsSettingsViewModel: ObservableObject {
         didSet {
             guard oldValue != selectedVisionOllamaModelTag else { return }
             inferenceProviderStore.setSelectedOllamaModelTag(selectedVisionOllamaModelTag, for: .vision)
+            refreshAvailability()
+        }
+    }
+    @Published var selectedVisionLMStudioModelIdentifier: String {
+        didSet {
+            guard oldValue != selectedVisionLMStudioModelIdentifier else { return }
+            inferenceProviderStore.setSelectedLMStudioModelIdentifier(
+                selectedVisionLMStudioModelIdentifier,
+                for: .vision
+            )
             refreshAvailability()
         }
     }
@@ -127,7 +156,7 @@ final class ModelsSettingsViewModel: ObservableObject {
 
     private let vocabularySettingsStore: any VocabularyBoostingSettingsStoring
     private let inferenceProviderStore: InferenceProviderSelectionStore
-    private let ollamaEndpointStore: OllamaEndpointSettingsStore
+    private let connectionStore: ProviderConnectionSettingsStore
     private let summarizationModelStore: SummarizationModelSelectionStore
     private let summarizationContextWindowStore: SummarizationContextWindowSelectionStore
     private let visionModelStore: VisionModelSelectionStore
@@ -139,6 +168,7 @@ final class ModelsSettingsViewModel: ObservableObject {
     private let availabilityProvider: any CapabilityAvailabilityProviding
     private let usesCustomAvailabilityProvider: Bool
     private let providedOllamaModelDiscoverer: (any OllamaModelDiscovering)?
+    private let providedLMStudioModelDiscoverer: (any LMStudioModelDiscovering)?
     private var cancellables: Set<AnyCancellable> = []
     private var isRestoringVocabularySettings = false
     private var lastModelValidation = ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])
@@ -147,7 +177,7 @@ final class ModelsSettingsViewModel: ObservableObject {
     init(
         modelManager: (any ModelManaging)? = nil,
         inferenceProviderStore: InferenceProviderSelectionStore = InferenceProviderSelectionStore(),
-        ollamaEndpointStore: OllamaEndpointSettingsStore = OllamaEndpointSettingsStore(),
+        connectionStore: ProviderConnectionSettingsStore = ProviderConnectionSettingsStore(),
         summarizationModelStore: SummarizationModelSelectionStore = SummarizationModelSelectionStore(),
         summarizationContextWindowStore: SummarizationContextWindowSelectionStore = SummarizationContextWindowSelectionStore(),
         visionModelStore: VisionModelSelectionStore = VisionModelSelectionStore(),
@@ -157,10 +187,11 @@ final class ModelsSettingsViewModel: ObservableObject {
         transcriptionLanguageStore: TranscriptionLanguageSelectionStore = TranscriptionLanguageSelectionStore(),
         availabilityProvider: (any CapabilityAvailabilityProviding)? = nil,
         ollamaModelDiscoverer: (any OllamaModelDiscovering)? = nil,
+        lmStudioModelDiscoverer: (any LMStudioModelDiscovering)? = nil,
         vocabularySettingsStore: (any VocabularyBoostingSettingsStoring)? = nil
     ) {
         self.inferenceProviderStore = inferenceProviderStore
-        self.ollamaEndpointStore = ollamaEndpointStore
+        self.connectionStore = connectionStore
         self.summarizationModelStore = summarizationModelStore
         self.summarizationContextWindowStore = summarizationContextWindowStore
         self.visionModelStore = visionModelStore
@@ -178,9 +209,11 @@ final class ModelsSettingsViewModel: ObservableObject {
             fluidAudioModelStore: fluidAudioModelStore
         )
         self.providedOllamaModelDiscoverer = ollamaModelDiscoverer
+        self.providedLMStudioModelDiscoverer = lmStudioModelDiscoverer
         self.usesCustomAvailabilityProvider = availabilityProvider != nil
         self.availabilityProvider = availabilityProvider ?? InferenceRuntimeFactory(
             providerStore: inferenceProviderStore,
+            connectionStore: connectionStore,
             summarizationModelStore: summarizationModelStore,
             summarizationContextWindowStore: summarizationContextWindowStore,
             visionModelStore: visionModelStore
@@ -197,7 +230,9 @@ final class ModelsSettingsViewModel: ObservableObject {
             summarizationModelStore.setSelectedModelID(selectedModel.id)
         }
         self.selectedSummarizationOllamaModelTag = inferenceProviderStore.selectedOllamaModelTag(for: .summarization) ?? ""
-        self.selectedOllamaBaseURLString = ollamaEndpointStore.selectedBaseURLString()
+        self.selectedSummarizationLMStudioModelIdentifier = inferenceProviderStore.selectedLMStudioModelIdentifier(for: .summarization) ?? ""
+        self.selectedOllamaBaseURLString = connectionStore.selectedBaseURLString(for: .ollama)
+        self.selectedLMStudioBaseURLString = connectionStore.selectedBaseURLString(for: .lmStudio)
         self.selectedSummarizationContextWindowPreset = summarizationContextWindowStore.selectedPreset()
         let selectedVisionProvider = inferenceProviderStore.selectedProvider(for: .vision)
         self.selectedVisionProviderID = selectedVisionProvider.rawValue
@@ -207,6 +242,7 @@ final class ModelsSettingsViewModel: ObservableObject {
             visionModelStore.setSelectedModelID(selectedVisionModel.id)
         }
         self.selectedVisionOllamaModelTag = inferenceProviderStore.selectedOllamaModelTag(for: .vision) ?? ""
+        self.selectedVisionLMStudioModelIdentifier = inferenceProviderStore.selectedLMStudioModelIdentifier(for: .vision) ?? ""
         let selectedBackend = transcriptionBackendStore.selectedBackend()
         self.selectedTranscriptionBackendID = selectedBackend.id
         if transcriptionBackendStore.selectedBackendID() != selectedBackend.id {
@@ -255,7 +291,10 @@ final class ModelsSettingsViewModel: ObservableObject {
         availabilityTask?.cancel()
         let usesOllamaForSummarization = selectedSummarizationProviderID == InferenceProvider.ollama.rawValue
         let usesOllamaForVision = selectedVisionProviderID == InferenceProvider.ollama.rawValue
+        let usesLMStudioForSummarization = selectedSummarizationProviderID == InferenceProvider.lmStudio.rawValue
+        let usesLMStudioForVision = selectedVisionProviderID == InferenceProvider.lmStudio.rawValue
         let shouldDiscoverOllama = usesOllamaForSummarization || usesOllamaForVision
+        let shouldDiscoverLMStudio = usesLMStudioForSummarization || usesLMStudioForVision
         availabilityTask = Task { [weak self] in
             guard let self else { return }
             await MainActor.run {
@@ -271,6 +310,12 @@ final class ModelsSettingsViewModel: ObservableObject {
             } else {
                 snapshot = nil
             }
+            let lmStudioSnapshot: LMStudioDiscoverySnapshot?
+            if shouldDiscoverLMStudio {
+                lmStudioSnapshot = try? await self.discoverLMStudioModels()
+            } else {
+                lmStudioSnapshot = nil
+            }
 
             do {
                 let summarizationState = try await summarization
@@ -280,6 +325,7 @@ final class ModelsSettingsViewModel: ObservableObject {
                     self.summarizationAvailabilityState = summarizationState
                     self.visionAvailabilityState = visionState
                     self.ollamaDiscoverySnapshot = snapshot
+                    self.lmStudioDiscoverySnapshot = lmStudioSnapshot
                     self.isRefreshingAvailability = false
                 }
             } catch {
@@ -287,12 +333,19 @@ final class ModelsSettingsViewModel: ObservableObject {
                 await MainActor.run {
                     self.isRefreshingAvailability = false
                     if usesOllamaForSummarization {
-                        self.summarizationAvailabilityState = Self.unavailableState(for: .summarization)
+                        self.summarizationAvailabilityState = Self.unavailableState(for: .summarization, provider: .ollama)
                     }
                     if usesOllamaForVision {
-                        self.visionAvailabilityState = Self.unavailableState(for: .vision)
+                        self.visionAvailabilityState = Self.unavailableState(for: .vision, provider: .ollama)
+                    }
+                    if usesLMStudioForSummarization {
+                        self.summarizationAvailabilityState = Self.unavailableState(for: .summarization, provider: .lmStudio)
+                    }
+                    if usesLMStudioForVision {
+                        self.visionAvailabilityState = Self.unavailableState(for: .vision, provider: .lmStudio)
                     }
                     self.ollamaDiscoverySnapshot = snapshot
+                    self.lmStudioDiscoverySnapshot = lmStudioSnapshot
                 }
             }
         }
@@ -310,9 +363,18 @@ final class ModelsSettingsViewModel: ObservableObject {
         ollamaDiscoverySnapshot?.models.map(\.tag) ?? []
     }
 
+    var lmStudioDiscoveredModelIdentifiers: [String] {
+        lmStudioDiscoverySnapshot?.models.map(\.identifier) ?? []
+    }
+
     var showsOllamaEndpointConfiguration: Bool {
         selectedSummarizationProviderID == InferenceProvider.ollama.rawValue
             || selectedVisionProviderID == InferenceProvider.ollama.rawValue
+    }
+
+    var showsLMStudioEndpointConfiguration: Bool {
+        selectedSummarizationProviderID == InferenceProvider.lmStudio.rawValue
+            || selectedVisionProviderID == InferenceProvider.lmStudio.rawValue
     }
 
     var isBuiltInSummarizationProviderSelected: Bool {
@@ -487,25 +549,57 @@ final class ModelsSettingsViewModel: ObservableObject {
         return id
     }
 
-    private static func unavailableState(for capability: InferenceCapability) -> CapabilityAvailabilityState {
+    private static func unavailableState(
+        for capability: InferenceCapability,
+        provider: InferenceProvider
+    ) -> CapabilityAvailabilityState {
+        let message: String
+        let status: CapabilityAvailabilityStatus
+        switch provider {
+        case .builtIn:
+            message = "Provider status is unavailable."
+            status = .unknown
+        case .ollama:
+            message = "Ollama is unavailable. Start the local daemon and refresh."
+            status = .daemonUnavailable
+        case .lmStudio:
+            message = "LM Studio is unavailable. Start the local server and refresh."
+            status = .serverUnavailable
+        }
         CapabilityAvailabilityState(
             capabilityID: capability,
-            providerID: .ollama,
+            providerID: provider,
             isReady: false,
-            status: .daemonUnavailable,
-            message: "Ollama is unavailable. Start the local daemon and refresh.",
+            status: status,
+            message: message,
             selectedReference: nil
         )
     }
 
-    private func invalidEndpointState(for capability: InferenceCapability) -> CapabilityAvailabilityState {
+    private func invalidEndpointState(
+        for capability: InferenceCapability,
+        provider: InferenceProvider
+    ) -> CapabilityAvailabilityState {
+        let message: String
+        let selectedReference: String
+        switch provider {
+        case .builtIn:
+            message = "Provider configuration is invalid."
+            selectedReference = ""
+        case .ollama:
+            message = "Enter a valid Ollama base URL such as \(AppConfiguration.Defaults.defaultOllamaBaseURL)."
+            selectedReference = selectedOllamaBaseURLString
+        case .lmStudio:
+            message = "Enter a valid LM Studio base URL such as \(AppConfiguration.Defaults.defaultLMStudioBaseURL)."
+            selectedReference = selectedLMStudioBaseURLString
+        }
         CapabilityAvailabilityState(
             capabilityID: capability,
-            providerID: .ollama,
+            providerID: provider,
             isReady: false,
             status: .needsConfiguration,
-            message: "Enter a valid Ollama base URL such as \(AppConfiguration.Defaults.defaultOllamaBaseURL).",
-            selectedReference: selectedOllamaBaseURLString
+            message: message,
+            selectedReference: selectedReference
         )
     }
 
@@ -519,10 +613,16 @@ final class ModelsSettingsViewModel: ObservableObject {
             return try await availabilityProvider.availability(for: capability)
         case .ollama:
             guard let discoverer = makeOllamaModelDiscoverer() else {
-                return invalidEndpointState(for: capability)
+                return invalidEndpointState(for: capability, provider: .ollama)
             }
             let tag = inferenceProviderStore.selectedOllamaModelTag(for: capability) ?? ""
             return try await discoverer.validateModelTag(tag, for: capability)
+        case .lmStudio:
+            guard let discoverer = makeLMStudioModelDiscoverer() else {
+                return invalidEndpointState(for: capability, provider: .lmStudio)
+            }
+            let identifier = inferenceProviderStore.selectedLMStudioModelIdentifier(for: capability) ?? ""
+            return try await discoverer.validateModelIdentifier(identifier, for: capability)
         }
     }
 
@@ -540,10 +640,30 @@ final class ModelsSettingsViewModel: ObservableObject {
         if let providedOllamaModelDiscoverer {
             return providedOllamaModelDiscoverer
         }
-        guard let baseURL = ollamaEndpointStore.selectedBaseURL() else {
+        guard let baseURL = connectionStore.selectedBaseURL(for: .ollama) else {
             return nil
         }
         return OllamaModelDiscoveryService(client: OllamaAPIClient(baseURL: baseURL))
+    }
+
+    private func discoverLMStudioModels() async throws -> LMStudioDiscoverySnapshot {
+        guard let discoverer = makeLMStudioModelDiscoverer() else {
+            return LMStudioDiscoverySnapshot(
+                serverReachable: false,
+                failureReason: "Enter a valid LM Studio base URL such as \(AppConfiguration.Defaults.defaultLMStudioBaseURL)."
+            )
+        }
+        return try await discoverer.discoverModels()
+    }
+
+    private func makeLMStudioModelDiscoverer() -> (any LMStudioModelDiscovering)? {
+        if let providedLMStudioModelDiscoverer {
+            return providedLMStudioModelDiscoverer
+        }
+        guard let baseURL = connectionStore.selectedBaseURL(for: .lmStudio) else {
+            return nil
+        }
+        return LMStudioModelDiscoveryService(client: LMStudioAPIClient(baseURL: baseURL))
     }
 
     private var isSelectedTranscriptionModelMissingOrInvalid: Bool {

--- a/Minute/Sources/Views/Settings/PermissionsSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/PermissionsSettingsSection.swift
@@ -26,8 +26,7 @@ struct PermissionsSettingsSection: View {
                 action: requestScreenRecordingPermission
             )
 
-            Text("You can also grant permissions in System Settings > Privacy & Security.")
-                .minuteFootnote()
+            SettingsInlineMessage(text: "You can also grant permissions in System Settings > Privacy & Security.")
         }
         .onAppear {
             refreshPermissions()

--- a/Minute/Sources/Views/Settings/SettingsCategoryCatalog.swift
+++ b/Minute/Sources/Views/Settings/SettingsCategoryCatalog.swift
@@ -23,6 +23,49 @@ struct SettingsCategoryDefinition: Identifiable, Hashable {
     }
 }
 
+struct SettingsEntryDefinition: Hashable {
+    enum ID: String, CaseIterable, Hashable {
+        case saveAudio
+        case saveTranscript
+        case normalizeAnalysisAudio
+        case micActivityNotifications
+        case outputLanguage
+        case vaultRoot
+        case meetingsFolder
+        case audioFolder
+        case transcriptsFolder
+        case knownSpeakerSuggestions
+        case speakerProfiles
+        case microphoneAccess
+        case screenRecordingAccess
+        case transcriptionEngine
+        case transcriptionModel
+        case transcriptionLanguage
+        case fluidAudioModel
+        case vocabularyBoosting
+        case summarizationProvider
+        case summarizationModel
+        case summarizationContextWindow
+        case screenContextEnabled
+        case screenContextProvider
+        case screenContextModel
+        case screenContextCaptureInterval
+        case screenContextVideoImport
+        case ollamaBaseURL
+        case lmStudioBaseURL
+        case transcriptionModelDownloads
+        case summarizationModelDownloads
+        case screenContextModelDownloads
+        case meetingTypesEditor
+        case automaticallyCheckUpdates
+        case automaticallyDownloadUpdates
+        case checkForUpdates
+    }
+
+    let id: ID
+    let categoryID: SettingsCategoryDefinition.ID
+}
+
 enum SettingsCategoryCatalog {
     // When adding a new category:
     // 1) Add a new `ID` case.
@@ -36,7 +79,7 @@ enum SettingsCategoryCatalog {
                 title: "General",
                 iconName: "slider.horizontal.3",
                 sortOrder: 10,
-                description: "Default behavior, language, and capture options.",
+                description: "Recording defaults, output behavior, and language.",
                 isVisible: true
             ),
             SettingsCategoryDefinition(
@@ -68,7 +111,7 @@ enum SettingsCategoryCatalog {
                 title: "AI & Models",
                 iconName: "sparkles",
                 sortOrder: 50,
-                description: "Transcription, summarization, and local model status.",
+                description: "Transcription, summarization, screen context, and local model readiness.",
                 isVisible: true
             ),
             SettingsCategoryDefinition(
@@ -91,6 +134,62 @@ enum SettingsCategoryCatalog {
 
         definitions.sort { $0.sortOrder < $1.sortOrder }
         return definitions.filter(\.isVisible)
+    }
+
+    static func entries(updatesEnabled: Bool) -> [SettingsEntryDefinition] {
+        var definitions: [SettingsEntryDefinition] = [
+            SettingsEntryDefinition(id: .saveAudio, categoryID: .general),
+            SettingsEntryDefinition(id: .saveTranscript, categoryID: .general),
+            SettingsEntryDefinition(id: .normalizeAnalysisAudio, categoryID: .general),
+            SettingsEntryDefinition(id: .micActivityNotifications, categoryID: .general),
+            SettingsEntryDefinition(id: .outputLanguage, categoryID: .general),
+            SettingsEntryDefinition(id: .vaultRoot, categoryID: .storage),
+            SettingsEntryDefinition(id: .meetingsFolder, categoryID: .storage),
+            SettingsEntryDefinition(id: .audioFolder, categoryID: .storage),
+            SettingsEntryDefinition(id: .transcriptsFolder, categoryID: .storage),
+            SettingsEntryDefinition(id: .knownSpeakerSuggestions, categoryID: .speakers),
+            SettingsEntryDefinition(id: .speakerProfiles, categoryID: .speakers),
+            SettingsEntryDefinition(id: .microphoneAccess, categoryID: .privacy),
+            SettingsEntryDefinition(id: .screenRecordingAccess, categoryID: .privacy),
+            SettingsEntryDefinition(id: .transcriptionEngine, categoryID: .ai),
+            SettingsEntryDefinition(id: .transcriptionModel, categoryID: .ai),
+            SettingsEntryDefinition(id: .transcriptionLanguage, categoryID: .ai),
+            SettingsEntryDefinition(id: .fluidAudioModel, categoryID: .ai),
+            SettingsEntryDefinition(id: .vocabularyBoosting, categoryID: .ai),
+            SettingsEntryDefinition(id: .summarizationProvider, categoryID: .ai),
+            SettingsEntryDefinition(id: .summarizationModel, categoryID: .ai),
+            SettingsEntryDefinition(id: .summarizationContextWindow, categoryID: .ai),
+            SettingsEntryDefinition(id: .screenContextEnabled, categoryID: .ai),
+            SettingsEntryDefinition(id: .screenContextProvider, categoryID: .ai),
+            SettingsEntryDefinition(id: .screenContextModel, categoryID: .ai),
+            SettingsEntryDefinition(id: .screenContextCaptureInterval, categoryID: .ai),
+            SettingsEntryDefinition(id: .screenContextVideoImport, categoryID: .ai),
+            SettingsEntryDefinition(id: .ollamaBaseURL, categoryID: .ai),
+            SettingsEntryDefinition(id: .lmStudioBaseURL, categoryID: .ai),
+            SettingsEntryDefinition(id: .transcriptionModelDownloads, categoryID: .ai),
+            SettingsEntryDefinition(id: .summarizationModelDownloads, categoryID: .ai),
+            SettingsEntryDefinition(id: .screenContextModelDownloads, categoryID: .ai),
+            SettingsEntryDefinition(id: .meetingTypesEditor, categoryID: .meetingTypes),
+        ]
+
+        if updatesEnabled {
+            definitions.append(contentsOf: [
+                SettingsEntryDefinition(id: .automaticallyCheckUpdates, categoryID: .updates),
+                SettingsEntryDefinition(id: .automaticallyDownloadUpdates, categoryID: .updates),
+                SettingsEntryDefinition(id: .checkForUpdates, categoryID: .updates),
+            ])
+        }
+
+        return definitions
+    }
+
+    static func categoryID(
+        for entryID: SettingsEntryDefinition.ID,
+        updatesEnabled: Bool
+    ) -> SettingsCategoryDefinition.ID? {
+        entries(updatesEnabled: updatesEnabled)
+            .first(where: { $0.id == entryID })?
+            .categoryID
     }
 
     static func fallbackSelection(

--- a/Minute/Sources/Views/Settings/SettingsFieldComponents.swift
+++ b/Minute/Sources/Views/Settings/SettingsFieldComponents.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct SettingsFieldBlock<Content: View>: View {
     let title: String
-    let subtitle: String
+    let subtitle: String?
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -11,9 +11,11 @@ struct SettingsFieldBlock<Content: View>: View {
             Text(title)
                 .minuteRowTitle()
 
-            Text(subtitle)
-                .minuteCaption()
-                .fixedSize(horizontal: false, vertical: true)
+            if let subtitle, !subtitle.isEmpty {
+                Text(subtitle)
+                    .minuteCaption()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             content()
         }
@@ -33,21 +35,14 @@ struct SettingsSingleLineInput: View {
             } else {
                 Text(text.isEmpty ? placeholder : text)
                     .foregroundStyle(text.isEmpty ? Color.minuteTextMuted : Color.minuteTextPrimary)
-                    .font(.system(size: 14, weight: .medium))
+                    .minuteControlValue()
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, MinuteControlMetrics.horizontalPadding)
+        .padding(.vertical, MinuteControlMetrics.verticalPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color(nsColor: .textBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(Color.minuteOutline, lineWidth: 1)
-        )
+        .minuteInputFieldChrome()
     }
 }
 
@@ -94,6 +89,161 @@ struct SettingsLeftAlignedTextField: NSViewRepresentable {
         func controlTextDidChange(_ obj: Notification) {
             guard let field = obj.object as? NSTextField else { return }
             text.wrappedValue = field.stringValue
+        }
+    }
+}
+
+struct SettingsMultilineInput: View {
+    @Binding var text: String
+    let placeholder: String
+    let minHeight: CGFloat
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            TextEditor(text: $text)
+                .font(.system(size: 13, weight: .medium))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 8)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: minHeight)
+
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text(placeholder)
+                    .minuteCaption()
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 14)
+                    .allowsHitTesting(false)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .minuteInputFieldChrome()
+    }
+}
+
+struct SettingsReadOnlyValue: View {
+    let text: String
+    let placeholder: String
+
+    init(text: String, placeholder: String = "Not set") {
+        self.text = text
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        Text(displayValue)
+            .foregroundStyle(text.isEmpty ? Color.minuteTextMuted : Color.minuteTextPrimary)
+            .minuteControlValue()
+            .lineLimit(3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, MinuteControlMetrics.horizontalPadding)
+            .padding(.vertical, MinuteControlMetrics.verticalPadding)
+            .minuteInputFieldChrome()
+    }
+
+    private var displayValue: String {
+        text.isEmpty ? placeholder : text
+    }
+}
+
+struct SettingsInlineMessage: View {
+    enum Tone {
+        case neutral
+        case warning
+        case error
+
+        var color: Color {
+            switch self {
+            case .neutral:
+                return Color.minuteTextSecondary
+            case .warning:
+                return .orange
+            case .error:
+                return .red
+            }
+        }
+    }
+
+    let text: String
+    var tone: Tone = .neutral
+
+    var body: some View {
+        Text(text)
+            .minuteCaption()
+            .foregroundStyle(tone.color)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+struct SettingsActionRow<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        HStack(spacing: 10) {
+            content()
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct SettingsCard<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            content()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.minuteSurface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.minuteOutline, lineWidth: 1)
+        )
+    }
+}
+
+struct SettingsMenuField<Option>: View {
+    let title: String
+    let subtitle: String?
+    let options: [Option]
+    let selectionLabel: String
+    let optionLabel: (Option) -> String
+    let isSelected: (Option) -> Bool
+    let onSelect: (Option) -> Void
+
+    var body: some View {
+        SettingsFieldBlock(title: title, subtitle: subtitle) {
+            Menu {
+                ForEach(Array(options.indices), id: \.self) { index in
+                    let option = options[index]
+                    Button {
+                        onSelect(option)
+                    } label: {
+                        if isSelected(option) {
+                            Label(optionLabel(option), systemImage: "checkmark")
+                        } else {
+                            Text(optionLabel(option))
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(selectionLabel)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.minuteTextSecondary)
+                }
+                .minuteDropdownStyle()
+            }
+            .menuStyle(.borderlessButton)
         }
     }
 }

--- a/Minute/Sources/Views/Settings/SummarizationContextWindowPicker.swift
+++ b/Minute/Sources/Views/Settings/SummarizationContextWindowPicker.swift
@@ -7,31 +7,26 @@ struct SummarizationContextWindowPicker: View {
     @Binding var selection: SummarizationContextWindowPreset
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Summarization context window")
-                .minuteRowTitle()
-
+        SettingsFieldBlock(
+            title: "Summarization context window",
+            subtitle: selection.detailText
+        ) {
             VStack(alignment: .leading, spacing: 10) {
                 HStack {
                     Text(selection.displayName)
-                        .font(.callout.weight(.semibold))
+                        .minuteControlValue()
                     Spacer()
                     Text(tokenCountLabel)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
+                        .minuteCaption()
                 }
 
                 SettingsSteppedControl(
                     stepLabels: presets.map(\.shortDisplayName),
                     selectedIndex: selectedIndexBinding
                 )
+
+                SettingsInlineMessage(text: recommendationText)
             }
-
-            Text(selection.detailText)
-                .minuteCaption()
-
-            Text(recommendationText)
-                .minuteCaption()
         }
         .gridCellColumns(2)
     }

--- a/Minute/Sources/Views/Settings/SummarizationModelPicker.swift
+++ b/Minute/Sources/Views/Settings/SummarizationModelPicker.swift
@@ -18,42 +18,15 @@ struct SummarizationModelPicker: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .minuteRowTitle()
-
-            Menu {
-                ForEach(models) { model in
-                    Button {
-                        selection = model.id
-                    } label: {
-                        if model.id == selection {
-                            Label(menuLabel(for: model), systemImage: "checkmark")
-                        } else {
-                            Text(menuLabel(for: model))
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selectedMenuLabel)
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .minuteDropdownStyle()
-            }
-            .menuStyle(.borderlessButton)
-
-            if let selectedModel {
-                Text(selectedModel.summary)
-                    .minuteCaption()
-            }
-        }
+        SettingsMenuField(
+            title: title,
+            subtitle: selectedModel?.summary,
+            options: models,
+            selectionLabel: selectedMenuLabel,
+            optionLabel: menuLabel(for:),
+            isSelected: { $0.id == selection },
+            onSelect: { selection = $0.id }
+        )
     }
 
     private var selectedModel: SummarizationModel? {

--- a/Minute/Sources/Views/Settings/SummarizationProviderPicker.swift
+++ b/Minute/Sources/Views/Settings/SummarizationProviderPicker.swift
@@ -9,64 +9,35 @@ struct SummarizationProviderPicker: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Summarization provider")
-                .minuteRowTitle()
-
-            Menu {
-                ForEach(providers, id: \.rawValue) { provider in
-                    Button {
-                        selection = provider.rawValue
-                    } label: {
-                        if provider.rawValue == selection {
-                            Label(provider.displayName, systemImage: "checkmark")
-                        } else {
-                            Text(provider.displayName)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selectedProvider?.displayName ?? "Select provider")
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .minuteDropdownStyle()
-            }
-            .menuStyle(.borderlessButton)
-
-            if let selectedProvider {
-                Text(selectedProvider.description)
-                    .minuteCaption()
-            }
+            SettingsMenuField(
+                title: "Summarization provider",
+                subtitle: selectedProvider?.description,
+                options: providers,
+                selectionLabel: selectedProvider?.displayName ?? "Select provider",
+                optionLabel: { $0.displayName },
+                isSelected: { $0.rawValue == selection },
+                onSelect: { selection = $0.rawValue }
+            )
 
             if selectedProvider == .ollama {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Ollama model tag")
-                        .minuteRowTitle()
-
-                    TextField("e.g. llama3.2:latest", text: $ollamaModelTag)
-                        .textFieldStyle(.roundedBorder)
-                        .autocorrectionDisabled()
-
-                    Text("Use a tag already available in your local Ollama daemon.")
-                        .minuteCaption()
+                SettingsFieldBlock(
+                    title: "Ollama model tag",
+                    subtitle: "Use a tag already available in your local Ollama daemon."
+                ) {
+                    SettingsSingleLineInput(
+                        text: $ollamaModelTag,
+                        placeholder: "e.g. llama3.2:latest"
+                    )
                 }
             } else if selectedProvider == .lmStudio {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("LM Studio model")
-                        .minuteRowTitle()
-
-                    TextField("e.g. qwen2.5-7b-instruct", text: $lmStudioModelIdentifier)
-                        .textFieldStyle(.roundedBorder)
-                        .autocorrectionDisabled()
-
-                    Text("Use a model identifier already available in your local LM Studio server.")
-                        .minuteCaption()
+                SettingsFieldBlock(
+                    title: "LM Studio model",
+                    subtitle: "Use a model identifier already available in your local LM Studio server."
+                ) {
+                    SettingsSingleLineInput(
+                        text: $lmStudioModelIdentifier,
+                        placeholder: "e.g. qwen2.5-7b-instruct"
+                    )
                 }
             }
         }

--- a/Minute/Sources/Views/Settings/SummarizationProviderPicker.swift
+++ b/Minute/Sources/Views/Settings/SummarizationProviderPicker.swift
@@ -5,6 +5,7 @@ struct SummarizationProviderPicker: View {
     let providers: [InferenceProvider]
     @Binding var selection: String
     @Binding var ollamaModelTag: String
+    @Binding var lmStudioModelIdentifier: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -53,6 +54,18 @@ struct SummarizationProviderPicker: View {
                         .autocorrectionDisabled()
 
                     Text("Use a tag already available in your local Ollama daemon.")
+                        .minuteCaption()
+                }
+            } else if selectedProvider == .lmStudio {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("LM Studio model")
+                        .minuteRowTitle()
+
+                    TextField("e.g. qwen2.5-7b-instruct", text: $lmStudioModelIdentifier)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+
+                    Text("Use a model identifier already available in your local LM Studio server.")
                         .minuteCaption()
                 }
             }

--- a/Minute/Sources/Views/Settings/TranscriptionBackendPicker.swift
+++ b/Minute/Sources/Views/Settings/TranscriptionBackendPicker.swift
@@ -6,42 +6,15 @@ struct TranscriptionBackendPicker: View {
     @Binding var selection: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Transcription engine")
-                .minuteRowTitle()
-
-            Menu {
-                ForEach(backends) { backend in
-                    Button {
-                        selection = backend.id
-                    } label: {
-                        if backend.id == selection {
-                            Label(backend.displayName, systemImage: "checkmark")
-                        } else {
-                            Text(backend.displayName)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selectedLabel)
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .minuteDropdownStyle()
-            }
-            .menuStyle(.borderlessButton)
-
-            if let selectedBackend {
-                Text(selectedBackend.summary)
-                    .minuteCaption()
-            }
-        }
+        SettingsMenuField(
+            title: "Transcription engine",
+            subtitle: selectedBackend?.summary,
+            options: backends,
+            selectionLabel: selectedLabel,
+            optionLabel: { $0.displayName },
+            isSelected: { $0.id == selection },
+            onSelect: { selection = $0.id }
+        )
     }
 
     private var selectedBackend: TranscriptionBackend? {

--- a/Minute/Sources/Views/Settings/TranscriptionLanguagePicker.swift
+++ b/Minute/Sources/Views/Settings/TranscriptionLanguagePicker.swift
@@ -6,40 +6,15 @@ struct TranscriptionLanguagePicker: View {
     @Binding var selection: TranscriptionLanguage
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Transcription language")
-                .minuteRowTitle()
-
-            Menu {
-                ForEach(languages) { language in
-                    Button {
-                        selection = language
-                    } label: {
-                        if language == selection {
-                            Label(language.displayName, systemImage: "checkmark")
-                        } else {
-                            Text(language.displayName)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selection.displayName)
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .minuteDropdownStyle()
-            }
-            .menuStyle(.borderlessButton)
-
-            Text(captionText)
-                .minuteCaption()
-        }
+        SettingsMenuField(
+            title: "Transcription language",
+            subtitle: captionText,
+            options: languages,
+            selectionLabel: selection.displayName,
+            optionLabel: { $0.displayName },
+            isSelected: { $0 == selection },
+            onSelect: { selection = $0 }
+        )
     }
 
     private var captionText: String {

--- a/Minute/Sources/Views/Settings/TranscriptionModelPicker.swift
+++ b/Minute/Sources/Views/Settings/TranscriptionModelPicker.swift
@@ -7,42 +7,15 @@ struct TranscriptionModelPicker: View {
     @Binding var selection: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Transcription model")
-                .minuteRowTitle()
-
-            Menu {
-                ForEach(models) { model in
-                    Button {
-                        selection = model.id
-                    } label: {
-                        if model.id == selection {
-                            Label(menuLabel(for: model), systemImage: "checkmark")
-                        } else {
-                            Text(menuLabel(for: model))
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selectedMenuLabel)
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .minuteDropdownStyle()
-            }
-            .menuStyle(.borderlessButton)
-
-            if let selectedModel {
-                Text(selectedModel.summary)
-                    .minuteCaption()
-            }
-        }
+        SettingsMenuField(
+            title: "Transcription model",
+            subtitle: selectedModel?.summary,
+            options: models,
+            selectionLabel: selectedMenuLabel,
+            optionLabel: menuLabel(for:),
+            isSelected: { $0.id == selection },
+            onSelect: { selection = $0.id }
+        )
     }
 
     private var selectedModel: TranscriptionModel? {

--- a/Minute/Sources/Views/Settings/UpdatesSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/UpdatesSettingsSection.swift
@@ -6,24 +6,31 @@ struct UpdatesSettingsSection: View {
     var body: some View {
         if model.isUpdaterEnabled {
             Section("Updates") {
-                Toggle(
+                SettingsToggleRow(
                     "Automatically check for updates",
+                    detail: "Check for new Minute releases in the background.",
                     isOn: Binding(
                         get: { model.automaticallyChecksForUpdates },
                         set: { model.setAutomaticallyChecksForUpdates($0) }
                     )
                 )
-                Toggle(
+
+                SettingsToggleRow(
                     "Automatically download updates",
+                    detail: "Download available updates before you choose to install them.",
                     isOn: Binding(
                         get: { model.automaticallyDownloadsUpdates },
                         set: { model.setAutomaticallyDownloadsUpdates($0) }
                     )
                 )
-                Button("Check for Updates...") {
-                    model.checkForUpdates()
+
+                SettingsActionRow {
+                    Button("Check for Updates...") {
+                        model.checkForUpdates()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!model.canCheckForUpdates)
                 }
-                .disabled(!model.canCheckForUpdates)
             }
         }
     }

--- a/Minute/Sources/Views/Settings/VaultConfigurationView.swift
+++ b/Minute/Sources/Views/Settings/VaultConfigurationView.swift
@@ -26,30 +26,31 @@ struct VaultConfigurationView: View {
         case .wizard:
             VStack(alignment: .leading, spacing: 16) {
                 Text("Vault")
-                    .font(.title3.bold())
+                    .minuteSectionTitle()
                 vaultRootSection
 
                 Divider()
 
                 Text("Folders")
-                    .font(.title3.bold())
+                    .minuteSectionTitle()
                 foldersSection
             }
         }
     }
 
     private var vaultRootSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Vault root")
-                Spacer()
-                Text(model.vaultRootPathDisplay)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.trailing)
+        VStack(alignment: .leading, spacing: 12) {
+            SettingsFieldBlock(
+                title: "Vault root",
+                subtitle: "Minute writes meeting notes, transcripts, and audio inside this vault."
+            ) {
+                SettingsReadOnlyValue(
+                    text: model.vaultRootPathDisplay == "Not selected" ? "" : model.vaultRootPathDisplay,
+                    placeholder: "Not selected"
+                )
             }
 
-            HStack {
+            SettingsActionRow {
                 Button("Choose vault...") {
                     Task { await model.chooseVaultRootFolder() }
                 }
@@ -62,26 +63,47 @@ struct VaultConfigurationView: View {
                 .disabled(model.vaultRootPathDisplay == "Not selected")
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-
-                Spacer()
             }
         }
     }
 
     private var foldersSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            TextField("Meetings folder (relative)", text: $model.meetingsRelativePath)
-                .minuteTextFieldStyle()
-            TextField("Audio folder (relative)", text: $model.audioRelativePath)
-                .minuteTextFieldStyle()
-            TextField("Transcript folder (relative)", text: $model.transcriptsRelativePath)
-                .minuteTextFieldStyle()
-            Text(
-                "Defaults: \(AppConfiguration.Defaults.defaultMeetingsRelativePath), " +
-                "\(AppConfiguration.Defaults.defaultAudioRelativePath), and " +
-                "\(AppConfiguration.Defaults.defaultTranscriptsRelativePath)"
+        VStack(alignment: .leading, spacing: 14) {
+            SettingsFieldBlock(
+                title: "Meetings folder",
+                subtitle: "Relative path for rendered meeting notes."
+            ) {
+                SettingsSingleLineInput(
+                    text: $model.meetingsRelativePath,
+                    placeholder: AppConfiguration.Defaults.defaultMeetingsRelativePath
+                )
+            }
+
+            SettingsFieldBlock(
+                title: "Audio folder",
+                subtitle: "Relative path for saved WAV files."
+            ) {
+                SettingsSingleLineInput(
+                    text: $model.audioRelativePath,
+                    placeholder: AppConfiguration.Defaults.defaultAudioRelativePath
+                )
+            }
+
+            SettingsFieldBlock(
+                title: "Transcript folder",
+                subtitle: "Relative path for rendered transcript Markdown files."
+            ) {
+                SettingsSingleLineInput(
+                    text: $model.transcriptsRelativePath,
+                    placeholder: AppConfiguration.Defaults.defaultTranscriptsRelativePath
+                )
+            }
+
+            SettingsInlineMessage(
+                text: "Defaults: \(AppConfiguration.Defaults.defaultMeetingsRelativePath), " +
+                    "\(AppConfiguration.Defaults.defaultAudioRelativePath), and " +
+                    "\(AppConfiguration.Defaults.defaultTranscriptsRelativePath)."
             )
-                .minuteCaption()
         }
     }
 }

--- a/Minute/Sources/Views/Settings/VisionProviderPicker.swift
+++ b/Minute/Sources/Views/Settings/VisionProviderPicker.swift
@@ -11,40 +11,15 @@ struct VisionProviderPicker: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Screen context provider")
-                .minuteRowTitle()
-
-            Menu {
-                ForEach(providers, id: \.rawValue) { provider in
-                    Button {
-                        selection = provider.rawValue
-                    } label: {
-                        if provider.rawValue == selection {
-                            Label(provider.displayName, systemImage: "checkmark")
-                        } else {
-                            Text(provider.displayName)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selectedProvider?.displayName ?? "Select provider")
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .minuteDropdownStyle()
-            }
-            .menuStyle(.borderlessButton)
-
-            if let selectedProvider {
-                Text(selectedProvider.description)
-                    .minuteCaption()
-            }
+            SettingsMenuField(
+                title: "Screen context provider",
+                subtitle: selectedProvider?.description,
+                options: providers,
+                selectionLabel: selectedProvider?.displayName ?? "Select provider",
+                optionLabel: { $0.displayName },
+                isSelected: { $0.rawValue == selection },
+                onSelect: { selection = $0.rawValue }
+            )
 
             if selectedProvider == .builtIn {
                 SummarizationModelPicker(
@@ -53,28 +28,24 @@ struct VisionProviderPicker: View {
                     selection: $builtInModelSelection
                 )
             } else if selectedProvider == .ollama {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Ollama screen context model tag")
-                        .minuteRowTitle()
-
-                    TextField("e.g. llava:latest", text: $ollamaModelTag)
-                        .textFieldStyle(.roundedBorder)
-                        .autocorrectionDisabled()
-
-                    Text("Use an installed Ollama model that supports screen-context or vision inference.")
-                        .minuteCaption()
+                SettingsFieldBlock(
+                    title: "Ollama screen context model tag",
+                    subtitle: "Use an installed Ollama model that supports screen-context or vision inference."
+                ) {
+                    SettingsSingleLineInput(
+                        text: $ollamaModelTag,
+                        placeholder: "e.g. llava:latest"
+                    )
                 }
             } else if selectedProvider == .lmStudio {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("LM Studio screen context model")
-                        .minuteRowTitle()
-
-                    TextField("e.g. qwen2.5-vl-7b", text: $lmStudioModelIdentifier)
-                        .textFieldStyle(.roundedBorder)
-                        .autocorrectionDisabled()
-
-                    Text("Use a local LM Studio model that supports vision or screen-context input.")
-                        .minuteCaption()
+                SettingsFieldBlock(
+                    title: "LM Studio screen context model",
+                    subtitle: "Use a local LM Studio model that supports vision or screen-context input."
+                ) {
+                    SettingsSingleLineInput(
+                        text: $lmStudioModelIdentifier,
+                        placeholder: "e.g. qwen2.5-vl-7b"
+                    )
                 }
             }
         }

--- a/Minute/Sources/Views/Settings/VisionProviderPicker.swift
+++ b/Minute/Sources/Views/Settings/VisionProviderPicker.swift
@@ -7,6 +7,7 @@ struct VisionProviderPicker: View {
     @Binding var selection: String
     @Binding var builtInModelSelection: String
     @Binding var ollamaModelTag: String
+    @Binding var lmStudioModelIdentifier: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -61,6 +62,18 @@ struct VisionProviderPicker: View {
                         .autocorrectionDisabled()
 
                     Text("Use an installed Ollama model that supports screen-context or vision inference.")
+                        .minuteCaption()
+                }
+            } else if selectedProvider == .lmStudio {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("LM Studio screen context model")
+                        .minuteRowTitle()
+
+                    TextField("e.g. qwen2.5-vl-7b", text: $lmStudioModelIdentifier)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+
+                    Text("Use a local LM Studio model that supports vision or screen-context input.")
                         .minuteCaption()
                 }
             }

--- a/Minute/Sources/Views/Settings/VocabularyBoostingSection.swift
+++ b/Minute/Sources/Views/Settings/VocabularyBoostingSection.swift
@@ -6,22 +6,23 @@ struct VocabularyBoostingSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Toggle("Enable vocabulary boosting", isOn: $model.vocabularyBoostingEnabled)
+            SettingsToggleRow(
+                "Enable vocabulary boosting",
+                detail: "Improve recognition for names, acronyms, and domain terms.",
+                isOn: $model.vocabularyBoostingEnabled
+            )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Terms")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                TextEditor(text: $model.vocabularyBoostingTermsInput)
-                    .font(.body)
-                    .frame(minHeight: 72)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .strokeBorder(Color.secondary.opacity(0.2))
-                    )
-                    .accessibilityLabel(Text("Vocabulary terms"))
-                    .accessibilityHint(Text("Comma or newline separated terms and phrases."))
+            SettingsFieldBlock(
+                title: "Terms",
+                subtitle: "Comma or newline separated terms and phrases."
+            ) {
+                SettingsMultilineInput(
+                    text: $model.vocabularyBoostingTermsInput,
+                    placeholder: "Acme, Q4 planning, InfraOps",
+                    minHeight: 72
+                )
+                .accessibilityLabel(Text("Vocabulary terms"))
+                .accessibilityHint(Text("Comma or newline separated terms and phrases."))
             }
 
             Picker("Strength", selection: $model.vocabularyBoostingStrength) {
@@ -31,22 +32,22 @@ struct VocabularyBoostingSection: View {
             }
             .pickerStyle(.segmented)
 
-            Text(model.vocabularyHintText)
-                .minuteCaption()
+            SettingsInlineMessage(text: model.vocabularyHintText)
 
             if model.showsVocabularyReadinessRow, let message = model.vocabularyReadinessMessage {
-                HStack(alignment: .center, spacing: 10) {
-                    StatusIcon(state: .attention)
-                    Text(message)
-                        .minuteCaption()
-                    Spacer()
-                    Button("Download Models") {
-                        model.startDownload()
+                SettingsCard {
+                    HStack(alignment: .center, spacing: 10) {
+                        StatusIcon(state: .attention)
+                        Text(message)
+                            .minuteCaption()
+                        Spacer()
+                        Button("Download Models") {
+                            model.startDownload()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
                 }
-                .padding(.vertical, 4)
             }
         }
     }

--- a/Minute/Styles/MinuteDropdownStyle.swift
+++ b/Minute/Styles/MinuteDropdownStyle.swift
@@ -4,19 +4,10 @@ import SwiftUI
 struct MinuteDropdownLabelStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .font(.callout)
-            .foregroundStyle(.primary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color(nsColor: NSColor.controlBackgroundColor))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(Color(nsColor: NSColor.separatorColor), lineWidth: 1)
-            )
+            .minuteControlValue()
+            .padding(.horizontal, MinuteControlMetrics.horizontalPadding)
+            .padding(.vertical, MinuteControlMetrics.verticalPadding)
+            .minuteInputFieldChrome()
     }
 }
 

--- a/Minute/Styles/MinuteTextFieldStyle.swift
+++ b/Minute/Styles/MinuteTextFieldStyle.swift
@@ -1,19 +1,37 @@
 import AppKit
 import SwiftUI
 
-extension View {
-    func minuteTextFieldStyle() -> some View {
-        self.textFieldStyle(.plain)
-            .font(.callout)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
+enum MinuteControlMetrics {
+    static let cornerRadius: CGFloat = 10
+    static let horizontalPadding: CGFloat = 12
+    static let verticalPadding: CGFloat = 10
+}
+
+private struct MinuteInputFieldChrome: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color(nsColor: NSColor.controlBackgroundColor))
+                RoundedRectangle(cornerRadius: MinuteControlMetrics.cornerRadius, style: .continuous)
+                    .fill(Color(nsColor: .textBackgroundColor))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(Color(nsColor: NSColor.separatorColor), lineWidth: 1)
+                RoundedRectangle(cornerRadius: MinuteControlMetrics.cornerRadius, style: .continuous)
+                    .stroke(Color.minuteOutline, lineWidth: 1)
             )
+    }
+}
+
+extension View {
+    func minuteInputFieldChrome() -> some View {
+        modifier(MinuteInputFieldChrome())
+    }
+
+    func minuteTextFieldStyle() -> some View {
+        self.textFieldStyle(.plain)
+            .minuteControlValue()
+            .padding(.horizontal, MinuteControlMetrics.horizontalPadding)
+            .padding(.vertical, MinuteControlMetrics.verticalPadding)
+            .minuteInputFieldChrome()
     }
 }

--- a/Minute/Styles/MinuteTextStyle.swift
+++ b/Minute/Styles/MinuteTextStyle.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 
 extension View {
+    func minuteSettingsHeaderTitle() -> some View {
+        font(.system(size: 22, weight: .semibold))
+            .tracking(-0.4)
+            .foregroundStyle(Color.minuteTextPrimary)
+    }
+
+    func minuteSettingsHeaderSubtitle() -> some View {
+        font(.system(size: 13, weight: .medium))
+            .tracking(-0.1)
+            .foregroundStyle(Color.minuteTextSecondary)
+    }
+
     func minuteSectionTitle() -> some View {
         font(.system(size: 18, weight: .semibold))
             .tracking(-0.3)
@@ -29,5 +41,11 @@ extension View {
         font(.system(size: 11, weight: .medium))
             .tracking(-0.1)
             .foregroundStyle(Color.minuteTextMuted)
+    }
+
+    func minuteControlValue() -> some View {
+        font(.system(size: 14, weight: .medium))
+            .tracking(-0.1)
+            .foregroundStyle(Color.minuteTextPrimary)
     }
 }

--- a/MinuteCore/Package.resolved
+++ b/MinuteCore/Package.resolved
@@ -1,39 +1,12 @@
 {
-  "originHash" : "774a19f9c25afbc50c8c2364f87c26d11557fb8883cf99de9f23d9c2a1b6b99f",
+  "originHash" : "6f42e6354c744c677422f30e9b8fcc0c90b70d8f6ab0dd999b9dace9a7453a28",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "d19ce5a81af0a55d43892df53012e4a2b07c69b1"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
-        "version" : "2.3.1"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "573e5c9036c2f136b3a8a071da8e8907322403d0",
-        "version" : "1.1.6"
+        "revision" : "e5c6456dd9cbbd6bcdc3aeefbddfcd483c5d3ca6"
       }
     }
   ],

--- a/MinuteCore/Package.swift
+++ b/MinuteCore/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", revision: "d19ce5a81af0a55d43892df53012e4a2b07c69b1"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", revision: "e5c6456dd9cbbd6bcdc3aeefbddfcd483c5d3ca6"),
     ],
     targets: [
         // Precompiled whisper.cpp XCFramework (downloaded from ggml-org/whisper.cpp releases).

--- a/MinuteCore/Package.swift
+++ b/MinuteCore/Package.swift
@@ -26,6 +26,10 @@ let package = Package(
             name: "MinuteOllama",
             targets: ["MinuteOllama"]
         ),
+        .library(
+            name: "MinuteLMStudio",
+            targets: ["MinuteLMStudio"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/FluidInference/FluidAudio.git", revision: "d19ce5a81af0a55d43892df53012e4a2b07c69b1"),
@@ -61,11 +65,16 @@ let package = Package(
             name: "MinuteOllama",
             dependencies: ["MinuteCore"]
         ),
+        .target(
+            name: "MinuteLMStudio",
+            dependencies: ["MinuteCore"]
+        ),
         .testTarget(
             name: "MinuteCoreTests",
             dependencies: [
                 "MinuteCore",
                 "MinuteOllama",
+                "MinuteLMStudio",
             ],
             resources: [
                 .process("Fixtures/Transcript"),

--- a/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
+++ b/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
@@ -17,11 +17,14 @@ public struct AppConfiguration: Sendable, Equatable {
         public static let summarizationModelIDKey = "summarizationModelID"
         public static let summarizationProviderIDKey = "summarizationProviderID"
         public static let summarizationOllamaModelTagKey = "summarizationOllamaModelTag"
+        public static let summarizationLMStudioModelIdentifierKey = "summarizationLMStudioModelIdentifier"
         public static let ollamaBaseURLKey = "ollamaBaseURL"
+        public static let lmStudioBaseURLKey = "lmStudioBaseURL"
         public static let summarizationContextWindowPresetKey = "summarizationContextWindowPreset"
         public static let visionProviderIDKey = "visionProviderID"
         public static let visionBuiltInModelIDKey = "visionBuiltInModelID"
         public static let visionOllamaModelTagKey = "visionOllamaModelTag"
+        public static let visionLMStudioModelIdentifierKey = "visionLMStudioModelIdentifier"
         public static let transcriptionModelIDKey = "transcriptionModelID"
         public static let transcriptionBackendIDKey = "transcriptionBackendID"
         public static let fluidAudioAsrModelIDKey = "fluidAudioAsrModelID"
@@ -50,6 +53,7 @@ public struct AppConfiguration: Sendable, Equatable {
         public static let defaultScreenContextVideoImportEnabled = false
         public static let defaultScreenContextCaptureIntervalSeconds: TimeInterval = 60
         public static let defaultOllamaBaseURL = "http://127.0.0.1:11434"
+        public static let defaultLMStudioBaseURL = "http://127.0.0.1:1234"
         public static let defaultMicActivityNotificationsEnabled = true
         public static let defaultKnownSpeakerSuggestionsEnabled = false
         public static let defaultOutputLanguage = OutputLanguage.defaultSelection
@@ -81,10 +85,13 @@ public struct AppConfiguration: Sendable, Equatable {
     public var screenContextCaptureIntervalSeconds: TimeInterval
     public var summarizationProviderID: String
     public var summarizationOllamaModelTag: String?
+    public var summarizationLMStudioModelIdentifier: String?
     public var ollamaBaseURL: String
+    public var lmStudioBaseURL: String
     public var visionProviderID: String
     public var visionBuiltInModelID: String
     public var visionOllamaModelTag: String?
+    public var visionLMStudioModelIdentifier: String?
     public var micActivityNotificationsEnabled: Bool
     public var knownSpeakerSuggestionsEnabled: Bool
     public var vocabularyBoostingEnabled: Bool
@@ -124,9 +131,16 @@ public struct AppConfiguration: Sendable, Equatable {
         summarizationOllamaModelTag = Self.normalizedOptionalString(
             defaults.string(forKey: Defaults.summarizationOllamaModelTagKey)
         )
-        ollamaBaseURL = Self.validatedOllamaBaseURL(
+        summarizationLMStudioModelIdentifier = Self.normalizedOptionalString(
+            defaults.string(forKey: Defaults.summarizationLMStudioModelIdentifierKey)
+        )
+        ollamaBaseURL = Self.validatedLocalServerBaseURL(
             defaults.string(forKey: Defaults.ollamaBaseURLKey),
             fallback: Defaults.defaultOllamaBaseURL
+        )
+        lmStudioBaseURL = Self.validatedLocalServerBaseURL(
+            defaults.string(forKey: Defaults.lmStudioBaseURLKey),
+            fallback: Defaults.defaultLMStudioBaseURL
         )
         let visionProviderRaw = defaults.string(forKey: Defaults.visionProviderIDKey)
             ?? Defaults.defaultVisionProviderID
@@ -137,6 +151,9 @@ public struct AppConfiguration: Sendable, Equatable {
             ?? Defaults.defaultVisionBuiltInModelID
         visionOllamaModelTag = Self.normalizedOptionalString(
             defaults.string(forKey: Defaults.visionOllamaModelTagKey)
+        )
+        visionLMStudioModelIdentifier = Self.normalizedOptionalString(
+            defaults.string(forKey: Defaults.visionLMStudioModelIdentifierKey)
         )
 
         micActivityNotificationsEnabled = defaults.object(forKey: Defaults.micActivityNotificationsEnabledKey) as? Bool
@@ -161,6 +178,10 @@ public struct AppConfiguration: Sendable, Equatable {
     }
 
     public static func validatedOllamaBaseURL(_ value: String?, fallback: String) -> String {
+        validatedLocalServerBaseURL(value, fallback: fallback)
+    }
+
+    public static func validatedLocalServerBaseURL(_ value: String?, fallback: String) -> String {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else {
             return fallback

--- a/MinuteCore/Sources/MinuteCore/Domain/CapabilityAvailabilityState.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/CapabilityAvailabilityState.swift
@@ -4,6 +4,7 @@ public enum CapabilityAvailabilityStatus: String, Sendable, Codable {
     case ready
     case needsConfiguration
     case daemonUnavailable
+    case serverUnavailable
     case modelMissing
     case unsupported
     case visionUnsupported
@@ -39,6 +40,7 @@ public struct InferenceTaskBinding: Sendable, Equatable, Codable {
     public var capabilityID: InferenceCapability
     public var providerID: InferenceProvider
     public var providerReference: String
+    public var connectionBaseURLString: String?
     public var capturedAt: Date
     public var supportsVisionInputs: Bool
 
@@ -46,12 +48,14 @@ public struct InferenceTaskBinding: Sendable, Equatable, Codable {
         capabilityID: InferenceCapability,
         providerID: InferenceProvider,
         providerReference: String,
+        connectionBaseURLString: String? = nil,
         capturedAt: Date = Date(),
         supportsVisionInputs: Bool
     ) {
         self.capabilityID = capabilityID
         self.providerID = providerID
         self.providerReference = providerReference
+        self.connectionBaseURLString = connectionBaseURLString
         self.capturedAt = capturedAt
         self.supportsVisionInputs = supportsVisionInputs
     }

--- a/MinuteCore/Sources/MinuteCore/Domain/InferenceProvider.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/InferenceProvider.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum InferenceProvider: String, CaseIterable, Sendable, Codable {
     case builtIn
     case ollama
+    case lmStudio
 
     public var displayName: String {
         switch self {
@@ -10,6 +11,8 @@ public enum InferenceProvider: String, CaseIterable, Sendable, Codable {
             return "Built-in"
         case .ollama:
             return "Ollama"
+        case .lmStudio:
+            return "LM Studio"
         }
     }
 
@@ -19,6 +22,8 @@ public enum InferenceProvider: String, CaseIterable, Sendable, Codable {
             return "Use Minute's built-in local models."
         case .ollama:
             return "Use a local Ollama daemon and a model tag you manage."
+        case .lmStudio:
+            return "Use a local LM Studio server and a model you manage."
         }
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Domain/LMStudioModelDescriptor.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/LMStudioModelDescriptor.swift
@@ -54,6 +54,6 @@ public struct LMStudioModelDescriptor: Sendable, Equatable, Codable, Identifiabl
         self.quantizationLabel = quantizationLabel
         self.state = state
         self.maxContextLength = maxContextLength
-        self.supportsVision = supportsVision ?? modelType.caseInsensitiveCompare("vlm") == .orderedSame
+        self.supportsVision = supportsVision ?? (modelType.caseInsensitiveCompare("vlm") == .orderedSame)
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Domain/LMStudioModelDescriptor.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/LMStudioModelDescriptor.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+public struct LMStudioDiscoverySnapshot: Sendable, Equatable, Codable {
+    public var serverReachable: Bool
+    public var discoveredAt: Date
+    public var models: [LMStudioModelDescriptor]
+    public var failureReason: String?
+
+    public init(
+        serverReachable: Bool,
+        discoveredAt: Date = Date(),
+        models: [LMStudioModelDescriptor] = [],
+        failureReason: String? = nil
+    ) {
+        self.serverReachable = serverReachable
+        self.discoveredAt = discoveredAt
+        self.models = models
+        self.failureReason = failureReason
+    }
+}
+
+public struct LMStudioModelDescriptor: Sendable, Equatable, Codable, Identifiable {
+    public var id: String { identifier }
+
+    public var identifier: String
+    public var displayName: String
+    public var modelType: String
+    public var publisher: String?
+    public var architecture: String?
+    public var compatibilityType: String?
+    public var quantizationLabel: String?
+    public var state: String?
+    public var maxContextLength: Int?
+    public var supportsVision: Bool
+
+    public init(
+        identifier: String,
+        displayName: String,
+        modelType: String,
+        publisher: String? = nil,
+        architecture: String? = nil,
+        compatibilityType: String? = nil,
+        quantizationLabel: String? = nil,
+        state: String? = nil,
+        maxContextLength: Int? = nil,
+        supportsVision: Bool? = nil
+    ) {
+        self.identifier = identifier
+        self.displayName = displayName
+        self.modelType = modelType
+        self.publisher = publisher
+        self.architecture = architecture
+        self.compatibilityType = compatibilityType
+        self.quantizationLabel = quantizationLabel
+        self.state = state
+        self.maxContextLength = maxContextLength
+        self.supportsVision = supportsVision ?? modelType.caseInsensitiveCompare("vlm") == .orderedSame
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Domain/ScreenContext.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/ScreenContext.swift
@@ -142,16 +142,24 @@ public struct ScreenContextEvent: Sendable, Equatable {
 
 public enum ScreenContextLifecycleEventType: String, Sendable, Equatable {
     case sharedWindowClosed
+    case inferenceUnavailable
 }
 
 public struct ScreenContextLifecycleEvent: Sendable, Equatable {
     public var type: ScreenContextLifecycleEventType
     public var windowTitle: String
+    public var message: String?
     public var timestamp: Date
 
-    public init(type: ScreenContextLifecycleEventType, windowTitle: String, timestamp: Date = Date()) {
+    public init(
+        type: ScreenContextLifecycleEventType,
+        windowTitle: String,
+        message: String? = nil,
+        timestamp: Date = Date()
+    ) {
         self.type = type
         self.windowTitle = windowTitle
+        self.message = message
         self.timestamp = timestamp
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Domain/ScreenContextInferenceFailurePolicy.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/ScreenContextInferenceFailurePolicy.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public enum ScreenContextInferenceFailurePolicy {
+    public static func terminalMessage(for error: Error) -> String? {
+        guard let minuteError = error as? MinuteError else { return nil }
+
+        switch minuteError {
+        case .modelMissing:
+            return "Screen context is unavailable because the selected vision model files are missing. Repair or reselect the model in Settings -> Models."
+        case .mmprojMissing:
+            return "Screen context is unavailable because the selected multimodal projector file is missing. Repair or reselect the model in Settings -> Models."
+        case .llamaMTMDMissing:
+            return "Screen context is unavailable because the multimodal inference component is missing. Repair the local installation and try again."
+        case .llamaMTMDFailed(let exitCode, let output):
+            return terminalMessageForMTMDFailure(exitCode: exitCode, output: output)
+        default:
+            return nil
+        }
+    }
+}
+
+private extension ScreenContextInferenceFailurePolicy {
+    static func terminalMessageForMTMDFailure(exitCode: Int32, output: String) -> String? {
+        let trimmedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedOutput = trimmedOutput.lowercased()
+
+        let imageInputFailureMarkers = [
+            "number of image token positions",
+            "number of image features",
+            "could not process image input",
+            "image token positions",
+            "iterating prediction stream",
+            "the model has crashed without additional information"
+        ]
+
+        let isLikelyPermanentImageInputFailure =
+            exitCode == 400
+            || imageInputFailureMarkers.contains { normalizedOutput.contains($0) }
+
+        guard isLikelyPermanentImageInputFailure else { return nil }
+
+        if trimmedOutput.isEmpty {
+            return "Selected vision model could not process image input. Choose another vision-capable model in Settings -> Models."
+        }
+
+        return """
+        Selected vision model could not process image input. Choose another vision-capable model in Settings -> Models. Provider reported: \(trimmedOutput)
+        """
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Services/FluidAudioASRVersionResolver.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/FluidAudioASRVersionResolver.swift
@@ -6,6 +6,8 @@ enum FluidAudioASRVersionResolver {
         switch key.lowercased() {
         case "v2":
             return .v2
+        case "tdtctc110m", "tdt-ctc-110m", "tdt_ctc_110m":
+            return .tdtCtc110m
         default:
             return .v3
         }

--- a/MinuteCore/Sources/MinuteCore/Services/FluidAudioTranscriptionService.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/FluidAudioTranscriptionService.swift
@@ -61,11 +61,8 @@ public struct FluidAudioTranscriptionService: VocabularyBoostingTranscriptionSer
         }
 
         let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
-        await configureVocabularyBoostingIfAvailable(
-            manager: manager,
-            vocabulary: resolvedVocabulary
-        )
+        try await manager.loadModels(models)
+        await logUnavailableVocabularyBoostingIfNeeded(vocabulary: resolvedVocabulary)
 
         do {
             let converter = AudioConverter()
@@ -99,33 +96,16 @@ public struct FluidAudioTranscriptionService: VocabularyBoostingTranscriptionSer
 }
 
 private extension FluidAudioTranscriptionService {
-    func configureVocabularyBoostingIfAvailable(
-        manager: AsrManager,
+    func logUnavailableVocabularyBoostingIfNeeded(
         vocabulary: TranscriptionVocabularySettings?
     ) async {
         guard let vocabulary = vocabularyContext(from: vocabulary) else {
-            manager.disableVocabularyBoosting()
             return
         }
 
-        do {
-            let ctcModels = try await FluidAudioCTCModelCache.shared.models(
-                variant: Self.ctcVocabularyVariant
-            )
-            try await manager.configureVocabularyBoosting(
-                vocabulary: vocabulary.context,
-                ctcModels: ctcModels,
-                config: vocabulary.config
-            )
-            logger.debug(
-                "FluidAudio ASR vocabulary boosting configured: terms=\(vocabulary.context.terms.count, privacy: .public) strength=\(vocabulary.strengthLabel, privacy: .public)"
-            )
-        } catch {
-            manager.disableVocabularyBoosting()
-            logger.warning(
-                "FluidAudio ASR vocabulary boosting unavailable; proceeding without boost: \(ErrorHandler.debugMessage(for: error), privacy: .public)"
-            )
-        }
+        logger.warning(
+            "FluidAudio batch vocabulary boosting is unavailable with the current upstream API; proceeding without boost for \(vocabulary.context.terms.count, privacy: .public) terms at strength \(vocabulary.strengthLabel, privacy: .public)"
+        )
     }
 
     func vocabularyContext(
@@ -299,22 +279,6 @@ private actor FluidAudioASRModelCache {
     }
 }
 
-private actor FluidAudioCTCModelCache {
-    static let shared = FluidAudioCTCModelCache()
-    private var cached: [String: CtcModels] = [:]
-
-    func models(variant: CtcModelVariant) async throws -> CtcModels {
-        let key = variant.rawValue
-        if let cached = cached[key] {
-            return cached
-        }
-
-        let models = try await CtcModels.downloadAndLoad(variant: variant)
-        cached[key] = models
-        return models
-    }
-}
-
 private extension AsrModelVersion {
     var cacheKey: String {
         switch self {
@@ -322,6 +286,8 @@ private extension AsrModelVersion {
             return "v2"
         case .v3:
             return "v3"
+        case .tdtCtc110m:
+            return "tdtctc110m"
         }
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Services/InferenceProviderSelectionStore.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/InferenceProviderSelectionStore.swift
@@ -4,6 +4,7 @@ public final class InferenceProviderSelectionStore: @unchecked Sendable {
     private let defaults: UserDefaults
     private let providerKeys: [InferenceCapability: String]
     private let ollamaTagKeys: [InferenceCapability: String]
+    private let lmStudioModelIdentifierKeys: [InferenceCapability: String]
 
     public init(
         defaults: UserDefaults = .standard,
@@ -14,11 +15,16 @@ public final class InferenceProviderSelectionStore: @unchecked Sendable {
         ollamaTagKeys: [InferenceCapability: String] = [
             .summarization: AppConfiguration.Defaults.summarizationOllamaModelTagKey,
             .vision: AppConfiguration.Defaults.visionOllamaModelTagKey,
+        ],
+        lmStudioModelIdentifierKeys: [InferenceCapability: String] = [
+            .summarization: AppConfiguration.Defaults.summarizationLMStudioModelIdentifierKey,
+            .vision: AppConfiguration.Defaults.visionLMStudioModelIdentifierKey,
         ]
     ) {
         self.defaults = defaults
         self.providerKeys = providerKeys
         self.ollamaTagKeys = ollamaTagKeys
+        self.lmStudioModelIdentifierKeys = lmStudioModelIdentifierKeys
     }
 
     public func selectedProvider(for capability: InferenceCapability) -> InferenceProvider {
@@ -42,22 +48,74 @@ public final class InferenceProviderSelectionStore: @unchecked Sendable {
 
     public func selectedOllamaModelTag(for capability: InferenceCapability) -> String? {
         guard let key = ollamaTagKeys[capability] else { return nil }
-        let trimmed = defaults.string(forKey: key)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
+        return normalizedOptionalString(forKey: key)
     }
 
     public func setSelectedOllamaModelTag(_ tag: String?, for capability: InferenceCapability) {
         guard let key = ollamaTagKeys[capability] else { return }
-        let trimmed = tag?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if trimmed.isEmpty {
-            defaults.removeObject(forKey: key)
-        } else {
-            defaults.set(trimmed, forKey: key)
-        }
+        setNormalizedOptionalString(tag, forKey: key)
     }
 
     public func clearSelectedOllamaModelTag(for capability: InferenceCapability) {
         guard let key = ollamaTagKeys[capability] else { return }
         defaults.removeObject(forKey: key)
+    }
+
+    public func selectedLMStudioModelIdentifier(for capability: InferenceCapability) -> String? {
+        guard let key = lmStudioModelIdentifierKeys[capability] else { return nil }
+        return normalizedOptionalString(forKey: key)
+    }
+
+    public func setSelectedLMStudioModelIdentifier(_ identifier: String?, for capability: InferenceCapability) {
+        guard let key = lmStudioModelIdentifierKeys[capability] else { return }
+        setNormalizedOptionalString(identifier, forKey: key)
+    }
+
+    public func clearSelectedLMStudioModelIdentifier(for capability: InferenceCapability) {
+        guard let key = lmStudioModelIdentifierKeys[capability] else { return }
+        defaults.removeObject(forKey: key)
+    }
+
+    public func selectedProviderReference(
+        for capability: InferenceCapability,
+        provider: InferenceProvider
+    ) -> String? {
+        switch provider {
+        case .builtIn:
+            return nil
+        case .ollama:
+            return selectedOllamaModelTag(for: capability)
+        case .lmStudio:
+            return selectedLMStudioModelIdentifier(for: capability)
+        }
+    }
+
+    public func setSelectedProviderReference(
+        _ reference: String?,
+        for capability: InferenceCapability,
+        provider: InferenceProvider
+    ) {
+        switch provider {
+        case .builtIn:
+            break
+        case .ollama:
+            setSelectedOllamaModelTag(reference, for: capability)
+        case .lmStudio:
+            setSelectedLMStudioModelIdentifier(reference, for: capability)
+        }
+    }
+
+    private func normalizedOptionalString(forKey key: String) -> String? {
+        let trimmed = defaults.string(forKey: key)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func setNormalizedOptionalString(_ value: String?, forKey key: String) {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            defaults.removeObject(forKey: key)
+        } else {
+            defaults.set(trimmed, forKey: key)
+        }
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Services/InferenceRuntimeFactory.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/InferenceRuntimeFactory.swift
@@ -1,18 +1,16 @@
 import Foundation
 
-public protocol OllamaModelDiscovering: Sendable {
-    func discoverModels() async throws -> OllamaDiscoverySnapshot
-    func validateModelTag(_ tag: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState
-}
-
 public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding {
     public typealias BuiltInSummarizationBuilder =
         @Sendable (SummarizationModelSelectionStore, SummarizationContextWindowSelectionStore, SummarizationHardwareProfile) -> any SummarizationServicing
-    public typealias OllamaSummarizationBuilder = @Sendable (String) -> any SummarizationServicing
+    public typealias OllamaSummarizationBuilder = @Sendable (String, URL?) -> any SummarizationServicing
+    public typealias LMStudioSummarizationBuilder = @Sendable (String, URL?) -> any SummarizationServicing
     public typealias BuiltInVisionBuilder = @Sendable (VisionModelSelectionStore) -> any ScreenContextInferencing
-    public typealias OllamaVisionBuilder = @Sendable (String) -> any ScreenContextInferencing
+    public typealias OllamaVisionBuilder = @Sendable (String, URL?) -> any ScreenContextInferencing
+    public typealias LMStudioVisionBuilder = @Sendable (String, URL?) -> any ScreenContextInferencing
 
     private let providerStore: InferenceProviderSelectionStore
+    private let connectionStore: ProviderConnectionSettingsStore
     private let summarizationModelStore: SummarizationModelSelectionStore
     private let summarizationContextWindowStore: SummarizationContextWindowSelectionStore
     private let visionModelStore: VisionModelSelectionStore
@@ -20,24 +18,32 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
     private let dateProvider: @Sendable () -> Date
     private let builtInSummarizationBuilder: BuiltInSummarizationBuilder
     private let ollamaSummarizationBuilder: OllamaSummarizationBuilder
+    private let lmStudioSummarizationBuilder: LMStudioSummarizationBuilder
     private let builtInVisionBuilder: BuiltInVisionBuilder
     private let ollamaVisionBuilder: OllamaVisionBuilder
+    private let lmStudioVisionBuilder: LMStudioVisionBuilder
     private let ollamaModelDiscoverer: (any OllamaModelDiscovering)?
+    private let lmStudioModelDiscoverer: (any LMStudioModelDiscovering)?
 
     public init(
         providerStore: InferenceProviderSelectionStore = InferenceProviderSelectionStore(),
+        connectionStore: ProviderConnectionSettingsStore = ProviderConnectionSettingsStore(),
         summarizationModelStore: SummarizationModelSelectionStore = SummarizationModelSelectionStore(),
         summarizationContextWindowStore: SummarizationContextWindowSelectionStore = SummarizationContextWindowSelectionStore(),
         visionModelStore: VisionModelSelectionStore = VisionModelSelectionStore(),
         hardwareProfileProvider: @escaping @Sendable () -> SummarizationHardwareProfile = { .current() },
         dateProvider: @escaping @Sendable () -> Date = Date.init,
         builtInSummarizationBuilder: @escaping BuiltInSummarizationBuilder = { _, _, _ in MissingSummarizationService() },
-        ollamaSummarizationBuilder: @escaping OllamaSummarizationBuilder = { _ in MissingSummarizationService() },
+        ollamaSummarizationBuilder: @escaping OllamaSummarizationBuilder = { _, _ in MissingSummarizationService() },
+        lmStudioSummarizationBuilder: @escaping LMStudioSummarizationBuilder = { _, _ in MissingSummarizationService() },
         builtInVisionBuilder: @escaping BuiltInVisionBuilder = { _ in MissingScreenContextInferenceService() },
-        ollamaVisionBuilder: @escaping OllamaVisionBuilder = { _ in MissingScreenContextInferenceService() },
-        ollamaModelDiscoverer: (any OllamaModelDiscovering)? = nil
+        ollamaVisionBuilder: @escaping OllamaVisionBuilder = { _, _ in MissingScreenContextInferenceService() },
+        lmStudioVisionBuilder: @escaping LMStudioVisionBuilder = { _, _ in MissingScreenContextInferenceService() },
+        ollamaModelDiscoverer: (any OllamaModelDiscovering)? = nil,
+        lmStudioModelDiscoverer: (any LMStudioModelDiscovering)? = nil
     ) {
         self.providerStore = providerStore
+        self.connectionStore = connectionStore
         self.summarizationModelStore = summarizationModelStore
         self.summarizationContextWindowStore = summarizationContextWindowStore
         self.visionModelStore = visionModelStore
@@ -45,9 +51,12 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
         self.dateProvider = dateProvider
         self.builtInSummarizationBuilder = builtInSummarizationBuilder
         self.ollamaSummarizationBuilder = ollamaSummarizationBuilder
+        self.lmStudioSummarizationBuilder = lmStudioSummarizationBuilder
         self.builtInVisionBuilder = builtInVisionBuilder
         self.ollamaVisionBuilder = ollamaVisionBuilder
+        self.lmStudioVisionBuilder = lmStudioVisionBuilder
         self.ollamaModelDiscoverer = ollamaModelDiscoverer
+        self.lmStudioModelDiscoverer = lmStudioModelDiscoverer
     }
 
     public func resolveBinding(for capability: InferenceCapability) throws -> InferenceTaskBinding {
@@ -59,6 +68,7 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
                 capabilityID: capability,
                 providerID: provider,
                 providerReference: model.id,
+                connectionBaseURLString: nil,
                 capturedAt: dateProvider(),
                 supportsVisionInputs: false
             )
@@ -71,6 +81,7 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
                 capabilityID: capability,
                 providerID: provider,
                 providerReference: model.id,
+                connectionBaseURLString: nil,
                 capturedAt: dateProvider(),
                 supportsVisionInputs: true
             )
@@ -82,6 +93,19 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
                 capabilityID: capability,
                 providerID: provider,
                 providerReference: tag,
+                connectionBaseURLString: connectionStore.selectedBaseURLString(for: .ollama),
+                capturedAt: dateProvider(),
+                supportsVisionInputs: capability == .vision
+            )
+        case (_, .lmStudio):
+            guard let identifier = providerStore.selectedLMStudioModelIdentifier(for: capability), !identifier.isEmpty else {
+                throw MinuteError.modelMissing
+            }
+            return InferenceTaskBinding(
+                capabilityID: capability,
+                providerID: provider,
+                providerReference: identifier,
+                connectionBaseURLString: connectionStore.selectedBaseURLString(for: .lmStudio),
                 capturedAt: dateProvider(),
                 supportsVisionInputs: capability == .vision
             )
@@ -105,7 +129,9 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
                 hardwareProfileProvider()
             )
         case .ollama:
-            return ollamaSummarizationBuilder(binding.providerReference)
+            return ollamaSummarizationBuilder(binding.providerReference, resolvedConnectionURL(for: binding))
+        case .lmStudio:
+            return lmStudioSummarizationBuilder(binding.providerReference, resolvedConnectionURL(for: binding))
         }
     }
 
@@ -122,7 +148,9 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
         case .builtIn:
             return builtInVisionBuilder(visionModelStore)
         case .ollama:
-            return ollamaVisionBuilder(binding.providerReference)
+            return ollamaVisionBuilder(binding.providerReference, resolvedConnectionURL(for: binding))
+        case .lmStudio:
+            return lmStudioVisionBuilder(binding.providerReference, resolvedConnectionURL(for: binding))
         }
     }
 
@@ -135,7 +163,7 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
                 ),
                 reservedOutputTokens: 1_024
             )
-        case .ollama:
+        case .ollama, .lmStudio:
             return .default
         }
     }
@@ -197,6 +225,44 @@ public struct InferenceRuntimeFactory: Sendable, CapabilityAvailabilityProviding
                 )
             }
             return try await ollamaModelDiscoverer.validateModelTag(trimmedTag, for: capability)
+        case (_, .lmStudio):
+            let trimmedIdentifier = providerStore.selectedLMStudioModelIdentifier(for: capability)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !trimmedIdentifier.isEmpty else {
+                return CapabilityAvailabilityState(
+                    capabilityID: capability,
+                    providerID: provider,
+                    isReady: false,
+                    status: .needsConfiguration,
+                    message: "Choose an LM Studio model for \(capability.displayName.lowercased()).",
+                    selectedReference: nil
+                )
+            }
+            guard let lmStudioModelDiscoverer else {
+                return CapabilityAvailabilityState(
+                    capabilityID: capability,
+                    providerID: provider,
+                    isReady: false,
+                    status: .unknown,
+                    message: "LM Studio validation is unavailable.",
+                    selectedReference: trimmedIdentifier
+                )
+            }
+            return try await lmStudioModelDiscoverer.validateModelIdentifier(trimmedIdentifier, for: capability)
+        }
+    }
+
+    private func resolvedConnectionURL(for binding: InferenceTaskBinding) -> URL? {
+        if let connectionBaseURLString = binding.connectionBaseURLString,
+           let url = URL(string: connectionBaseURLString) {
+            return url
+        }
+
+        switch binding.providerID {
+        case .builtIn:
+            return nil
+        case .ollama, .lmStudio:
+            return connectionStore.selectedBaseURL(for: binding.providerID)
         }
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Services/OllamaEndpointSettingsStore.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/OllamaEndpointSettingsStore.swift
@@ -16,7 +16,7 @@ public final class OllamaEndpointSettingsStore: @unchecked Sendable {
     }
 
     public func selectedBaseURLString() -> String {
-        AppConfiguration.validatedOllamaBaseURL(
+        AppConfiguration.validatedLocalServerBaseURL(
             defaults.string(forKey: key),
             fallback: defaultBaseURLString
         )
@@ -27,7 +27,7 @@ public final class OllamaEndpointSettingsStore: @unchecked Sendable {
     }
 
     public func setSelectedBaseURLString(_ value: String?) {
-        let normalized = AppConfiguration.validatedOllamaBaseURL(value, fallback: defaultBaseURLString)
+        let normalized = AppConfiguration.validatedLocalServerBaseURL(value, fallback: defaultBaseURLString)
         if normalized == defaultBaseURLString {
             defaults.removeObject(forKey: key)
         } else {

--- a/MinuteCore/Sources/MinuteCore/Services/ProviderConnectionSettingsStore.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ProviderConnectionSettingsStore.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public final class ProviderConnectionSettingsStore: @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let keys: [InferenceProvider: String]
+    private let defaultBaseURLStrings: [InferenceProvider: String]
+
+    public init(
+        defaults: UserDefaults = .standard,
+        keys: [InferenceProvider: String] = [
+            .ollama: AppConfiguration.Defaults.ollamaBaseURLKey,
+            .lmStudio: AppConfiguration.Defaults.lmStudioBaseURLKey,
+        ],
+        defaultBaseURLStrings: [InferenceProvider: String] = [
+            .ollama: AppConfiguration.Defaults.defaultOllamaBaseURL,
+            .lmStudio: AppConfiguration.Defaults.defaultLMStudioBaseURL,
+        ]
+    ) {
+        self.defaults = defaults
+        self.keys = keys
+        self.defaultBaseURLStrings = defaultBaseURLStrings
+    }
+
+    public func selectedBaseURLString(for provider: InferenceProvider) -> String {
+        let fallback = defaultBaseURLStrings[provider] ?? AppConfiguration.Defaults.defaultOllamaBaseURL
+        guard let key = keys[provider] else { return fallback }
+        return AppConfiguration.validatedLocalServerBaseURL(
+            defaults.string(forKey: key),
+            fallback: fallback
+        )
+    }
+
+    public func selectedBaseURL(for provider: InferenceProvider) -> URL? {
+        URL(string: selectedBaseURLString(for: provider))
+    }
+
+    public func setSelectedBaseURLString(_ value: String?, for provider: InferenceProvider) {
+        guard let key = keys[provider] else { return }
+        let fallback = defaultBaseURLStrings[provider] ?? AppConfiguration.Defaults.defaultOllamaBaseURL
+        let normalized = AppConfiguration.validatedLocalServerBaseURL(value, fallback: fallback)
+        if normalized == fallback {
+            defaults.removeObject(forKey: key)
+        } else {
+            defaults.set(normalized, forKey: key)
+        }
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift
@@ -176,6 +176,8 @@ private final class ScreenContextCaptureSession: @unchecked Sendable {
     private var captureTask: Task<Void, Never>?
     private var firstTimestampSeconds: Double?
     private var closedWindowTitlesNotified: Set<String> = []
+    private let terminalInferenceFailureLock = NSLock()
+    private var hasTerminalInferenceFailure = false
 
     private init(
         sources: [ScreenContextCaptureSource],
@@ -277,8 +279,11 @@ private final class ScreenContextCaptureSession: @unchecked Sendable {
     }
 
     private func captureOnce() async {
+        guard !didEncounterTerminalInferenceFailure() else { return }
+
         for source in sources {
             if Task.isCancelled { return }
+            if didEncounterTerminalInferenceFailure() { return }
             if statusReporter.snapshot().isInferenceRunning {
                 statusReporter.markSkipped()
                 continue
@@ -340,6 +345,19 @@ private final class ScreenContextCaptureSession: @unchecked Sendable {
                         )
                         await collector.append(event)
                     } catch {
+                        if let message = ScreenContextInferenceFailurePolicy.terminalMessage(for: error) {
+                            if reportTerminalInferenceFailureIfNeeded() {
+                                logger.error("Screen inference disabled after terminal failure: \(message, privacy: .public)")
+                                lifecycleEventHandler?(
+                                    ScreenContextLifecycleEvent(
+                                        type: .inferenceUnavailable,
+                                        windowTitle: windowTitle,
+                                        message: message
+                                    )
+                                )
+                            }
+                            return
+                        }
                         logger.error("Screen inference failed: \(ErrorHandler.debugMessage(for: error), privacy: .public)")
                     }
                 }
@@ -365,6 +383,22 @@ private final class ScreenContextCaptureSession: @unchecked Sendable {
                 windowTitle: windowTitle
             )
         )
+    }
+
+    private func didEncounterTerminalInferenceFailure() -> Bool {
+        terminalInferenceFailureLock.lock()
+        defer { terminalInferenceFailureLock.unlock() }
+        return hasTerminalInferenceFailure
+    }
+
+    private func reportTerminalInferenceFailureIfNeeded() -> Bool {
+        terminalInferenceFailureLock.lock()
+        defer { terminalInferenceFailureLock.unlock() }
+
+        guard !hasTerminalInferenceFailure else { return false }
+        hasTerminalInferenceFailure = true
+        captureTask?.cancel()
+        return true
     }
 
     fileprivate static func captureImageData(for window: SCWindow) async throws -> Data {

--- a/MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift
@@ -347,7 +347,10 @@ private final class ScreenContextCaptureSession: @unchecked Sendable {
                     } catch {
                         if let message = ScreenContextInferenceFailurePolicy.terminalMessage(for: error) {
                             if reportTerminalInferenceFailureIfNeeded() {
-                                logger.error("Screen inference disabled after terminal failure: \(message, privacy: .public)")
+                                let clippedMessage = String(message.prefix(240))
+                                logger.error(
+                                    "Screen inference disabled after terminal failure: \(clippedMessage, privacy: .private(mask: .hash))"
+                                )
                                 lifecycleEventHandler?(
                                     ScreenContextLifecycleEvent(
                                         type: .inferenceUnavailable,

--- a/MinuteCore/Sources/MinuteCore/Services/ScreenContextVideoFrameExtractor.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ScreenContextVideoFrameExtractor.swift
@@ -95,7 +95,10 @@ public final class ScreenContextVideoFrameExtractor: @unchecked Sendable {
                 processedCount += 1
             } catch {
                 if let terminalFailureMessage = ScreenContextInferenceFailurePolicy.terminalMessage(for: error) {
-                    logger.error("Video screen inference disabled after terminal failure: \(terminalFailureMessage, privacy: .public)")
+                    let clippedMessage = String(terminalFailureMessage.prefix(240))
+                    logger.error(
+                        "Video screen inference disabled after terminal failure: \(clippedMessage, privacy: .private(mask: .hash))"
+                    )
                     events.sort { $0.timestampSeconds < $1.timestampSeconds }
                     return ScreenContextVideoInferenceResult(
                         events: events,

--- a/MinuteCore/Sources/MinuteCore/Services/ScreenContextVideoFrameExtractor.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ScreenContextVideoFrameExtractor.swift
@@ -6,10 +6,16 @@ import os
 public struct ScreenContextVideoInferenceResult: Sendable, Equatable {
     public var events: [ScreenContextEvent]
     public var processedCount: Int
+    public var terminalFailureMessage: String?
 
-    public init(events: [ScreenContextEvent], processedCount: Int) {
+    public init(
+        events: [ScreenContextEvent],
+        processedCount: Int,
+        terminalFailureMessage: String? = nil
+    ) {
         self.events = events
         self.processedCount = processedCount
+        self.terminalFailureMessage = terminalFailureMessage
     }
 }
 
@@ -88,6 +94,15 @@ public final class ScreenContextVideoFrameExtractor: @unchecked Sendable {
                 }
                 processedCount += 1
             } catch {
+                if let terminalFailureMessage = ScreenContextInferenceFailurePolicy.terminalMessage(for: error) {
+                    logger.error("Video screen inference disabled after terminal failure: \(terminalFailureMessage, privacy: .public)")
+                    events.sort { $0.timestampSeconds < $1.timestampSeconds }
+                    return ScreenContextVideoInferenceResult(
+                        events: events,
+                        processedCount: processedCount,
+                        terminalFailureMessage: terminalFailureMessage
+                    )
+                }
                 logger.error("Video frame inference failed: \(ErrorHandler.debugMessage(for: error), privacy: .public)")
             }
 

--- a/MinuteCore/Sources/MinuteCore/Services/ServiceProtocols.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ServiceProtocols.swift
@@ -350,6 +350,16 @@ public protocol ScreenContextInferencing: Sendable {
     func inferScreenContext(from imageData: Data, windowTitle: String) async throws -> ScreenContextInference
 }
 
+public protocol OllamaModelDiscovering: Sendable {
+    func discoverModels() async throws -> OllamaDiscoverySnapshot
+    func validateModelTag(_ tag: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState
+}
+
+public protocol LMStudioModelDiscovering: Sendable {
+    func discoverModels() async throws -> LMStudioDiscoverySnapshot
+    func validateModelIdentifier(_ identifier: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState
+}
+
 public protocol CapabilityAvailabilityProviding: Sendable {
     func availability(for capability: InferenceCapability) async throws -> CapabilityAvailabilityState
 }

--- a/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
+++ b/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
@@ -440,7 +440,7 @@ private extension LMStudioAPIClient {
             let explicitSupportsVision = try container.decodeIfPresent(Bool.self, forKey: DynamicCodingKey("supports_vision"))
             let capabilities = try container.decodeIfPresent([String].self, forKey: DynamicCodingKey("capabilities")) ?? []
             supportsVision = explicitSupportsVision
-                ?? modelType.caseInsensitiveCompare("vlm") == .orderedSame
+                ?? (modelType.caseInsensitiveCompare("vlm") == .orderedSame)
                 || capabilities.contains(where: { $0.caseInsensitiveCompare("vision") == .orderedSame })
         }
     }

--- a/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
+++ b/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
@@ -1,5 +1,8 @@
+import CoreGraphics
 import Foundation
+import ImageIO
 import MinuteCore
+import UniformTypeIdentifiers
 
 public struct LMStudioAPIClient: Sendable {
     public struct ChatMessage: Sendable, Encodable {
@@ -196,6 +199,20 @@ public struct LMStudioAPIClient: Sendable {
                     selectedReference: trimmedIdentifier
                 )
             }
+            if capability == .vision {
+                do {
+                    try await probeVisionInputSupport(modelIdentifier: trimmedIdentifier)
+                } catch let error as LMStudioRequestError {
+                    return CapabilityAvailabilityState(
+                        capabilityID: capability,
+                        providerID: .lmStudio,
+                        isReady: false,
+                        status: .visionUnsupported,
+                        message: visionProbeFailureMessage(from: error.message),
+                        selectedReference: trimmedIdentifier
+                    )
+                }
+            }
 
             return CapabilityAvailabilityState(
                 capabilityID: capability,
@@ -281,6 +298,44 @@ private extension LMStudioAPIClient {
         }
     }
 
+    struct ErrorResponse: Decodable {
+        enum ErrorValue: Decodable {
+            case string(String)
+            case object(Detail)
+
+            struct Detail: Decodable {
+                var message: String?
+                var code: String?
+                var type: String?
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                if let value = try? container.decode(String.self) {
+                    self = .string(value)
+                } else {
+                    self = .object(try container.decode(Detail.self))
+                }
+            }
+
+            var resolvedMessage: String? {
+                switch self {
+                case .string(let value):
+                    return value
+                case .object(let detail):
+                    return detail.message ?? detail.code ?? detail.type
+                }
+            }
+        }
+
+        var error: ErrorValue?
+        var message: String?
+
+        var resolvedMessage: String? {
+            error?.resolvedMessage ?? message
+        }
+    }
+
     func performChatCompletion(
         modelIdentifier: String,
         messages: [ChatMessage],
@@ -311,6 +366,29 @@ private extension LMStudioAPIClient {
             throw LMStudioRequestError.requestFailed(statusCode: -1, message: "LM Studio returned an empty response")
         }
         return output
+    }
+
+    func probeVisionInputSupport(modelIdentifier: String) async throws {
+        let response = try await performChatCompletion(
+            modelIdentifier: modelIdentifier,
+            messages: [
+                ChatMessage(
+                    role: "user",
+                    content: [
+                        .text("Reply with OK."),
+                        .imageDataURL(Self.visionProbeImageDataURL)
+                    ]
+                )
+            ],
+            maxTokens: 8
+        )
+
+        guard !response.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw LMStudioRequestError.requestFailed(
+                statusCode: -1,
+                message: "LM Studio returned an empty response for image input."
+            )
+        }
     }
 
     struct ChatCompletionResponse: Decodable {
@@ -494,7 +572,7 @@ private extension LMStudioAPIClient {
             }
 
             guard (200..<300).contains(httpResponse.statusCode) else {
-                let message = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
+                let message = decodedErrorMessage(from: data) ?? String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
                 if httpResponse.statusCode == 404 {
                     throw LMStudioRequestError.notFound
                 }
@@ -520,6 +598,71 @@ private extension LMStudioAPIClient {
         components.percentEncodedPath = "/" + joinedPath
         return components.url ?? baseURL.appendingPathComponent(normalizedPath)
     }
+
+    func decodedErrorMessage(from data: Data) -> String? {
+        guard !data.isEmpty else { return nil }
+        let decoded = try? JSONDecoder().decode(ErrorResponse.self, from: data)
+        return decoded?.resolvedMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func visionProbeFailureMessage(from backendMessage: String) -> String {
+        let trimmedMessage = backendMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedMessage.isEmpty else {
+            return "Selected LM Studio model could not process image input. Load the model in LM Studio or choose another vision-capable model."
+        }
+
+        return "Selected LM Studio model could not process image input. Load the model in LM Studio or choose another vision-capable model. LM Studio reported: \(trimmedMessage)"
+    }
+
+    static var visionProbeImageDataURL: String {
+        "data:image/png;base64,\(visionProbeImageBase64)"
+    }
+
+    private static let visionProbeImageBase64: String = {
+        let size = CGSize(width: 800, height: 600)
+        let bytesPerRow = Int(size.width) * 4
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                data: nil,
+                width: Int(size.width),
+                height: Int(size.height),
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            return ""
+        }
+
+        context.setFillColor(red: 1, green: 1, blue: 1, alpha: 1)
+        context.fill(CGRect(origin: .zero, size: size))
+        context.setFillColor(red: 0.85, green: 0.9, blue: 0.95, alpha: 1)
+        context.fill(CGRect(x: 48, y: 56, width: 704, height: 120))
+        context.fill(CGRect(x: 48, y: 216, width: 520, height: 36))
+        context.fill(CGRect(x: 48, y: 276, width: 612, height: 36))
+        context.fill(CGRect(x: 48, y: 336, width: 468, height: 36))
+
+        guard let image = context.makeImage() else {
+            return ""
+        }
+
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return ""
+        }
+
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return ""
+        }
+
+        return Data(referencing: data).base64EncodedString()
+    }()
 }
 
 private extension CharacterSet {

--- a/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
+++ b/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
@@ -1,0 +1,546 @@
+import Foundation
+import MinuteCore
+
+public struct LMStudioAPIClient: Sendable {
+    public struct ChatMessage: Sendable, Encodable {
+        public struct ContentPart: Sendable, Encodable {
+            public var type: String
+            public var text: String?
+            public var imageURL: ImageURL?
+
+            public struct ImageURL: Sendable, Encodable {
+                public var url: String
+
+                public init(url: String) {
+                    self.url = url
+                }
+            }
+
+            public init(type: String, text: String? = nil, imageURL: ImageURL? = nil) {
+                self.type = type
+                self.text = text
+                self.imageURL = imageURL
+            }
+
+            public static func text(_ value: String) -> Self {
+                Self(type: "text", text: value)
+            }
+
+            public static func imageDataURL(_ value: String) -> Self {
+                Self(type: "image_url", imageURL: ImageURL(url: value))
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case type
+                case text
+                case imageURL = "image_url"
+            }
+        }
+
+        public var role: String
+        public var content: [ContentPart]
+
+        public init(role: String, content: [ContentPart]) {
+            self.role = role
+            self.content = content
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case role
+            case content
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(role, forKey: .role)
+            if content.count == 1,
+               let first = content.first,
+               first.type == "text",
+               let text = first.text,
+               first.imageURL == nil {
+                try container.encode(text, forKey: .content)
+            } else {
+                try container.encode(content, forKey: .content)
+            }
+        }
+    }
+
+    public var baseURL: URL
+    private let session: URLSession
+
+    public init(
+        baseURL: URL = URL(string: AppConfiguration.Defaults.defaultLMStudioBaseURL)!,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func listLocalModels() async throws -> LMStudioDiscoverySnapshot {
+        do {
+            let response = try await decodeRequest(
+                path: "api/v0/models",
+                method: "GET",
+                body: Optional<Data>.none,
+                as: ModelListResponse.self
+            )
+
+            return LMStudioDiscoverySnapshot(
+                serverReachable: true,
+                models: response.models
+                    .map(\.descriptor)
+                    .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+            )
+        } catch {
+            return LMStudioDiscoverySnapshot(
+                serverReachable: false,
+                failureReason: "LM Studio is unavailable. Start the local server and refresh."
+            )
+        }
+    }
+
+    public func complete(
+        modelIdentifier: String,
+        systemPrompt: String?,
+        prompt: String,
+        maxTokens: Int
+    ) async throws -> String {
+        var messages: [ChatMessage] = []
+        if let systemPrompt, !systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            messages.append(ChatMessage(role: "system", content: [.text(systemPrompt)]))
+        }
+        messages.append(ChatMessage(role: "user", content: [.text(prompt)]))
+        do {
+            return try await performChatCompletion(
+                modelIdentifier: modelIdentifier,
+                messages: messages,
+                maxTokens: maxTokens
+            )
+        } catch let error as MinuteError {
+            throw error
+        } catch let error as LMStudioRequestError {
+            throw MinuteError.llamaFailed(
+                exitCode: Int32(error.statusCode),
+                output: error.message
+            )
+        } catch {
+            throw MinuteError.llamaFailed(
+                exitCode: -1,
+                output: ErrorHandler.debugMessage(for: error)
+            )
+        }
+    }
+
+    public func chat(
+        modelIdentifier: String,
+        messages: [ChatMessage],
+        maxTokens: Int
+    ) async throws -> String {
+        do {
+            return try await performChatCompletion(
+                modelIdentifier: modelIdentifier,
+                messages: messages,
+                maxTokens: maxTokens
+            )
+        } catch let error as MinuteError {
+            throw error
+        } catch let error as LMStudioRequestError {
+            throw MinuteError.llamaMTMDFailed(
+                exitCode: Int32(error.statusCode),
+                output: error.message
+            )
+        } catch {
+            throw MinuteError.llamaMTMDFailed(
+                exitCode: -1,
+                output: ErrorHandler.debugMessage(for: error)
+            )
+        }
+    }
+
+    public func validateModelIdentifier(
+        _ identifier: String,
+        for capability: InferenceCapability
+    ) async throws -> CapabilityAvailabilityState {
+        let trimmedIdentifier = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedIdentifier.isEmpty else {
+            return CapabilityAvailabilityState(
+                capabilityID: capability,
+                providerID: .lmStudio,
+                isReady: false,
+                status: .needsConfiguration,
+                message: "Choose an LM Studio model for \(capability.displayName.lowercased()).",
+                selectedReference: nil
+            )
+        }
+
+        do {
+            let model = try await fetchModelRecord(identifier: trimmedIdentifier)
+            let descriptor = model.descriptor
+            if descriptor.modelType.caseInsensitiveCompare("embeddings") == .orderedSame {
+                return CapabilityAvailabilityState(
+                    capabilityID: capability,
+                    providerID: .lmStudio,
+                    isReady: false,
+                    status: .unsupported,
+                    message: "Selected LM Studio model does not support text generation.",
+                    selectedReference: trimmedIdentifier
+                )
+            }
+            if capability == .vision && !descriptor.supportsVision {
+                return CapabilityAvailabilityState(
+                    capabilityID: capability,
+                    providerID: .lmStudio,
+                    isReady: false,
+                    status: .visionUnsupported,
+                    message: "Selected LM Studio model does not advertise vision support.",
+                    selectedReference: trimmedIdentifier
+                )
+            }
+
+            return CapabilityAvailabilityState(
+                capabilityID: capability,
+                providerID: .lmStudio,
+                isReady: true,
+                status: .ready,
+                message: "Using local LM Studio model \(descriptor.displayName).",
+                selectedReference: trimmedIdentifier
+            )
+        } catch let error as LMStudioRequestError {
+            switch error {
+            case .notFound:
+                return CapabilityAvailabilityState(
+                    capabilityID: capability,
+                    providerID: .lmStudio,
+                    isReady: false,
+                    status: .modelMissing,
+                    message: "Selected LM Studio model is not available in the local server. Load it in LM Studio first.",
+                    selectedReference: trimmedIdentifier
+                )
+            case .requestFailed:
+                return CapabilityAvailabilityState(
+                    capabilityID: capability,
+                    providerID: .lmStudio,
+                    isReady: false,
+                    status: .serverUnavailable,
+                    message: "LM Studio is unavailable. Start the local server and refresh.",
+                    selectedReference: trimmedIdentifier
+                )
+            }
+        } catch {
+            return CapabilityAvailabilityState(
+                capabilityID: capability,
+                providerID: .lmStudio,
+                isReady: false,
+                status: .serverUnavailable,
+                message: "LM Studio is unavailable. Start the local server and refresh.",
+                selectedReference: trimmedIdentifier
+            )
+        }
+    }
+}
+
+private extension LMStudioAPIClient {
+    enum LMStudioRequestError: Error {
+        case notFound
+        case requestFailed(statusCode: Int, message: String)
+
+        var statusCode: Int {
+            switch self {
+            case .notFound:
+                return 404
+            case .requestFailed(let statusCode, _):
+                return statusCode
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .notFound:
+                return "LM Studio model not found"
+            case .requestFailed(_, let message):
+                return message
+            }
+        }
+    }
+
+    struct ChatCompletionRequest: Encodable {
+        var model: String
+        var messages: [ChatMessage]
+        var temperature: Double
+        var topP: Double
+        var maxTokens: Int
+        var seed: Int
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case messages
+            case temperature
+            case topP = "top_p"
+            case maxTokens = "max_tokens"
+            case seed
+        }
+    }
+
+    func performChatCompletion(
+        modelIdentifier: String,
+        messages: [ChatMessage],
+        maxTokens: Int
+    ) async throws -> String {
+        let trimmedModelIdentifier = modelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedModelIdentifier.isEmpty else {
+            throw MinuteError.modelMissing
+        }
+
+        let requestBody = ChatCompletionRequest(
+            model: trimmedModelIdentifier,
+            messages: messages,
+            temperature: 0.2,
+            topP: 0.9,
+            maxTokens: maxTokens,
+            seed: 42
+        )
+        let data = try JSONEncoder().encode(requestBody)
+        let response = try await decodeRequest(
+            path: "v1/chat/completions",
+            method: "POST",
+            body: data,
+            as: ChatCompletionResponse.self
+        )
+
+        guard let output = response.resolvedOutput else {
+            throw LMStudioRequestError.requestFailed(statusCode: -1, message: "LM Studio returned an empty response")
+        }
+        return output
+    }
+
+    struct ChatCompletionResponse: Decodable {
+        struct Choice: Decodable {
+            struct Message: Decodable {
+                enum ContentValue: Decodable {
+                    case string(String)
+                    case parts([ContentPart])
+
+                    struct ContentPart: Decodable {
+                        var type: String?
+                        var text: String?
+                    }
+
+                    init(from decoder: Decoder) throws {
+                        let container = try decoder.singleValueContainer()
+                        if let value = try? container.decode(String.self) {
+                            self = .string(value)
+                        } else {
+                            self = .parts(try container.decode([ContentPart].self))
+                        }
+                    }
+                }
+
+                var content: ContentValue?
+            }
+
+            var message: Message
+        }
+
+        var choices: [Choice]
+
+        var resolvedOutput: String? {
+            for choice in choices {
+                switch choice.message.content {
+                case .string(let value):
+                    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        return trimmed
+                    }
+                case .parts(let parts):
+                    let text = parts.compactMap(\.text).joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !text.isEmpty {
+                        return text
+                    }
+                case .none:
+                    continue
+                }
+            }
+            return nil
+        }
+    }
+
+    struct ModelListResponse: Decodable {
+        var models: [ModelRecord]
+
+        init(from decoder: Decoder) throws {
+            if let container = try? decoder.singleValueContainer(),
+               let models = try? container.decode([ModelRecord].self) {
+                self.models = models
+                return
+            }
+
+            let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+            self.models = try container.decodeIfPresent([ModelRecord].self, forKey: DynamicCodingKey("data"))
+                ?? container.decodeIfPresent([ModelRecord].self, forKey: DynamicCodingKey("models"))
+                ?? []
+        }
+    }
+
+    struct ModelRecord: Decodable {
+        var identifier: String
+        var displayName: String
+        var modelType: String
+        var publisher: String?
+        var architecture: String?
+        var compatibilityType: String?
+        var quantizationLabel: String?
+        var state: String?
+        var maxContextLength: Int?
+        var supportsVision: Bool
+
+        var descriptor: LMStudioModelDescriptor {
+            LMStudioModelDescriptor(
+                identifier: identifier,
+                displayName: displayName,
+                modelType: modelType,
+                publisher: publisher,
+                architecture: architecture,
+                compatibilityType: compatibilityType,
+                quantizationLabel: quantizationLabel,
+                state: state,
+                maxContextLength: maxContextLength,
+                supportsVision: supportsVision
+            )
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+
+            let identifier = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("id"))
+                ?? container.decodeIfPresent(String.self, forKey: DynamicCodingKey("model_id"))
+                ?? container.decodeIfPresent(String.self, forKey: DynamicCodingKey("path"))
+                ?? ""
+            self.identifier = identifier
+
+            let displayName = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("display_name"))
+                ?? container.decodeIfPresent(String.self, forKey: DynamicCodingKey("name"))
+                ?? identifier.components(separatedBy: "/").last
+                ?? identifier
+            self.displayName = displayName
+
+            let modelType = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("type"))
+                ?? container.decodeIfPresent(String.self, forKey: DynamicCodingKey("model_type"))
+                ?? "llm"
+            self.modelType = modelType
+
+            publisher = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("publisher"))
+            architecture = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("architecture"))
+                ?? container.decodeIfPresent(String.self, forKey: DynamicCodingKey("arch"))
+            compatibilityType = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("compatibility_type"))
+            quantizationLabel = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("quantization"))
+                ?? container.decodeIfPresent(String.self, forKey: DynamicCodingKey("quantization_label"))
+            state = try container.decodeIfPresent(String.self, forKey: DynamicCodingKey("state"))
+            maxContextLength = try container.decodeIfPresent(Int.self, forKey: DynamicCodingKey("max_context_length"))
+
+            let explicitSupportsVision = try container.decodeIfPresent(Bool.self, forKey: DynamicCodingKey("supports_vision"))
+            let capabilities = try container.decodeIfPresent([String].self, forKey: DynamicCodingKey("capabilities")) ?? []
+            supportsVision = explicitSupportsVision
+                ?? modelType.caseInsensitiveCompare("vlm") == .orderedSame
+                || capabilities.contains(where: { $0.caseInsensitiveCompare("vision") == .orderedSame })
+        }
+    }
+
+    func fetchModelRecord(identifier: String) async throws -> ModelRecord {
+        let encodedIdentifier = identifier.addingPercentEncoding(withAllowedCharacters: .urlPathSegmentAllowed)
+            ?? identifier
+        do {
+            return try await decodeRequest(
+                path: "api/v0/models/\(encodedIdentifier)",
+                method: "GET",
+                body: Optional<Data>.none,
+                as: ModelRecord.self
+            )
+        } catch let error as LMStudioRequestError {
+            switch error {
+            case .notFound:
+                throw error
+            case .requestFailed:
+                let models = try await decodeRequest(
+                    path: "api/v0/models",
+                    method: "GET",
+                    body: Optional<Data>.none,
+                    as: ModelListResponse.self
+                )
+                if let model = models.models.first(where: {
+                    $0.identifier.caseInsensitiveCompare(identifier) == .orderedSame
+                }) {
+                    return model
+                }
+                throw error
+            }
+        }
+    }
+
+    func decodeRequest<Response: Decodable>(
+        path: String,
+        method: String,
+        body: Data?,
+        as type: Response.Type
+    ) async throws -> Response {
+        var request = URLRequest(url: endpointURL(path: path))
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw LMStudioRequestError.requestFailed(statusCode: -1, message: "Invalid LM Studio response")
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                let message = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
+                if httpResponse.statusCode == 404 {
+                    throw LMStudioRequestError.notFound
+                }
+                throw LMStudioRequestError.requestFailed(statusCode: httpResponse.statusCode, message: message)
+            }
+
+            return try JSONDecoder().decode(type, from: data)
+        } catch let error as LMStudioRequestError {
+            throw error
+        } catch {
+            throw LMStudioRequestError.requestFailed(statusCode: -1, message: ErrorHandler.debugMessage(for: error))
+        }
+    }
+
+    func endpointURL(path: String) -> URL {
+        let normalizedPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        let basePath = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let joinedPath = ([basePath].filter { !$0.isEmpty } + [normalizedPath]).joined(separator: "/")
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+        components.scheme = components.scheme ?? baseURL.scheme
+        components.host = components.host ?? baseURL.host
+        components.port = components.port ?? baseURL.port
+        components.percentEncodedPath = "/" + joinedPath
+        return components.url ?? baseURL.appendingPathComponent(normalizedPath)
+    }
+}
+
+private extension CharacterSet {
+    static let urlPathSegmentAllowed = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
+}
+
+private struct DynamicCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init(_ stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(stringValue: String) {
+        self.init(stringValue)
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+}

--- a/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioModelDiscoveryService.swift
+++ b/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioModelDiscoveryService.swift
@@ -1,0 +1,21 @@
+import Foundation
+import MinuteCore
+
+public struct LMStudioModelDiscoveryService: LMStudioModelDiscovering {
+    public var client: LMStudioAPIClient
+
+    public init(client: LMStudioAPIClient = LMStudioAPIClient()) {
+        self.client = client
+    }
+
+    public func discoverModels() async throws -> LMStudioDiscoverySnapshot {
+        try await client.listLocalModels()
+    }
+
+    public func validateModelIdentifier(
+        _ identifier: String,
+        for capability: InferenceCapability
+    ) async throws -> CapabilityAvailabilityState {
+        try await client.validateModelIdentifier(identifier, for: capability)
+    }
+}

--- a/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioSummarizationService.swift
+++ b/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioSummarizationService.swift
@@ -1,0 +1,147 @@
+import Foundation
+import MinuteCore
+
+public struct LMStudioSummarizationService: SummarizationServicing {
+    public var maxTokens: Int
+    public var modelIdentifier: String
+    public var client: LMStudioAPIClient
+
+    public init(
+        modelIdentifier: String,
+        maxTokens: Int = 1_024,
+        client: LMStudioAPIClient = LMStudioAPIClient()
+    ) {
+        self.modelIdentifier = modelIdentifier
+        self.maxTokens = maxTokens
+        self.client = client
+    }
+
+    public func summarize(
+        transcript: String,
+        meetingDate: Date,
+        meetingType: MeetingType,
+        languageProcessing: LanguageProcessingProfile,
+        outputLanguage: OutputLanguage
+    ) async throws -> String {
+        try await summarize(
+            transcript: transcript,
+            meetingDate: meetingDate,
+            meetingType: meetingType,
+            languageProcessing: languageProcessing,
+            outputLanguage: outputLanguage,
+            resolvedPromptBundle: nil
+        )
+    }
+
+    public func summarize(
+        transcript: String,
+        meetingDate: Date,
+        meetingType: MeetingType,
+        languageProcessing: LanguageProcessingProfile,
+        outputLanguage: OutputLanguage,
+        resolvedPromptBundle: ResolvedPromptBundle?
+    ) async throws -> String {
+        let prompts = resolvedPrompts(
+            meetingType: meetingType,
+            languageProcessing: languageProcessing,
+            outputLanguage: outputLanguage,
+            resolvedPromptBundle: resolvedPromptBundle
+        )
+        return try await client.complete(
+            modelIdentifier: modelIdentifier,
+            systemPrompt: prompts.systemPrompt,
+            prompt: PromptFactory.userPrompt(
+                transcript: datedTranscript(transcript, meetingDate: meetingDate),
+                preamble: prompts.userPromptPreamble
+            ),
+            maxTokens: maxTokens
+        )
+    }
+
+    public func classify(transcript: String) async throws -> MeetingType {
+        let response = try await client.complete(
+            modelIdentifier: modelIdentifier,
+            systemPrompt: nil,
+            prompt: MeetingTypeClassifier.prompt(for: transcript),
+            maxTokens: 16
+        )
+        return MeetingTypeClassifier.parseResponse(response)
+    }
+
+    public func classify(
+        transcript: String,
+        candidates: [MeetingTypeClassifierCandidate],
+        fallbackTypeID: String
+    ) async throws -> String {
+        let fallbackLabel = candidates.first(where: { $0.typeId == fallbackTypeID })?.label ?? "General"
+        let response = try await client.complete(
+            modelIdentifier: modelIdentifier,
+            systemPrompt: nil,
+            prompt: MeetingTypeClassifier.prompt(
+                for: transcript,
+                candidates: candidates,
+                fallbackLabel: fallbackLabel
+            ),
+            maxTokens: 32
+        )
+        return MeetingTypeClassifier.parseResponse(
+            response,
+            candidates: candidates,
+            fallbackTypeID: fallbackTypeID
+        )
+    }
+
+    public func repairJSON(_ invalidJSON: String) async throws -> String {
+        try await client.complete(
+            modelIdentifier: modelIdentifier,
+            systemPrompt: nil,
+            prompt: repairPrompt(invalidJSON),
+            maxTokens: maxTokens
+        )
+    }
+}
+
+private extension LMStudioSummarizationService {
+    func resolvedPrompts(
+        meetingType: MeetingType,
+        languageProcessing: LanguageProcessingProfile,
+        outputLanguage: OutputLanguage,
+        resolvedPromptBundle: ResolvedPromptBundle?
+    ) -> (systemPrompt: String, userPromptPreamble: String) {
+        if let resolvedPromptBundle {
+            return (
+                systemPrompt: resolvedPromptBundle.systemPrompt,
+                userPromptPreamble: resolvedPromptBundle.userPromptPreamble
+            )
+        }
+
+        let strategy = PromptFactory.strategy(for: meetingType)
+        return (
+            systemPrompt: PromptFactory.systemPrompt(
+                strategy: strategy,
+                languageProcessing: languageProcessing,
+                outputLanguage: outputLanguage
+            ),
+            userPromptPreamble: PromptFactory.userPromptPreamble(
+                strategy: strategy,
+                languageProcessing: languageProcessing,
+                outputLanguage: outputLanguage
+            )
+        )
+    }
+
+    func datedTranscript(_ transcript: String, meetingDate: Date) -> String {
+        "Meeting Date: \(MinuteISODate.format(meetingDate))\n\n\(transcript)"
+    }
+
+    func repairPrompt(_ invalidJSON: String) -> String {
+        """
+        Repair the following invalid JSON so it becomes one valid JSON object.
+        Preserve the intended meaning.
+        Do not add markdown fences or commentary.
+
+        Invalid JSON:
+        \(invalidJSON)
+        """
+    }
+}

--- a/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioVisionInferenceService.swift
+++ b/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioVisionInferenceService.swift
@@ -1,0 +1,49 @@
+import Foundation
+import MinuteCore
+
+public struct LMStudioVisionInferenceService: ScreenContextInferencing {
+    public var maxTokens: Int
+    public var modelIdentifier: String
+    public var client: LMStudioAPIClient
+
+    public init(
+        modelIdentifier: String,
+        maxTokens: Int = 256,
+        client: LMStudioAPIClient = LMStudioAPIClient()
+    ) {
+        self.maxTokens = maxTokens
+        self.modelIdentifier = modelIdentifier
+        self.client = client
+    }
+
+    public func inferScreenContext(from imageData: Data, windowTitle: String) async throws -> ScreenContextInference {
+        let encodedImage = imageData.base64EncodedString()
+        let response = try await client.chat(
+            modelIdentifier: modelIdentifier,
+            messages: [
+                LMStudioAPIClient.ChatMessage(
+                    role: "user",
+                    content: [
+                        .text(prompt(for: windowTitle)),
+                        .imageDataURL("data:image/png;base64,\(encodedImage)"),
+                    ]
+                )
+            ],
+            maxTokens: maxTokens
+        )
+
+        return ScreenContextInference(text: response.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}
+
+private extension LMStudioVisionInferenceService {
+    func prompt(for windowTitle: String) -> String {
+        """
+        Analyze this screenshot from the window titled "\(windowTitle)".
+        Return a concise plain-text screen context summary for meeting notes.
+        Focus on agenda items, participant names, visible headings, and shared artifacts.
+        If nothing useful is visible, return an empty string.
+        Do not include markdown fences.
+        """
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/AppConfigurationTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/AppConfigurationTests.swift
@@ -25,9 +25,13 @@ struct AppConfigurationTests {
         )
         expectEqual(configuration.summarizationProviderID, AppConfiguration.Defaults.defaultSummarizationProviderID)
         expectEqual(configuration.summarizationOllamaModelTag, nil)
+        expectEqual(configuration.summarizationLMStudioModelIdentifier, nil)
+        expectEqual(configuration.ollamaBaseURL, AppConfiguration.Defaults.defaultOllamaBaseURL)
+        expectEqual(configuration.lmStudioBaseURL, AppConfiguration.Defaults.defaultLMStudioBaseURL)
         expectEqual(configuration.visionProviderID, AppConfiguration.Defaults.defaultVisionProviderID)
         expectEqual(configuration.visionBuiltInModelID, AppConfiguration.Defaults.defaultVisionBuiltInModelID)
         expectEqual(configuration.visionOllamaModelTag, nil)
+        expectEqual(configuration.visionLMStudioModelIdentifier, nil)
         expectEqual(
             configuration.micActivityNotificationsEnabled,
             AppConfiguration.Defaults.defaultMicActivityNotificationsEnabled
@@ -108,20 +112,24 @@ struct AppConfigurationTests {
     func defaults_normalizesInferenceConfiguration() {
         let defaults = makeDefaults()
         defaults.set("invalid", forKey: AppConfiguration.Defaults.summarizationProviderIDKey)
-        defaults.set("ollama", forKey: AppConfiguration.Defaults.visionProviderIDKey)
+        defaults.set("lmStudio", forKey: AppConfiguration.Defaults.visionProviderIDKey)
         defaults.set("   llama3.2-vision   ", forKey: AppConfiguration.Defaults.visionOllamaModelTagKey)
         defaults.set("   ", forKey: AppConfiguration.Defaults.summarizationOllamaModelTagKey)
+        defaults.set("   qwen2.5-vl-instruct   ", forKey: AppConfiguration.Defaults.visionLMStudioModelIdentifierKey)
         defaults.set("missing-model", forKey: AppConfiguration.Defaults.visionBuiltInModelIDKey)
         defaults.set("  http://192.168.1.20:11434  ", forKey: AppConfiguration.Defaults.ollamaBaseURLKey)
+        defaults.set("  http://127.0.0.1:1234  ", forKey: AppConfiguration.Defaults.lmStudioBaseURLKey)
 
         let configuration = AppConfiguration(defaults: defaults)
 
         expectEqual(configuration.summarizationProviderID, AppConfiguration.Defaults.defaultSummarizationProviderID)
-        expectEqual(configuration.visionProviderID, InferenceProvider.ollama.rawValue)
+        expectEqual(configuration.visionProviderID, InferenceProvider.lmStudio.rawValue)
         expectEqual(configuration.summarizationOllamaModelTag, nil)
         expectEqual(configuration.visionOllamaModelTag, "llama3.2-vision")
+        expectEqual(configuration.visionLMStudioModelIdentifier, "qwen2.5-vl-instruct")
         expectEqual(configuration.visionBuiltInModelID, AppConfiguration.Defaults.defaultVisionBuiltInModelID)
         expectEqual(configuration.ollamaBaseURL, "http://192.168.1.20:11434")
+        expectEqual(configuration.lmStudioBaseURL, "http://127.0.0.1:1234")
     }
 
     @Test
@@ -132,6 +140,16 @@ struct AppConfigurationTests {
         let configuration = AppConfiguration(defaults: defaults)
 
         expectEqual(configuration.ollamaBaseURL, AppConfiguration.Defaults.defaultOllamaBaseURL)
+    }
+
+    @Test
+    func defaults_fallsBackForInvalidLMStudioBaseURL() {
+        let defaults = makeDefaults()
+        defaults.set("not a url", forKey: AppConfiguration.Defaults.lmStudioBaseURLKey)
+
+        let configuration = AppConfiguration(defaults: defaults)
+
+        expectEqual(configuration.lmStudioBaseURL, AppConfiguration.Defaults.defaultLMStudioBaseURL)
     }
 
     private func makeDefaults() -> UserDefaults {

--- a/MinuteCore/Tests/MinuteCoreTests/DefaultModelManagerTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/DefaultModelManagerTests.swift
@@ -160,6 +160,27 @@ struct DefaultModelManagerTests {
     }
 
     @Test
+    func defaultRequiredModels_skipsBuiltInInferenceArtifactsWhenLMStudioOwnsBothCapabilities() {
+        let visionModel = SummarizationModelCatalog.all.first { $0.mmprojDestinationURL != nil } ?? SummarizationModelCatalog.defaultModel
+        let summarizationModel = SummarizationModelCatalog.defaultModel
+
+        let models = DefaultModelManager.defaultRequiredModels(
+            selectedSummarizationModelID: summarizationModel.id,
+            summarizationProvider: .lmStudio,
+            selectedVisionModelID: visionModel.id,
+            visionProvider: .lmStudio,
+            screenContextEnabled: true,
+            selectedTranscriptionModelID: "whisper/base",
+            transcriptionBackend: .whisper
+        )
+
+        #expect(!models.contains { $0.id == summarizationModel.id })
+        #expect(!models.contains { $0.id == visionModel.id })
+        #expect(!models.contains { $0.id == "\(visionModel.id)/mmproj" })
+        #expect(models.contains { $0.id == "whisper/base" })
+    }
+
+    @Test
     func validateModels_mergesFluidAudioVocabularyReadinessWhenFluidBackendSelected() async throws {
         let suite = "DefaultModelManagerTests.validateModels.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))

--- a/MinuteCore/Tests/MinuteCoreTests/FluidAudioASRVersionResolverTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/FluidAudioASRVersionResolverTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import MinuteCore
+
+struct FluidAudioASRVersionResolverTests {
+    @Test
+    func resolvesV2Key() {
+        #expect(FluidAudioASRVersionResolver.version(for: "v2") == .v2)
+    }
+
+    @Test
+    func resolvesTdtCtc110mAliases() {
+        #expect(FluidAudioASRVersionResolver.version(for: "tdtctc110m") == .tdtCtc110m)
+        #expect(FluidAudioASRVersionResolver.version(for: "tdt-ctc-110m") == .tdtCtc110m)
+        #expect(FluidAudioASRVersionResolver.version(for: "tdt_ctc_110m") == .tdtCtc110m)
+    }
+
+    @Test
+    func defaultsUnknownKeysToV3() {
+        #expect(FluidAudioASRVersionResolver.version(for: "unknown") == .v3)
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/InferenceProviderSelectionStoreTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/InferenceProviderSelectionStoreTests.swift
@@ -12,6 +12,8 @@ struct InferenceProviderSelectionStoreTests {
         #expect(store.selectedProvider(for: .vision) == .builtIn)
         #expect(store.selectedOllamaModelTag(for: .summarization) == nil)
         #expect(store.selectedOllamaModelTag(for: .vision) == nil)
+        #expect(store.selectedLMStudioModelIdentifier(for: .summarization) == nil)
+        #expect(store.selectedLMStudioModelIdentifier(for: .vision) == nil)
     }
 
     @Test
@@ -40,6 +42,22 @@ struct InferenceProviderSelectionStoreTests {
         store.setSelectedOllamaModelTag("   ", for: .vision)
         #expect(store.selectedOllamaModelTag(for: .vision) == nil)
         #expect(store.selectedOllamaModelTag(for: .summarization) == "llama3.2")
+    }
+
+    @Test
+    func persistsAndNormalizesLMStudioIdentifiersIndependently() {
+        let defaults = makeDefaults()
+        let store = InferenceProviderSelectionStore(defaults: defaults)
+
+        store.setSelectedLMStudioModelIdentifier("  qwen2.5-7b-instruct  ", for: .summarization)
+        store.setSelectedLMStudioModelIdentifier(" qwen2.5-vl ", for: .vision)
+
+        #expect(store.selectedLMStudioModelIdentifier(for: .summarization) == "qwen2.5-7b-instruct")
+        #expect(store.selectedLMStudioModelIdentifier(for: .vision) == "qwen2.5-vl")
+
+        store.setSelectedLMStudioModelIdentifier("  ", for: .vision)
+        #expect(store.selectedLMStudioModelIdentifier(for: .vision) == nil)
+        #expect(store.selectedLMStudioModelIdentifier(for: .summarization) == "qwen2.5-7b-instruct")
     }
 
     private func makeDefaults() -> UserDefaults {

--- a/MinuteCore/Tests/MinuteCoreTests/InferenceRuntimeFactoryTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/InferenceRuntimeFactoryTests.swift
@@ -31,13 +31,16 @@ struct InferenceRuntimeFactoryTests {
     func resolvesOllamaBindingsPerCapability() throws {
         let defaults = makeDefaults()
         let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        let connectionStore = ProviderConnectionSettingsStore(defaults: defaults)
         providerStore.setSelectedProvider(.ollama, for: .summarization)
         providerStore.setSelectedOllamaModelTag("phi4", for: .summarization)
         providerStore.setSelectedProvider(.ollama, for: .vision)
         providerStore.setSelectedOllamaModelTag("llava", for: .vision)
+        connectionStore.setSelectedBaseURLString("http://127.0.0.1:11434", for: .ollama)
 
         let factory = InferenceRuntimeFactory(
             providerStore: providerStore,
+            connectionStore: connectionStore,
             summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults),
             visionModelStore: VisionModelSelectionStore(defaults: defaults)
         )
@@ -47,9 +50,42 @@ struct InferenceRuntimeFactoryTests {
 
         #expect(summarization.providerID == .ollama)
         #expect(summarization.providerReference == "phi4")
+        #expect(summarization.connectionBaseURLString == "http://127.0.0.1:11434")
         #expect(summarization.supportsVisionInputs == false)
         #expect(vision.providerID == .ollama)
         #expect(vision.providerReference == "llava")
+        #expect(vision.connectionBaseURLString == "http://127.0.0.1:11434")
+        #expect(vision.supportsVisionInputs == true)
+    }
+
+    @Test
+    func resolvesLMStudioBindingsPerCapability() throws {
+        let defaults = makeDefaults()
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        let connectionStore = ProviderConnectionSettingsStore(defaults: defaults)
+        providerStore.setSelectedProvider(.lmStudio, for: .summarization)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-7b-instruct", for: .summarization)
+        providerStore.setSelectedProvider(.lmStudio, for: .vision)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-vl-7b", for: .vision)
+        connectionStore.setSelectedBaseURLString("http://127.0.0.1:1234", for: .lmStudio)
+
+        let factory = InferenceRuntimeFactory(
+            providerStore: providerStore,
+            connectionStore: connectionStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults),
+            visionModelStore: VisionModelSelectionStore(defaults: defaults)
+        )
+
+        let summarization = try factory.resolveBinding(for: .summarization)
+        let vision = try factory.resolveBinding(for: .vision)
+
+        #expect(summarization.providerID == .lmStudio)
+        #expect(summarization.providerReference == "qwen2.5-7b-instruct")
+        #expect(summarization.connectionBaseURLString == "http://127.0.0.1:1234")
+        #expect(summarization.supportsVisionInputs == false)
+        #expect(vision.providerID == .lmStudio)
+        #expect(vision.providerReference == "qwen2.5-vl-7b")
+        #expect(vision.connectionBaseURLString == "http://127.0.0.1:1234")
         #expect(vision.supportsVisionInputs == true)
     }
 
@@ -68,12 +104,13 @@ struct InferenceRuntimeFactoryTests {
             summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults),
             visionModelStore: VisionModelSelectionStore(defaults: defaults),
             builtInSummarizationBuilder: { _, _, _ in MissingSummarizationService() },
-            ollamaSummarizationBuilder: { tag in
+            ollamaSummarizationBuilder: { tag, baseURL in
                 #expect(tag == "phi4")
+                #expect(baseURL?.absoluteString == AppConfiguration.Defaults.defaultOllamaBaseURL)
                 return summarizationService
             },
             builtInVisionBuilder: { _ in visionService },
-            ollamaVisionBuilder: { _ in MissingScreenContextInferenceService() }
+            ollamaVisionBuilder: { _, _ in MissingScreenContextInferenceService() }
         )
 
         let resolvedSummarization = try factory.makeSummarizationService()
@@ -101,8 +138,9 @@ struct InferenceRuntimeFactoryTests {
                 #expect(store.selectedModel().id == summarizationStore.selectedModel().id)
                 return builtInService
             },
-            ollamaSummarizationBuilder: { tag in
+            ollamaSummarizationBuilder: { tag, baseURL in
                 #expect(tag == "phi4-mini")
+                #expect(baseURL?.absoluteString == AppConfiguration.Defaults.defaultOllamaBaseURL)
                 return ollamaService
             }
         )
@@ -141,8 +179,9 @@ struct InferenceRuntimeFactoryTests {
                 #expect(store.selectedModel().id == builtInVision.id)
                 return MissingScreenContextInferenceService()
             },
-            ollamaVisionBuilder: { tag in
+            ollamaVisionBuilder: { tag, baseURL in
                 #expect(tag == "llava:latest")
+                #expect(baseURL?.absoluteString == AppConfiguration.Defaults.defaultOllamaBaseURL)
                 return ollamaVisionService
             }
         )
@@ -205,6 +244,37 @@ struct InferenceRuntimeFactoryTests {
         #expect(discoverer.validatedTags.first?.1 == "phi4-mini")
     }
 
+    @Test
+    func availability_usesLMStudioValidatorForVisionCapability() async throws {
+        let defaults = makeDefaults()
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        providerStore.setSelectedProvider(.lmStudio, for: .vision)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-vl", for: .vision)
+        let discoverer = StubLMStudioModelDiscoverer(
+            validationState: CapabilityAvailabilityState(
+                capabilityID: .vision,
+                providerID: .lmStudio,
+                isReady: true,
+                status: .ready,
+                message: "Ready",
+                selectedReference: "qwen2.5-vl"
+            )
+        )
+        let factory = InferenceRuntimeFactory(
+            providerStore: providerStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults),
+            visionModelStore: VisionModelSelectionStore(defaults: defaults),
+            lmStudioModelDiscoverer: discoverer
+        )
+
+        let state = try await factory.availability(for: .vision)
+
+        #expect(state.status == .ready)
+        #expect(discoverer.validatedIdentifiers.count == 1)
+        #expect(discoverer.validatedIdentifiers.first?.0 == .vision)
+        #expect(discoverer.validatedIdentifiers.first?.1 == "qwen2.5-vl")
+    }
+
     private func makeDefaults() -> UserDefaults {
         let suiteName = "InferenceRuntimeFactoryTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -227,6 +297,24 @@ private final class StubOllamaModelDiscoverer: OllamaModelDiscovering, @unchecke
 
     func validateModelTag(_ tag: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState {
         validatedTags.append((capability, tag))
+        return validationState
+    }
+}
+
+private final class StubLMStudioModelDiscoverer: LMStudioModelDiscovering, @unchecked Sendable {
+    let validationState: CapabilityAvailabilityState
+    private(set) var validatedIdentifiers: [(InferenceCapability, String)] = []
+
+    init(validationState: CapabilityAvailabilityState) {
+        self.validationState = validationState
+    }
+
+    func discoverModels() async throws -> LMStudioDiscoverySnapshot {
+        LMStudioDiscoverySnapshot(serverReachable: true)
+    }
+
+    func validateModelIdentifier(_ identifier: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState {
+        validatedIdentifiers.append((capability, identifier))
         return validationState
     }
 }

--- a/MinuteCore/Tests/MinuteCoreTests/LMStudioAPIClientTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/LMStudioAPIClientTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+@testable import MinuteLMStudio
+
+@Suite(.serialized)
+struct LMStudioAPIClientTests {
+    @Test
+    func complete_usesChatCompletionsAndReturnsMessageContent() async throws {
+        let session = makeLMStudioClientSession { request in
+            #expect(request.url?.path == "/v1/chat/completions")
+            return .json(
+                #"""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "{\n  \"ok\": true\n}"
+                      }
+                    }
+                  ]
+                }
+                """#
+            )
+        }
+
+        let client = LMStudioAPIClient(
+            baseURL: URL(string: "http://127.0.0.1:1234")!,
+            session: session
+        )
+
+        let response = try await client.complete(
+            modelIdentifier: "qwen2.5-7b-instruct",
+            systemPrompt: "Return JSON.",
+            prompt: "Hello",
+            maxTokens: 64
+        )
+
+        #expect(response == "{\n  \"ok\": true\n}")
+    }
+
+    @Test
+    func chat_readsMultipartContentResponses() async throws {
+        let session = makeLMStudioClientSession { request in
+            #expect(request.url?.path == "/v1/chat/completions")
+            return .json(
+                #"""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": [
+                          { "type": "text", "text": "Visible answer" }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """#
+            )
+        }
+
+        let client = LMStudioAPIClient(
+            baseURL: URL(string: "http://127.0.0.1:1234")!,
+            session: session
+        )
+
+        let response = try await client.chat(
+            modelIdentifier: "qwen2.5-vl-7b",
+            messages: [.init(role: "user", content: [.text("Describe this image")])],
+            maxTokens: 64
+        )
+
+        #expect(response == "Visible answer")
+    }
+}
+
+private func makeLMStudioClientSession(
+    handler: @escaping @Sendable (URLRequest) throws -> LMStudioClientURLProtocolStub.Response
+) -> URLSession {
+    LMStudioClientURLProtocolStub.handler = handler
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [LMStudioClientURLProtocolStub.self]
+    return URLSession(configuration: configuration)
+}
+
+private final class LMStudioClientURLProtocolStub: URLProtocol, @unchecked Sendable {
+    enum Response {
+        case json(String)
+        case status(Int, String)
+    }
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> Response)?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            let response = try Self.handler?(request) ?? .status(500, #"{"error":"missing handler"}"#)
+            let payload: String
+            let statusCode: Int
+            switch response {
+            case .json(let body):
+                payload = body
+                statusCode = 200
+            case .status(let code, let body):
+                payload = body
+                statusCode = code
+            }
+
+            let httpResponse = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(payload.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/MinuteCore/Tests/MinuteCoreTests/LMStudioModelDiscoveryServiceTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/LMStudioModelDiscoveryServiceTests.swift
@@ -136,6 +136,107 @@ struct LMStudioModelDiscoveryServiceTests {
         #expect(state.status == .modelMissing)
         #expect(state.selectedReference == "missing-model")
     }
+
+    @Test
+    func validateModelIdentifier_rejectsVisionModelWhenImageProbeFails() async throws {
+        let session = makeLMStudioDiscoverySession { request in
+            switch request.url?.path {
+            case "/api/v0/models/qwen2.5-vl-7b-instruct":
+                return .json(
+                    #"""
+                    {
+                      "id": "qwen2.5-vl-7b-instruct",
+                      "object": "model",
+                      "type": "vlm",
+                      "publisher": "lmstudio-community",
+                      "arch": "qwen2_vl",
+                      "compatibility_type": "gguf",
+                      "quantization": "Q4_K_M",
+                      "state": "loaded",
+                      "max_context_length": 32768
+                    }
+                    """#
+                )
+            case "/v1/chat/completions":
+                return .status(
+                    400,
+                    #"""
+                    {
+                      "error": "Error in iterating prediction stream: ValueError: Number of image token positions (1450) does not match number of image features (448) for batch 0"
+                    }
+                    """#
+                )
+            default:
+                return .status(404, #"{"error":"not found"}"#)
+            }
+        }
+
+        let service = LMStudioModelDiscoveryService(
+            client: LMStudioAPIClient(
+                baseURL: URL(string: "http://127.0.0.1:1234")!,
+                session: session
+            )
+        )
+
+        let state = try await service.validateModelIdentifier("qwen2.5-vl-7b-instruct", for: .vision)
+
+        #expect(state.status == .visionUnsupported)
+        #expect(state.isReady == false)
+        #expect(state.message?.contains("could not process image input") == true)
+        #expect(state.message?.contains("Number of image token positions") == true)
+    }
+
+    @Test
+    func validateModelIdentifier_acceptsVisionModelWhenImageProbeSucceeds() async throws {
+        let session = makeLMStudioDiscoverySession { request in
+            switch request.url?.path {
+            case "/api/v0/models/qwen2.5-vl-7b-instruct":
+                return .json(
+                    #"""
+                    {
+                      "id": "qwen2.5-vl-7b-instruct",
+                      "object": "model",
+                      "type": "vlm",
+                      "publisher": "lmstudio-community",
+                      "arch": "qwen2_vl",
+                      "compatibility_type": "gguf",
+                      "quantization": "Q4_K_M",
+                      "state": "loaded",
+                      "max_context_length": 32768
+                    }
+                    """#
+                )
+            case "/v1/chat/completions":
+                return .json(
+                    #"""
+                    {
+                      "choices": [
+                        {
+                          "message": {
+                            "content": "OK"
+                          }
+                        }
+                      ]
+                    }
+                    """#
+                )
+            default:
+                return .status(404, #"{"error":"not found"}"#)
+            }
+        }
+
+        let service = LMStudioModelDiscoveryService(
+            client: LMStudioAPIClient(
+                baseURL: URL(string: "http://127.0.0.1:1234")!,
+                session: session
+            )
+        )
+
+        let state = try await service.validateModelIdentifier("qwen2.5-vl-7b-instruct", for: .vision)
+
+        #expect(state.status == .ready)
+        #expect(state.isReady)
+    }
 }
 
 private func makeLMStudioDiscoverySession(

--- a/MinuteCore/Tests/MinuteCoreTests/LMStudioModelDiscoveryServiceTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/LMStudioModelDiscoveryServiceTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+@testable import MinuteCore
+@testable import MinuteLMStudio
+
+@Suite(.serialized)
+struct LMStudioModelDiscoveryServiceTests {
+    @Test
+    func discoverModels_readsLocalInventoryAndVisionCapabilities() async throws {
+        let session = makeLMStudioDiscoverySession { request in
+            switch request.url?.path {
+            case "/api/v0/models":
+                return .json(
+                    #"""
+                    {
+                      "data": [
+                        {
+                          "id": "qwen2.5-vl-7b-instruct",
+                          "object": "model",
+                          "type": "vlm",
+                          "publisher": "lmstudio-community",
+                          "arch": "qwen2_vl",
+                          "compatibility_type": "gguf",
+                          "quantization": "Q4_K_M",
+                          "state": "not-loaded",
+                          "max_context_length": 32768
+                        },
+                        {
+                          "id": "qwen2.5-7b-instruct",
+                          "object": "model",
+                          "type": "llm",
+                          "publisher": "lmstudio-community",
+                          "arch": "qwen2",
+                          "compatibility_type": "gguf",
+                          "quantization": "Q4_K_M",
+                          "state": "loaded",
+                          "max_context_length": 131072
+                        }
+                      ]
+                    }
+                    """#
+                )
+            default:
+                Issue.record("Unexpected request: \(String(describing: request.url))")
+                return .status(404, #"{"error":"not found"}"#)
+            }
+        }
+
+        let service = LMStudioModelDiscoveryService(
+            client: LMStudioAPIClient(
+                baseURL: URL(string: "http://127.0.0.1:1234")!,
+                session: session
+            )
+        )
+
+        let snapshot = try await service.discoverModels()
+
+        #expect(snapshot.serverReachable)
+        #expect(snapshot.models.count == 2)
+        #expect(snapshot.models.first(where: { $0.identifier == "qwen2.5-7b-instruct" })?.supportsVision == false)
+        #expect(snapshot.models.first(where: { $0.identifier == "qwen2.5-vl-7b-instruct" })?.supportsVision == true)
+    }
+
+    @Test
+    func discoverModels_whenServerUnavailable_returnsUnavailableSnapshot() async throws {
+        let session = makeLMStudioDiscoverySession { _ in
+            throw URLError(.cannotConnectToHost)
+        }
+        let service = LMStudioModelDiscoveryService(
+            client: LMStudioAPIClient(
+                baseURL: URL(string: "http://127.0.0.1:1234")!,
+                session: session
+            )
+        )
+
+        let snapshot = try await service.discoverModels()
+
+        #expect(snapshot.serverReachable == false)
+        #expect(snapshot.models.isEmpty)
+        #expect(snapshot.failureReason != nil)
+    }
+
+    @Test
+    func validateModelIdentifier_rejectsVisionCapabilityWhenModelLacksVisionSupport() async throws {
+        let session = makeLMStudioDiscoverySession { request in
+            switch request.url?.path {
+            case "/api/v0/models/qwen2.5-7b-instruct":
+                return .json(
+                    #"""
+                    {
+                      "id": "qwen2.5-7b-instruct",
+                      "object": "model",
+                      "type": "llm",
+                      "publisher": "lmstudio-community",
+                      "arch": "qwen2",
+                      "compatibility_type": "gguf",
+                      "quantization": "Q4_K_M",
+                      "state": "loaded",
+                      "max_context_length": 131072
+                    }
+                    """#
+                )
+            default:
+                return .status(404, #"{"error":"not found"}"#)
+            }
+        }
+
+        let service = LMStudioModelDiscoveryService(
+            client: LMStudioAPIClient(
+                baseURL: URL(string: "http://127.0.0.1:1234")!,
+                session: session
+            )
+        )
+
+        let state = try await service.validateModelIdentifier("qwen2.5-7b-instruct", for: .vision)
+
+        #expect(state.status == .visionUnsupported)
+        #expect(state.isReady == false)
+    }
+
+    @Test
+    func validateModelIdentifier_reportsMissingModel() async throws {
+        let session = makeLMStudioDiscoverySession { _ in
+            return .status(404, #"{"error":"model not found"}"#)
+        }
+
+        let service = LMStudioModelDiscoveryService(
+            client: LMStudioAPIClient(
+                baseURL: URL(string: "http://127.0.0.1:1234")!,
+                session: session
+            )
+        )
+
+        let state = try await service.validateModelIdentifier("missing-model", for: .summarization)
+
+        #expect(state.status == .modelMissing)
+        #expect(state.selectedReference == "missing-model")
+    }
+}
+
+private func makeLMStudioDiscoverySession(
+    handler: @escaping @Sendable (URLRequest) throws -> LMStudioDiscoveryURLProtocolStub.Response
+) -> URLSession {
+    LMStudioDiscoveryURLProtocolStub.handler = handler
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [LMStudioDiscoveryURLProtocolStub.self]
+    return URLSession(configuration: configuration)
+}
+
+private final class LMStudioDiscoveryURLProtocolStub: URLProtocol, @unchecked Sendable {
+    enum Response {
+        case json(String)
+        case status(Int, String)
+    }
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> Response)?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            let response = try Self.handler?(request) ?? .status(500, #"{"error":"missing handler"}"#)
+            let payload: String
+            let statusCode: Int
+            switch response {
+            case .json(let body):
+                payload = body
+                statusCode = 200
+            case .status(let code, let body):
+                payload = body
+                statusCode = code
+            }
+
+            let httpResponse = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(payload.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/MinuteCore/Tests/MinuteCoreTests/MeetingPipelineCoordinatorTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/MeetingPipelineCoordinatorTests.swift
@@ -284,8 +284,9 @@ struct MeetingPipelineCoordinatorTests {
             summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults),
             summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults),
             visionModelStore: VisionModelSelectionStore(defaults: defaults),
-            ollamaSummarizationBuilder: { tag in
+            ollamaSummarizationBuilder: { tag, baseURL in
                 #expect(tag == "phi4-mini")
+                #expect(baseURL?.absoluteString == AppConfiguration.Defaults.defaultOllamaBaseURL)
                 return TestSummarizationService(
                     summarizationJSON: validExtractionJSON(title: "Ollama", date: "2025-01-12"),
                     repairJSON: validExtractionJSON(title: "Ollama", date: "2025-01-12")

--- a/MinuteCore/Tests/MinuteCoreTests/ScreenContextCaptureServiceWindowLifecycleTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/ScreenContextCaptureServiceWindowLifecycleTests.swift
@@ -108,6 +108,36 @@ struct ScreenContextCaptureServiceWindowLifecycleTests {
         }
         #expect(resolvedTitles == [["Slides"], ["Browser"]])
     }
+
+    @Test
+    func terminalInferenceFailure_emitsLifecycleEventOnceAndStopsRetrying() async throws {
+        let inferencer = TerminalFailureInferencer()
+        let service = ScreenContextCaptureService(inferencer: inferencer)
+        let recorder = LifecycleEventRecorder()
+
+        try await service._testStartCapture(
+            sources: [
+                ScreenContextCaptureSource(
+                    windowTitle: "Slides",
+                    captureImageData: { Data([0x01, 0x02, 0x03]) }
+                )
+            ],
+            minimumFrameInterval: 1.0,
+            lifecycleEventHandler: { event in
+                Task { await recorder.append(event) }
+            }
+        )
+
+        try await Task.sleep(nanoseconds: 1_350_000_000)
+        _ = await service.stopCapture()
+
+        let events = await recorder.events
+        let calls = await inferencer.callCount
+        #expect(calls == 1)
+        #expect(events.count == 1)
+        #expect(events.first?.type == .inferenceUnavailable)
+        #expect(events.first?.message?.contains("could not process image input") == true)
+    }
 }
 
 private actor LifecycleEventRecorder {
@@ -125,6 +155,20 @@ private actor VisionInferencerSpy: ScreenContextInferencing {
         _ = imageData
         calls.append(windowTitle)
         return ScreenContextInference(text: "Vision context for \(windowTitle)")
+    }
+}
+
+private actor TerminalFailureInferencer: ScreenContextInferencing {
+    private(set) var callCount: Int = 0
+
+    func inferScreenContext(from imageData: Data, windowTitle: String) async throws -> ScreenContextInference {
+        _ = imageData
+        _ = windowTitle
+        callCount += 1
+        throw MinuteError.llamaMTMDFailed(
+            exitCode: 400,
+            output: "Error in iterating prediction stream: ValueError: Number of image token positions (1450) does not match number of image features (448) for batch 0"
+        )
     }
 }
 

--- a/MinuteCore/Tests/MinuteCoreTests/ScreenContextInferenceFailurePolicyTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/ScreenContextInferenceFailurePolicyTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import MinuteCore
+
+struct ScreenContextInferenceFailurePolicyTests {
+    @Test
+    func imageTokenMismatch_isTerminalAndActionable() {
+        let error = MinuteError.llamaMTMDFailed(
+            exitCode: 400,
+            output: "Error in iterating prediction stream: ValueError: Number of image token positions (1450) does not match number of image features (448) for batch 0"
+        )
+
+        let message = ScreenContextInferenceFailurePolicy.terminalMessage(for: error)
+
+        #expect(message?.contains("could not process image input") == true)
+        #expect(message?.contains("Number of image token positions") == true)
+    }
+
+    @Test
+    func unrelatedFailure_isNotTerminal() {
+        let error = MinuteError.llamaMTMDFailed(
+            exitCode: 1,
+            output: "temporary transport failure"
+        )
+
+        #expect(ScreenContextInferenceFailurePolicy.terminalMessage(for: error) == nil)
+    }
+}

--- a/MinuteTests/MeetingPipelineViewModelCancelSessionTests.swift
+++ b/MinuteTests/MeetingPipelineViewModelCancelSessionTests.swift
@@ -215,6 +215,70 @@ struct MeetingPipelineViewModelCancelSessionTests {
     }
 
     @Test
+    func dismissCloseableStatus_afterFailure_resetsToIdle_andAllowsNewRecording() async throws {
+        let suiteName = "MeetingPipelineViewModelCancelSessionTests.failureReset.\(UUID().uuidString)"
+        let dependencies = try PipelineViewModelFixtureBuilder.makeDependencies(suiteName: suiteName)
+        let audioService = TestAudioService()
+        let importService = FailingMediaImportService()
+
+        let model = await MainActor.run {
+            MeetingPipelineViewModel(
+                audioService: audioService,
+                mediaImportService: importService,
+                recoveryService: MockRecordingRecoveryService(),
+                pipelineCoordinator: dependencies.coordinator,
+                screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
+                screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
+                screenContextSettingsStore: ScreenContextSettingsStore(),
+                vaultAccess: dependencies.viewModelVaultAccess,
+                recordingPermissions: .alwaysGranted(),
+                stagePreferencesStore: dependencies.stagePreferencesStore
+            )
+        }
+
+        await MainActor.run {
+            model.send(.importFile(URL(fileURLWithPath: "/tmp/failure.wav")))
+        }
+
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run {
+                if case .failed = model.state { return true }
+                return false
+            }
+        }
+
+        await MainActor.run {
+            model.dismissCloseableStatus()
+        }
+
+        let isIdleAfterDismiss = await MainActor.run {
+            if case .idle = model.state {
+                return model.captureState == .ready
+            }
+            return false
+        }
+        #expect(isIdleAfterDismiss)
+
+        await MainActor.run {
+            model.send(.startRecording)
+        }
+
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run {
+                if case .recording = model.state { return true }
+                return false
+            }
+        }
+
+        let observed = await audioService.observed
+        #expect(observed.startRecordingCalls == 1)
+
+        await MainActor.run {
+            model.send(.cancelRecording)
+        }
+    }
+
+    @Test
     func changingScreenContextSelectionWhileRecording_restartsCaptureSession() async throws {
         let captureService = ScreenContextCaptureService(inferencer: MockScreenContextInferenceService())
         let seededSource = ScreenContextCaptureSource(
@@ -563,6 +627,12 @@ private actor BlockingMediaImportService: MediaImporting {
             duration: 0,
             suggestedStartDate: Date()
         ))
+    }
+}
+
+private struct FailingMediaImportService: MediaImporting {
+    func importMedia(from _: URL) async throws -> MediaImportResult {
+        throw MinuteError.audioExportFailed
     }
 }
 

--- a/MinuteTests/MeetingPipelineViewModelScreenContextAlertsTests.swift
+++ b/MinuteTests/MeetingPipelineViewModelScreenContextAlertsTests.swift
@@ -165,4 +165,73 @@ struct MeetingPipelineViewModelScreenContextAlertsTests {
             model.send(.cancelRecording)
         }
     }
+
+    @Test
+    func invalidLMStudioVisionConfiguration_showsActionableAlertWithoutBlockingRecording() async throws {
+        let suiteName = "MeetingPipelineViewModelScreenContextAlertsTests.lmstudio.invalid.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
+        stagePreferencesStore.clear()
+
+        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
+        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
+        let coordinator = MeetingPipelineCoordinator(
+            transcriptionService: MockTranscriptionService(),
+            diarizationService: MockDiarizationService(),
+            summarizationServiceProvider: { MockSummarizationService() },
+            modelManager: MockModelManager(),
+            vaultAccess: coordinatorVaultAccess,
+            vaultWriter: DefaultVaultWriter()
+        )
+        let selection = ScreenContextWindowSelection(
+            bundleIdentifier: "com.apple.Keynote",
+            applicationName: "Keynote",
+            windowTitle: "Slides"
+        )
+
+        let model = await MainActor.run {
+            MeetingPipelineViewModel(
+                audioService: MockAudioService(),
+                mediaImportService: MockMediaImportService(),
+                recoveryService: MockRecordingRecoveryService(),
+                pipelineCoordinator: coordinator,
+                screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
+                screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
+                screenContextSettingsStore: ScreenContextSettingsStore(),
+                vaultAccess: viewModelVaultAccess,
+                recordingPermissions: .alwaysGranted(),
+                stagePreferencesStore: stagePreferencesStore,
+                visionAvailabilityProvider: {
+                    CapabilityAvailabilityState(
+                        capabilityID: .vision,
+                        providerID: .lmStudio,
+                        isReady: false,
+                        status: .serverUnavailable,
+                        message: "LM Studio is unavailable. Start the local server and refresh.",
+                        selectedReference: "qwen2.5-vl-7b"
+                    )
+                }
+            )
+        }
+
+        await MainActor.run {
+            model.send(.startRecordingWithWindow(selection))
+        }
+
+        try await eventually(timeoutNanoseconds: 1_500_000_000) {
+            await MainActor.run {
+                model.captureState == .recording && model.activeScreenContextAlertMessage != nil
+            }
+        }
+
+        let message = await MainActor.run {
+            model.activeScreenContextAlertMessage
+        }
+        #expect(message?.contains("LM Studio is unavailable") == true)
+
+        await MainActor.run {
+            model.send(.cancelRecording)
+        }
+    }
 }

--- a/MinuteTests/MeetingPipelineViewModelScreenContextAlertsTests.swift
+++ b/MinuteTests/MeetingPipelineViewModelScreenContextAlertsTests.swift
@@ -234,4 +234,73 @@ struct MeetingPipelineViewModelScreenContextAlertsTests {
             model.send(.cancelRecording)
         }
     }
+
+    @Test
+    func runtimeVisionFailure_showsConfigurationAlertWithoutStoppingRecording() async throws {
+        let suiteName = "MeetingPipelineViewModelScreenContextAlertsTests.runtime.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let stagePreferencesStore = StagePreferencesStore(defaults: defaults)
+        stagePreferencesStore.clear()
+
+        let coordinatorVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
+        let viewModelVaultAccess = VaultAccess(bookmarkStore: InMemoryVaultBookmarkStore(bookmark: nil))
+        let coordinator = MeetingPipelineCoordinator(
+            transcriptionService: MockTranscriptionService(),
+            diarizationService: MockDiarizationService(),
+            summarizationServiceProvider: { MockSummarizationService() },
+            modelManager: MockModelManager(),
+            vaultAccess: coordinatorVaultAccess,
+            vaultWriter: DefaultVaultWriter()
+        )
+
+        let model = await MainActor.run {
+            MeetingPipelineViewModel(
+                audioService: MockAudioService(),
+                mediaImportService: MockMediaImportService(),
+                recoveryService: MockRecordingRecoveryService(),
+                pipelineCoordinator: coordinator,
+                screenContextCaptureService: ScreenContextCaptureService(inferencer: MockScreenContextInferenceService()),
+                screenContextVideoExtractor: ScreenContextVideoFrameExtractor(inferencer: MockScreenContextInferenceService()),
+                screenContextSettingsStore: ScreenContextSettingsStore(),
+                vaultAccess: viewModelVaultAccess,
+                recordingPermissions: .alwaysGranted(),
+                stagePreferencesStore: stagePreferencesStore
+            )
+        }
+
+        await MainActor.run {
+            model.send(.startRecording)
+        }
+
+        try await eventually(timeoutNanoseconds: 1_500_000_000) {
+            await MainActor.run { model.captureState == .recording }
+        }
+
+        await MainActor.run {
+            model._testHandleScreenContextLifecycleEvent(
+                ScreenContextLifecycleEvent(
+                    type: .inferenceUnavailable,
+                    windowTitle: "Slides",
+                    message: "Selected vision model could not process image input."
+                )
+            )
+        }
+
+        try await eventually(timeoutNanoseconds: 1_500_000_000) {
+            await MainActor.run {
+                model.captureState == .recording
+                    && model.activeScreenContextAlertMessage?.contains("could not process image input") == true
+            }
+        }
+
+        let recordedEvent = await MainActor.run {
+            model.recordingSessionEvents.contains { $0.eventType == .screenContextConfigurationNotified }
+        }
+        #expect(recordedEvent)
+
+        await MainActor.run {
+            model.send(.cancelRecording)
+        }
+    }
 }

--- a/MinuteTests/ModelsSettingsInferenceProviderTests.swift
+++ b/MinuteTests/ModelsSettingsInferenceProviderTests.swift
@@ -73,6 +73,104 @@ struct ModelsSettingsInferenceProviderTests {
     }
 
     @Test
+    func lmStudioCapabilitySelectionsPersistIndependently() async throws {
+        let suite = "ModelsSettingsInferenceProviderTests.lmstudio.persist.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        let summarizationStore = SummarizationModelSelectionStore(defaults: defaults, key: "sum")
+        let visionStore = VisionModelSelectionStore(defaults: defaults, key: "vision")
+
+        let model = ModelsSettingsViewModel(
+            modelManager: StubInferenceProviderModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            inferenceProviderStore: providerStore,
+            summarizationModelStore: summarizationStore,
+            summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx"),
+            visionModelStore: visionStore,
+            transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+            transcriptionBackendStore: TranscriptionBackendSelectionStore(defaults: defaults, key: "backend"),
+            fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid")
+        )
+
+        model.selectedSummarizationProviderID = InferenceProvider.lmStudio.rawValue
+        model.selectedSummarizationLMStudioModelIdentifier = "qwen2.5-7b-instruct"
+        model.selectedVisionProviderID = InferenceProvider.ollama.rawValue
+        model.selectedVisionOllamaModelTag = "llava:latest"
+
+        #expect(providerStore.selectedProvider(for: .summarization) == .lmStudio)
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .summarization) == "qwen2.5-7b-instruct")
+        #expect(providerStore.selectedProvider(for: .vision) == .ollama)
+        #expect(providerStore.selectedOllamaModelTag(for: .vision) == "llava:latest")
+    }
+
+    @Test
+    func restoringPersistedLMStudioVisionSelection_updatesSettingsState() async throws {
+        let suite = "ModelsSettingsInferenceProviderTests.lmstudio.restore.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        providerStore.setSelectedProvider(.lmStudio, for: .vision)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-vl-7b", for: .vision)
+        let visionStore = VisionModelSelectionStore(defaults: defaults, key: "vision")
+        let builtInVision = visionStore.selectedModel()
+
+        let model = ModelsSettingsViewModel(
+            modelManager: StubInferenceProviderModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            inferenceProviderStore: providerStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults, key: "sum"),
+            summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx"),
+            visionModelStore: visionStore,
+            transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+            transcriptionBackendStore: TranscriptionBackendSelectionStore(defaults: defaults, key: "backend"),
+            fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid")
+        )
+
+        #expect(model.selectedVisionProviderID == InferenceProvider.lmStudio.rawValue)
+        #expect(model.selectedVisionLMStudioModelIdentifier == "qwen2.5-vl-7b")
+        #expect(model.selectedVisionModelID == builtInVision.id)
+    }
+
+    @Test
+    func lmStudioSelectionsPersistIndependentlyAcrossCapabilities() async throws {
+        let suite = "ModelsSettingsInferenceProviderTests.lmstudio.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        let connectionStore = ProviderConnectionSettingsStore(defaults: defaults)
+
+        let model = ModelsSettingsViewModel(
+            modelManager: StubInferenceProviderModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            inferenceProviderStore: providerStore,
+            connectionStore: connectionStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults, key: "sum"),
+            summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx"),
+            visionModelStore: VisionModelSelectionStore(defaults: defaults, key: "vision"),
+            transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+            transcriptionBackendStore: TranscriptionBackendSelectionStore(defaults: defaults, key: "backend"),
+            fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid")
+        )
+
+        model.selectedSummarizationProviderID = InferenceProvider.lmStudio.rawValue
+        model.selectedSummarizationLMStudioModelIdentifier = "qwen2.5-7b-instruct"
+        model.selectedLMStudioBaseURLString = "http://127.0.0.1:1234"
+        model.selectedVisionProviderID = InferenceProvider.lmStudio.rawValue
+        model.selectedVisionLMStudioModelIdentifier = "qwen2.5-vl-7b"
+
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .summarization) == "qwen2.5-7b-instruct")
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .vision) == "qwen2.5-vl-7b")
+        #expect(connectionStore.selectedBaseURLString(for: .lmStudio) == "http://127.0.0.1:1234")
+
+        model.selectedVisionProviderID = InferenceProvider.builtIn.rawValue
+
+        #expect(providerStore.selectedProvider(for: .vision) == .builtIn)
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .summarization) == "qwen2.5-7b-instruct")
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .vision) == "qwen2.5-vl-7b")
+    }
+
+    @Test
     func invalidOllamaVisionSelection_preservesTagAndExposesValidationState() async throws {
         let suite = "ModelsSettingsInferenceProviderTests.validation.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))
@@ -121,6 +219,56 @@ struct ModelsSettingsInferenceProviderTests {
         #expect(model.visionAvailabilityState.status == .visionUnsupported)
         #expect(model.ollamaDiscoveredModelTags == ["phi4-mini"])
     }
+
+    @Test
+    func invalidLMStudioVisionSelection_preservesIdentifierAndExposesValidationState() async throws {
+        let suite = "ModelsSettingsInferenceProviderTests.lmstudio.validation.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        providerStore.setSelectedProvider(.lmStudio, for: .vision)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-7b-instruct", for: .vision)
+
+        let model = ModelsSettingsViewModel(
+            modelManager: StubInferenceProviderModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            inferenceProviderStore: providerStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults, key: "sum"),
+            summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx"),
+            visionModelStore: VisionModelSelectionStore(defaults: defaults, key: "vision"),
+            transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+            transcriptionBackendStore: TranscriptionBackendSelectionStore(defaults: defaults, key: "backend"),
+            fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid"),
+            availabilityProvider: StubCapabilityAvailabilityProvider(
+                summarizationState: .ready(.summarization, reference: SummarizationModelCatalog.defaultModel.id),
+                visionState: CapabilityAvailabilityState(
+                    capabilityID: .vision,
+                    providerID: .lmStudio,
+                    isReady: false,
+                    status: .visionUnsupported,
+                    message: "Selected LM Studio model does not advertise vision support.",
+                    selectedReference: "qwen2.5-7b-instruct"
+                )
+            ),
+            lmStudioModelDiscoverer: StubLMStudioModelDiscoverer(
+                snapshot: LMStudioDiscoverySnapshot(
+                    serverReachable: true,
+                    models: [LMStudioModelDescriptor(identifier: "qwen2.5-7b-instruct", displayName: "qwen2.5-7b-instruct", modelType: "llm")]
+                )
+            )
+        )
+
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run {
+                model.visionAvailabilityState.status == .visionUnsupported &&
+                model.lmStudioDiscoveredModelIdentifiers == ["qwen2.5-7b-instruct"]
+            }
+        }
+
+        #expect(model.selectedVisionLMStudioModelIdentifier == "qwen2.5-7b-instruct")
+        #expect(model.visionAvailabilityState.status == .visionUnsupported)
+        #expect(model.lmStudioDiscoveredModelIdentifiers == ["qwen2.5-7b-instruct"])
+    }
 }
 
 private struct StubInferenceProviderModelManager: ModelManaging {
@@ -162,6 +310,18 @@ private struct StubOllamaModelDiscoverer: OllamaModelDiscovering {
 
     func validateModelTag(_ tag: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState {
         .ready(capability, reference: tag, provider: .ollama)
+    }
+}
+
+private struct StubLMStudioModelDiscoverer: LMStudioModelDiscovering {
+    var snapshot: LMStudioDiscoverySnapshot
+
+    func discoverModels() async throws -> LMStudioDiscoverySnapshot {
+        snapshot
+    }
+
+    func validateModelIdentifier(_ identifier: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState {
+        .ready(capability, reference: identifier, provider: .lmStudio)
     }
 }
 

--- a/MinuteTests/ModelsSettingsViewModelVocabularyBoostingTests.swift
+++ b/MinuteTests/ModelsSettingsViewModelVocabularyBoostingTests.swift
@@ -79,6 +79,33 @@ struct ModelsSettingsViewModelVocabularyBoostingTests {
         }
         #expect(message?.contains("CTC") == true)
     }
+
+    @Test
+    func exposesUnsupportedMessage_whenFluidAudioBackendSelected() async throws {
+        let suite = "ModelsSettingsViewModelVocabularyBoostingTests.unsupported.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let backendStore = TranscriptionBackendSelectionStore(defaults: defaults, key: "backend")
+        backendStore.setSelectedBackendID(TranscriptionBackend.fluidAudio.rawValue)
+
+        let model = await MainActor.run {
+            ModelsSettingsViewModel(
+                modelManager: StubModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+                summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults, key: "sum"),
+                transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+                transcriptionBackendStore: backendStore,
+                fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid")
+            )
+        }
+
+        let message = await MainActor.run {
+            model.vocabularyBoostingSupportMessage
+        }
+
+        #expect(message?.contains("currently unavailable") == true)
+        #expect(message?.contains("FluidAudio") == true)
+    }
 }
 
 private struct StubModelManager: ModelManaging {

--- a/MinuteTests/OnboardingInferenceProviderTests.swift
+++ b/MinuteTests/OnboardingInferenceProviderTests.swift
@@ -75,6 +75,108 @@ struct OnboardingInferenceProviderTests {
     }
 
     @Test
+    func selectingLMStudioSummarizationProvider_persistsIdentifierAndKeepsBuiltInModel() throws {
+        let suite = "OnboardingInferenceProviderTests.lmstudio.persist.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        let summarizationStore = SummarizationModelSelectionStore(defaults: defaults, key: "sum")
+        let contextStore = SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx")
+        let visionStore = VisionModelSelectionStore(defaults: defaults, key: "vision")
+        let transcriptionStore = TranscriptionModelSelectionStore(defaults: defaults, key: "trans")
+        let backendStore = TranscriptionBackendSelectionStore(defaults: defaults, key: "backend")
+        let fluidStore = FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid")
+
+        let model = OnboardingViewModel(
+            modelManager: StubOnboardingModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            defaults: defaults,
+            inferenceProviderStore: providerStore,
+            summarizationModelStore: summarizationStore,
+            summarizationContextWindowStore: contextStore,
+            visionModelStore: visionStore,
+            transcriptionModelStore: transcriptionStore,
+            transcriptionBackendStore: backendStore,
+            fluidAudioModelStore: fluidStore
+        )
+
+        model.selectedSummarizationProviderID = InferenceProvider.lmStudio.rawValue
+        model.selectedSummarizationLMStudioModelIdentifier = "  qwen2.5-7b-instruct  "
+
+        #expect(providerStore.selectedProvider(for: .summarization) == .lmStudio)
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .summarization) == "qwen2.5-7b-instruct")
+        #expect(model.isBuiltInSummarizationProviderSelected == false)
+        #expect(summarizationStore.selectedModelID() == SummarizationModelCatalog.defaultModel.id)
+    }
+
+    @Test
+    func restoringPersistedLMStudioSelection_updatesOnboardingState() throws {
+        let suite = "OnboardingInferenceProviderTests.lmstudio.restore.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        providerStore.setSelectedProvider(.lmStudio, for: .summarization)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-7b-instruct", for: .summarization)
+        providerStore.setSelectedProvider(.lmStudio, for: .vision)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-vl-7b", for: .vision)
+        let visionStore = VisionModelSelectionStore(defaults: defaults, key: "vision")
+
+        let model = OnboardingViewModel(
+            modelManager: StubOnboardingModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            defaults: defaults,
+            inferenceProviderStore: providerStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults, key: "sum"),
+            summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx"),
+            visionModelStore: visionStore,
+            transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+            transcriptionBackendStore: TranscriptionBackendSelectionStore(defaults: defaults, key: "backend"),
+            fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid")
+        )
+
+        #expect(model.selectedSummarizationProviderID == InferenceProvider.lmStudio.rawValue)
+        #expect(model.selectedSummarizationLMStudioModelIdentifier == "qwen2.5-7b-instruct")
+        #expect(model.selectedVisionProviderID == InferenceProvider.lmStudio.rawValue)
+        #expect(model.selectedVisionLMStudioModelIdentifier == "qwen2.5-vl-7b")
+        #expect(model.selectedVisionModelID == visionStore.selectedModel().id)
+    }
+
+    @Test
+    func selectingLMStudioProviders_persistsIdentifiersAndConnection() throws {
+        let suite = "OnboardingInferenceProviderTests.lmstudio.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        let connectionStore = ProviderConnectionSettingsStore(defaults: defaults)
+
+        let model = OnboardingViewModel(
+            modelManager: StubOnboardingModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            defaults: defaults,
+            inferenceProviderStore: providerStore,
+            connectionStore: connectionStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults, key: "sum"),
+            summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx"),
+            visionModelStore: VisionModelSelectionStore(defaults: defaults, key: "vision"),
+            transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+            transcriptionBackendStore: TranscriptionBackendSelectionStore(defaults: defaults, key: "backend"),
+            fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid")
+        )
+
+        model.selectedSummarizationProviderID = InferenceProvider.lmStudio.rawValue
+        model.selectedSummarizationLMStudioModelIdentifier = "  qwen2.5-7b-instruct  "
+        model.selectedVisionProviderID = InferenceProvider.lmStudio.rawValue
+        model.selectedVisionLMStudioModelIdentifier = "  qwen2.5-vl-7b  "
+        model.selectedLMStudioBaseURLString = " http://127.0.0.1:1234 "
+
+        #expect(providerStore.selectedProvider(for: .summarization) == .lmStudio)
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .summarization) == "qwen2.5-7b-instruct")
+        #expect(providerStore.selectedProvider(for: .vision) == .lmStudio)
+        #expect(providerStore.selectedLMStudioModelIdentifier(for: .vision) == "qwen2.5-vl-7b")
+        #expect(connectionStore.selectedBaseURLString(for: .lmStudio) == "http://127.0.0.1:1234")
+    }
+
+    @Test
     func invalidOllamaSelections_keepWizardBlockedUntilValidationPasses() async throws {
         let suite = "OnboardingInferenceProviderTests.validation.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))
@@ -169,6 +271,54 @@ struct OnboardingInferenceProviderTests {
         #expect(model.screenContextStageReady)
         #expect(model.modelsReady)
     }
+
+    @Test
+    func invalidLMStudioVisionSelection_keepsWizardBlockedUntilValidationPasses() async throws {
+        let suite = "OnboardingInferenceProviderTests.lmstudio.validation.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(true, forKey: AppConfiguration.Defaults.screenContextEnabledKey)
+
+        let providerStore = InferenceProviderSelectionStore(defaults: defaults)
+        providerStore.setSelectedProvider(.lmStudio, for: .summarization)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-7b-instruct", for: .summarization)
+        providerStore.setSelectedProvider(.lmStudio, for: .vision)
+        providerStore.setSelectedLMStudioModelIdentifier("qwen2.5-7b-instruct", for: .vision)
+
+        let model = OnboardingViewModel(
+            modelManager: StubOnboardingModelManager(validation: ModelValidationResult(missingModelIDs: [], invalidModelIDs: [])),
+            defaults: defaults,
+            inferenceProviderStore: providerStore,
+            summarizationModelStore: SummarizationModelSelectionStore(defaults: defaults, key: "sum"),
+            summarizationContextWindowStore: SummarizationContextWindowSelectionStore(defaults: defaults, key: "ctx"),
+            visionModelStore: VisionModelSelectionStore(defaults: defaults, key: "vision"),
+            transcriptionModelStore: TranscriptionModelSelectionStore(defaults: defaults, key: "trans"),
+            transcriptionBackendStore: TranscriptionBackendSelectionStore(defaults: defaults, key: "backend"),
+            fluidAudioModelStore: FluidAudioASRModelSelectionStore(defaults: defaults, key: "fluid"),
+            availabilityProvider: StubOnboardingAvailabilityProvider(
+                summarizationState: .ready(.summarization, reference: "qwen2.5-7b-instruct", provider: .lmStudio),
+                visionState: CapabilityAvailabilityState(
+                    capabilityID: .vision,
+                    providerID: .lmStudio,
+                    isReady: false,
+                    status: .visionUnsupported,
+                    message: "Selected LM Studio model does not advertise vision support.",
+                    selectedReference: "qwen2.5-7b-instruct"
+                )
+            ),
+            lmStudioModelDiscoverer: StubOnboardingLMStudioDiscoverer(snapshot: LMStudioDiscoverySnapshot(serverReachable: true))
+        )
+
+        try await eventually(timeoutNanoseconds: 1_000_000_000) {
+            await MainActor.run {
+                model.visionAvailabilityState.status == .visionUnsupported
+            }
+        }
+
+        #expect(model.selectedVisionLMStudioModelIdentifier == "qwen2.5-7b-instruct")
+        #expect(model.visionAvailabilityState.status == .visionUnsupported)
+        #expect(model.modelsReady == false)
+    }
 }
 
 private struct StubOnboardingModelManager: ModelManaging {
@@ -210,6 +360,18 @@ private struct StubOnboardingOllamaDiscoverer: OllamaModelDiscovering {
 
     func validateModelTag(_ tag: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState {
         .ready(capability, reference: tag, provider: .ollama)
+    }
+}
+
+private struct StubOnboardingLMStudioDiscoverer: LMStudioModelDiscovering {
+    var snapshot: LMStudioDiscoverySnapshot
+
+    func discoverModels() async throws -> LMStudioDiscoverySnapshot {
+        snapshot
+    }
+
+    func validateModelIdentifier(_ identifier: String, for capability: InferenceCapability) async throws -> CapabilityAvailabilityState {
+        .ready(capability, reference: identifier, provider: .lmStudio)
     }
 }
 

--- a/MinuteTests/SettingsCategoryCatalogTests.swift
+++ b/MinuteTests/SettingsCategoryCatalogTests.swift
@@ -22,4 +22,16 @@ struct SettingsCategoryCatalogTests {
         #expect(aiIndex! < meetingTypesIndex!)
         #expect(meetingTypesIndex! < updatesIndex!)
     }
+
+    @Test
+    func everySettingsEntry_hasExactlyOneCategoryOwner() {
+        let entries = SettingsCategoryCatalog.entries(updatesEnabled: true)
+
+        #expect(entries.count == SettingsEntryDefinition.ID.allCases.count)
+
+        for entryID in SettingsEntryDefinition.ID.allCases {
+            let matches = entries.filter { $0.id == entryID }
+            #expect(matches.count == 1)
+        }
+    }
 }

--- a/MinuteTests/SettingsSectionReachabilityTests.swift
+++ b/MinuteTests/SettingsSectionReachabilityTests.swift
@@ -19,4 +19,24 @@ struct SettingsSectionReachabilityTests {
 
         #expect(selection == .meetingTypes)
     }
+
+    @Test
+    func knownSpeakerSuggestions_isOwnedBySpeakersCategory() {
+        let category = SettingsCategoryCatalog.categoryID(
+            for: .knownSpeakerSuggestions,
+            updatesEnabled: true
+        )
+
+        #expect(category == .speakers)
+    }
+
+    @Test
+    func representativeSettingsRemainReachableFromTheirCategories() {
+        #expect(SettingsCategoryCatalog.categoryID(for: .outputLanguage, updatesEnabled: true) == .general)
+        #expect(SettingsCategoryCatalog.categoryID(for: .vaultRoot, updatesEnabled: true) == .storage)
+        #expect(SettingsCategoryCatalog.categoryID(for: .microphoneAccess, updatesEnabled: true) == .privacy)
+        #expect(SettingsCategoryCatalog.categoryID(for: .summarizationProvider, updatesEnabled: true) == .ai)
+        #expect(SettingsCategoryCatalog.categoryID(for: .meetingTypesEditor, updatesEnabled: true) == .meetingTypes)
+        #expect(SettingsCategoryCatalog.categoryID(for: .checkForUpdates, updatesEnabled: true) == .updates)
+    }
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,15 +2,15 @@ Minute Overview
 
 Minute is a native macOS app for capturing meetings locally and writing
 deterministic notes into a user-selected Obsidian vault. It records audio,
-transcribes with Fluidaudio, summarizes with local built-in or Ollama-backed
-inference, and writes a fixed set of artifacts to the vault.
+transcribes with Fluidaudio, summarizes with local built-in, Ollama-backed,
+or LM Studio-backed inference, and writes a fixed set of artifacts to the vault.
 
 What the app does
 - Record microphone + system audio locally.
 - Transcribe audio locally (Fluidaudio).
 - Optionally capture screen context locally for summaries.
 - Let advanced users configure summarization and screen-context vision separately,
-  with independent `Built-in` and `Ollama` provider/model choices.
+  with independent `Built-in`, `Ollama`, and `LM Studio` provider/model choices.
 - **Tailor summaries based on meeting type (built-in and custom).**
 - Summarize locally with a JSON-only LLM prompt using the configured local provider.
 - Render a deterministic Markdown note from JSON.
@@ -43,7 +43,7 @@ How the app works (pipeline)
    - Write transcript markdown to Meetings/_transcripts/.
 3) Summarize
    - Resolve the configured summarization provider/model for that run.
-   - Run the built-in local model or the local Ollama daemon with a JSON-only prompt.
+   - Run the built-in local model, local Ollama daemon, or local LM Studio server with a JSON-only prompt.
    - Validate JSON; if invalid, run a single repair pass.
    - If still invalid, emit a fallback note with empty sections.
    - Keep the resolved provider/model fixed for the lifetime of the in-flight task.
@@ -54,9 +54,11 @@ How the app works (pipeline)
 
 Advanced inference configuration
 - Summarization and screen-context vision are configured independently.
-- Each capability can use `Built-in` or `Ollama`.
+- Each capability can use `Built-in`, `Ollama`, or `LM Studio`.
 - Ollama discovery reflects models already downloaded to the configured Ollama daemon.
+- LM Studio discovery reflects models currently exposed by the configured local LM Studio server.
 - Vision validation checks whether the selected Ollama model advertises `vision` capability.
+- Vision validation also checks whether the selected LM Studio model advertises vision support.
 - If a capability is unavailable, the app surfaces actionable readiness state instead of silently falling back.
 
 State model
@@ -67,8 +69,9 @@ idle -> recording -> recorded -> processing(transcribe) -> processing(summarize)
 Permissions and privacy
 - The app is sandboxed and uses security-scoped bookmarks for the vault.
 - All audio and inference runs locally.
-- The only network access is for downloading model weights and, when enabled by the user, talking to the configured Ollama daemon endpoint.
+- The only network access is for downloading model weights and, when enabled by the user, talking to configured local-provider endpoints such as Ollama or LM Studio.
 - The default Ollama endpoint is loopback. Advanced users can point it at another user-managed Ollama host on their network.
+- The default LM Studio endpoint is loopback on port `1234`.
 - No transcript content is logged by default.
 - Known-speaker profiles and diarization embeddings (when enabled) are stored in app support, not in the vault.
 - The vault output contract remains exactly three files per meeting.
@@ -83,8 +86,8 @@ Technology snapshot
 - UI: SwiftUI (macOS 14+)
 - Audio: AVFoundation + ScreenCaptureKit
 - Transcription: Fluidaudio (library, XPC helper)
-- Summarization: built-in llama runtime or local Ollama daemon
-- Vision inference: built-in llama runtime or local Ollama daemon
+- Summarization: built-in llama runtime, local Ollama daemon, or local LM Studio server
+- Vision inference: built-in llama runtime, local Ollama daemon, or local LM Studio server
 - Markdown: deterministic renderer (model outputs JSON only)
 
 Code structure

--- a/specs/017-ollama-summarization-option/release-note.md
+++ b/specs/017-ollama-summarization-option/release-note.md
@@ -1,0 +1,29 @@
+# Release Note: Advanced Inference Provider Options
+
+More flexible local AI configuration, with independent model controls for summaries and screen context.
+
+Minute now gives advanced users separate local inference controls for summarization and screen-context vision. You can choose `Built-in` or `Ollama` for each capability independently, both during setup and later in Settings.
+
+## What's New
+
+- Separate provider and model selection for summarization and vision.
+- `Built-in` and `Ollama` are available in both onboarding and Settings.
+- Existing installs keep safe built-in defaults after upgrade.
+- Active summarization and vision tasks keep the provider/model they started with, even if settings change mid-run.
+- Ollama model discovery uses the local daemon's installed models.
+- Vision selections are validated so non-vision Ollama models are rejected with a clear message.
+
+## Why It Matters
+
+This update gives advanced users tighter control over their local runtime setup without changing Minute's core behavior. You can keep the built-in path, switch only summarization to Ollama, use a different Ollama model for vision, or mix providers based on your hardware and preferences.
+
+## Privacy and Compatibility
+
+- Processing remains local-first.
+- No cloud account is required.
+- The deterministic vault contract is unchanged: each processed meeting still writes exactly three files.
+- Transcription behavior is unchanged.
+
+## Notes for Existing Users
+
+If you are upgrading from an earlier version, Minute will keep working with built-in defaults for both summarization and vision until you choose otherwise. If an Ollama model is unavailable or does not support vision, Minute keeps the rest of your configuration intact and shows actionable readiness feedback.

--- a/specs/017-ollama-summarization-option/summary.md
+++ b/specs/017-ollama-summarization-option/summary.md
@@ -1,0 +1,56 @@
+# 017 — Ollama Summarization Option: Summary
+
+**Branch**: `017-ollama-summarization-option`
+**Status**: Draft
+**Created**: 2026-03-24
+
+## Overview
+
+This feature lets advanced users choose between **Built-in (llama.cpp)** and **Ollama** as the inference provider for both **summarization** and **vision/screen-context** tasks — independently of each other and independently of transcription.
+
+## Key Points
+
+- **Separate controls for summarization and vision**: Users can pick a different provider and model for each capability (e.g., Ollama for summarization, Built-in for vision).
+- **Surfaced in both wizard and settings**: Provider/model choices appear during first-run setup and remain editable in Settings at any time.
+- **No re-onboarding required**: Changing provider or model later doesn't force users back through the wizard.
+- **In-flight safety**: A running summarization or vision task keeps the provider/model it started with, even if settings change mid-task.
+- **Upgrade-safe defaults**: Existing users upgrading to this version receive sensible Built-in defaults for both capabilities — no breakage.
+- **Local-only**: Ollama is treated as a local runtime; no cloud calls are introduced. The existing three-file vault output contract is preserved.
+- **Validation**: If a user picks a vision model that doesn't actually support vision, the app blocks the selection with a clear message.
+
+## User Stories
+
+| # | Story | Priority |
+|---|-------|----------|
+| 1 | Choose summarization provider/model during setup wizard | P1 |
+| 2 | Configure vision separately from summarization | P2 |
+| 3 | Adjust AI configuration later in settings with clear feedback on unavailable providers | P3 |
+
+## Core Requirements (25 functional, 5 non-functional)
+
+- Independent provider/model persistence per capability
+- Built-in and Ollama offered for both summarization and vision
+- Wizard and settings share the same options and current values
+- Clear, actionable validation when a provider or model is unavailable
+- UI remains responsive; no main-thread blocking
+- Deterministic vault output contract (three files per meeting) unaffected
+
+## Key Entities
+
+- **Inference Capability** — summarization or vision
+- **Inference Provider** — Built-in or Ollama
+- **Inference Configuration Preference** — persisted per-capability setting
+- **Capability Availability State** — readiness status of the selected provider/model
+- **Inference Run Context** — per-task binding to the provider/model at task start
+
+## Success Criteria
+
+- 100% of clean installs can set both providers in the wizard
+- 100% of existing users retain valid Built-in defaults after upgrade
+- Settings changes take < 45 seconds
+- In-progress tasks are never disrupted by config changes
+- 90%+ of advanced test users correctly distinguish summarization, vision, and transcription on first attempt
+- Zero regressions to the vault output contract
+
+---
+*Auto-generated summary from [[Roblibob/Minute/Specs/017-ollama-summarization-option/spec|full spec]]*

--- a/specs/018-lm-studio-support/checklists/requirements.md
+++ b/specs/018-lm-studio-support/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: LM Studio Provider Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed on 2026-04-02 against the current spec draft.
+- No outstanding clarification markers or checklist failures remain.

--- a/specs/018-lm-studio-support/contracts/openapi.yaml
+++ b/specs/018-lm-studio-support/contracts/openapi.yaml
@@ -1,0 +1,304 @@
+openapi: 3.0.3
+info:
+  title: Minute Inference Provider Contract
+  version: 0.1.0
+  description: |
+    Internal local-only contract for selecting and validating inference providers
+    separately for summarization and vision.
+    These endpoints describe behavior boundaries and do not imply any public or remote API.
+servers:
+  - url: local://minute-core
+paths:
+  /inference/capabilities:
+    get:
+      summary: List configurable inference capabilities and their current selections
+      operationId: listInferenceCapabilities
+      responses:
+        '200':
+          description: Capability catalog and current selections
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InferenceCapabilityCatalogResponse'
+  /inference/capabilities/{capabilityId}/selection:
+    put:
+      summary: Update the active provider and model for one inference capability
+      operationId: updateInferenceCapabilitySelection
+      parameters:
+        - $ref: '#/components/parameters/CapabilityId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InferenceSelectionRequest'
+      responses:
+        '200':
+          description: Selection persisted and current readiness returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InferenceSelectionResponse'
+        '409':
+          description: Selection accepted for future tasks but current provider/model is not ready
+  /inference/providers/lm-studio/connection:
+    get:
+      summary: Read the saved local LM Studio connection settings
+      operationId: getLMStudioConnection
+      responses:
+        '200':
+          description: Saved LM Studio connection settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConnectionSettings'
+    put:
+      summary: Save the local LM Studio connection settings
+      operationId: updateLMStudioConnection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProviderConnectionSettingsRequest'
+      responses:
+        '200':
+          description: Connection settings persisted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConnectionSettings'
+  /inference/providers/lm-studio/discovery:
+    get:
+      summary: Discover locally available LM Studio models and local server state
+      operationId: discoverLMStudioModels
+      responses:
+        '200':
+          description: Local LM Studio server was contacted and inventory returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LMStudioDiscoverySnapshot'
+        '503':
+          description: LM Studio local server is unavailable
+  /inference/providers/lm-studio/validate:
+    post:
+      summary: Validate the selected LM Studio model for one capability
+      operationId: validateLMStudioSelection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LMStudioValidationRequest'
+      responses:
+        '200':
+          description: Selected model is available and valid for the capability
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapabilityAvailabilityState'
+        '404':
+          description: Selected model is not available from the local LM Studio server
+        '409':
+          description: Selected model exists but cannot satisfy the requested capability
+        '503':
+          description: LM Studio local server is unavailable
+components:
+  schemas:
+    InferenceCapabilityCatalogResponse:
+      type: object
+      required:
+        - capabilities
+      properties:
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceCapabilityState'
+    InferenceCapabilityState:
+      type: object
+      required:
+        - capabilityId
+        - selectedProviderId
+        - availability
+      properties:
+        capabilityId:
+          type: string
+          enum: [summarization, vision]
+        selectedProviderId:
+          type: string
+          enum: [builtIn, ollama, lmStudio]
+        selectedReference:
+          type: string
+        availableProviders:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceProvider'
+        availability:
+          $ref: '#/components/schemas/CapabilityAvailabilityState'
+    InferenceSelectionRequest:
+      type: object
+      required:
+        - selectedProviderId
+      properties:
+        selectedProviderId:
+          type: string
+          enum: [builtIn, ollama, lmStudio]
+        builtInModelId:
+          type: string
+        ollamaModelTag:
+          type: string
+        lmStudioModelIdentifier:
+          type: string
+    InferenceSelectionResponse:
+      type: object
+      required:
+        - capabilityId
+        - selectedProviderId
+        - availability
+      properties:
+        capabilityId:
+          type: string
+          enum: [summarization, vision]
+        selectedProviderId:
+          type: string
+          enum: [builtIn, ollama, lmStudio]
+        availability:
+          $ref: '#/components/schemas/CapabilityAvailabilityState'
+        preservedSelections:
+          type: object
+          additionalProperties:
+            type: string
+    InferenceProvider:
+      type: object
+      required:
+        - id
+        - displayName
+        - description
+        - supportsManagedDownloads
+        - supportsLocalDiscovery
+      properties:
+        id:
+          type: string
+          enum: [builtIn, ollama, lmStudio]
+        displayName:
+          type: string
+        description:
+          type: string
+        supportsManagedDownloads:
+          type: boolean
+        supportsLocalDiscovery:
+          type: boolean
+    ProviderConnectionSettings:
+      type: object
+      required:
+        - providerId
+        - baseUrl
+      properties:
+        providerId:
+          type: string
+          enum: [ollama, lmStudio]
+        baseUrl:
+          type: string
+          format: uri
+        lastValidatedAt:
+          type: string
+          format: date-time
+    ProviderConnectionSettingsRequest:
+      type: object
+      required:
+        - baseUrl
+      properties:
+        baseUrl:
+          type: string
+          format: uri
+    CapabilityAvailabilityState:
+      type: object
+      required:
+        - capabilityId
+        - providerId
+        - isReady
+        - status
+      properties:
+        capabilityId:
+          type: string
+          enum: [summarization, vision]
+        providerId:
+          type: string
+          enum: [builtIn, ollama, lmStudio]
+        isReady:
+          type: boolean
+        status:
+          type: string
+          enum: [ready, needs_configuration, daemon_unavailable, server_unavailable, model_missing, unsupported, vision_unsupported, unknown]
+        message:
+          type: string
+        selectedReference:
+          type: string
+    LMStudioValidationRequest:
+      type: object
+      required:
+        - capabilityId
+        - modelIdentifier
+      properties:
+        capabilityId:
+          type: string
+          enum: [summarization, vision]
+        modelIdentifier:
+          type: string
+          minLength: 1
+    LMStudioDiscoverySnapshot:
+      type: object
+      required:
+        - serverReachable
+        - discoveredAt
+        - models
+      properties:
+        serverReachable:
+          type: boolean
+        discoveredAt:
+          type: string
+          format: date-time
+        failureReason:
+          type: string
+        models:
+          type: array
+          items:
+            $ref: '#/components/schemas/LMStudioModelDescriptor'
+    LMStudioModelDescriptor:
+      type: object
+      required:
+        - identifier
+        - modelType
+        - supportsVision
+      properties:
+        identifier:
+          type: string
+        displayName:
+          type: string
+        modelType:
+          type: string
+          enum: [llm, vlm, embeddings]
+        publisher:
+          type: string
+        architecture:
+          type: string
+        compatibilityType:
+          type: string
+        quantizationLabel:
+          type: string
+        state:
+          type: string
+        maxContextLength:
+          type: integer
+          minimum: 1
+        supportsVision:
+          type: boolean
+  parameters:
+    CapabilityId:
+      name: capabilityId
+      in: path
+      required: true
+      schema:
+        type: string
+        enum: [summarization, vision]

--- a/specs/018-lm-studio-support/data-model.md
+++ b/specs/018-lm-studio-support/data-model.md
@@ -1,0 +1,179 @@
+# Data Model: LM Studio Provider Support
+
+This feature preserves the existing vault artifacts and extends capability-aware inference configuration so summarization and vision can each use `Built-in`, `Ollama`, or `LM Studio`.
+
+## Entities
+
+### InferenceCapability
+
+Represents one configurable AI task category.
+
+**Fields**:
+- `id: String`
+  - Enum: `summarization | vision`
+- `displayName: String`
+
+**Validation**:
+- `id` must be one of the supported capability identifiers.
+
+### InferenceProvider
+
+Represents the runtime family used for one capability.
+
+**Fields**:
+- `id: String`
+  - Enum: `builtIn | ollama | lmStudio`
+- `displayName: String`
+- `description: String`
+
+**Validation**:
+- `id` must be one of the supported provider identifiers.
+
+### InferenceConfigurationPreference
+
+Represents the persisted local configuration for one capability.
+
+**Fields**:
+- `capabilityID: String`
+- `selectedProviderID: String`
+- `builtInModelID: String?`
+- `ollamaModelTag: String?`
+- `lmStudioModelIdentifier: String?`
+- `lastUpdatedAt: Date?`
+
+**Validation**:
+- `capabilityID` must resolve to a known `InferenceCapability`.
+- `selectedProviderID` must resolve to a known `InferenceProvider`.
+- `builtInModelID`, when present, must resolve to a known built-in model for that capability.
+- `ollamaModelTag`, when present, must be a non-empty trimmed tag string.
+- `lmStudioModelIdentifier`, when present, must be a non-empty trimmed local model identifier.
+- Changing configuration for one capability must not erase the stored selection values for the other capability.
+
+### ProviderConnectionPreference
+
+Represents persisted local connection details for an advanced provider.
+
+**Fields**:
+- `providerID: String`
+  - Enum: `ollama | lmStudio`
+- `baseURL: String`
+- `lastValidatedAt: Date?`
+
+**Validation**:
+- `providerID` must identify a provider that uses a user-managed local server.
+- `baseURL` must be a valid HTTP or HTTPS URL.
+- For `lmStudio`, the default value is the local loopback server on port `1234`.
+
+### LMStudioDiscoverySnapshot
+
+Represents the most recent view of the local LM Studio server and the models it exposes.
+
+**Fields**:
+- `serverReachable: Bool`
+- `discoveredAt: Date`
+- `models: [LMStudioModelDescriptor]`
+- `failureReason: String?`
+
+**Validation**:
+- `models` may be empty when the server is reachable but no compatible local models are visible.
+- `failureReason` is present only when discovery could not complete successfully.
+
+### LMStudioModelDescriptor
+
+Represents one LM Studio model exposed by the local server.
+
+**Fields**:
+- `identifier: String`
+- `displayName: String`
+- `modelType: String`
+  - Examples: `llm`, `vlm`, `embeddings`
+- `publisher: String?`
+- `architecture: String?`
+- `compatibilityType: String?`
+- `quantizationLabel: String?`
+- `state: String?`
+- `maxContextLength: Int?`
+- `supportsVision: Bool`
+
+**Validation**:
+- `identifier` must be unique within one discovery snapshot.
+- `supportsVision == true` when `modelType` indicates a vision-capable model.
+- `maxContextLength`, when present, must be greater than zero.
+
+### CapabilityAvailabilityState
+
+Represents the user-facing readiness state for one capability's current provider and model selection.
+
+**Fields**:
+- `capabilityID: String`
+- `providerID: String`
+- `isReady: Bool`
+- `status: String`
+  - Enum: `ready | needs_configuration | daemon_unavailable | server_unavailable | model_missing | unsupported | vision_unsupported | unknown`
+- `message: String?`
+- `selectedReference: String?`
+
+**Validation**:
+- `capabilityID` must match the capability being evaluated.
+- `providerID` must match the provider being evaluated.
+- `isReady == true` only when `status == ready`.
+- `daemon_unavailable` is used for providers backed by a daemon-style local service such as Ollama.
+- `server_unavailable` is used for providers backed by a local HTTP server such as LM Studio.
+
+### InferenceTaskBinding
+
+Represents the immutable provider/runtime selection captured when an inference task starts.
+
+**Fields**:
+- `capabilityID: String`
+- `providerID: String`
+- `providerReference: String`
+  - built-in model ID, Ollama tag, or LM Studio model identifier
+- `connectionBaseURLString: String?`
+- `capturedAt: Date`
+- `supportsVisionInputs: Bool`
+
+**Validation**:
+- `capabilityID` must match a known capability.
+- `providerID` must match a known provider.
+- `providerReference` must be non-empty.
+- `connectionBaseURLString` is persisted for advanced providers so in-flight work stays pinned to the endpoint it started with.
+- The binding must not change after the task is created.
+
+## Relationships
+
+- `InferenceConfigurationPreference` belongs to exactly one `InferenceCapability`.
+- Each `InferenceCapability` selects exactly one active `InferenceProvider`.
+- `ProviderConnectionPreference` belongs to one advanced provider and may be shared across both capabilities.
+- `LMStudioDiscoverySnapshot` contains zero or more `LMStudioModelDescriptor` records discovered from the local LM Studio server.
+- `CapabilityAvailabilityState` is derived from `InferenceConfigurationPreference`, `ProviderConnectionPreference`, and provider-specific readiness checks.
+- `InferenceTaskBinding` is derived from `InferenceConfigurationPreference` at task start and is consumed by the active summarization or vision pipeline for the duration of that task.
+
+## State Transitions
+
+### Capability configuration flow
+
+1. `builtIn selected` -> `lmStudio selected`
+2. `ollama selected` -> `lmStudio selected`
+3. `lmStudio selected` -> `validating connection`
+4. `validating connection` -> `ready`
+5. `validating connection` -> `service_unavailable`
+6. `validating connection` -> `model_missing`
+7. `validating connection` -> `vision_unsupported`
+8. `lmStudio selected` -> `builtIn selected`
+9. `lmStudio selected` -> `ollama selected`
+
+### LM Studio discovery flow
+
+1. `idle` -> `checking local server`
+2. `checking local server` -> `inventory available`
+3. `checking local server` -> `service unavailable`
+4. `inventory available` -> `capabilities resolved`
+
+### Task binding flow
+
+1. User updates summarization or vision configuration in onboarding or settings.
+2. A new summarization or vision task starts.
+3. The system resolves an `InferenceTaskBinding` from the current configuration for that capability.
+4. The task executes entirely with that binding.
+5. Later configuration changes affect only future tasks.

--- a/specs/018-lm-studio-support/plan.md
+++ b/specs/018-lm-studio-support/plan.md
@@ -1,0 +1,181 @@
+# Implementation Plan: LM Studio Provider Support
+
+**Branch**: `018-lm-studio-support` | **Date**: 2026-04-02 | **Spec**: [spec.md](../018-lm-studio-support/spec.md)
+**Input**: Feature specification from `/specs/018-lm-studio-support/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add `LM Studio` as a third local inference provider for summarization and screen-context vision in onboarding and settings, matching the current advanced-provider workflow without changing the three-file vault contract. The implementation will keep provider binding in `MinuteCore`, add a dedicated `MinuteLMStudio` runtime target for local server discovery and inference, and generalize current Ollama-specific persistence and readiness paths so `Built-in`, `Ollama`, and `LM Studio` coexist cleanly.
+
+## Technical Context
+
+**Language/Version**: Swift 6.2 tools for `MinuteCore`; Swift/SwiftUI macOS app target on Xcode 15.x conventions  
+**Primary Dependencies**: SwiftUI, Combine, `MinuteCore`, `MinuteLlama`, `MinuteOllama`, new `MinuteLMStudio` target, Foundation networking for local server calls, AVFoundation, ScreenCaptureKit, FluidAudio  
+**Storage**: Local vault files, `UserDefaults`-backed provider preferences and local server settings, Application Support model artifacts for built-in runtimes, and user-managed Ollama and LM Studio state outside Minute  
+**Testing**: Swift Testing in `MinuteCore/Tests/MinuteCoreTests` plus app-facing tests in `MinuteTests`  
+**Target Platform**: macOS 14+ (Apple Silicon focus)
+**Project Type**: Native macOS app (`Minute/`) with shared business logic in Swift Package (`MinuteCore/`) and runtime-specific package targets  
+**Performance Goals**: Provider changes and readiness refresh should feel immediate in onboarding and settings; LM Studio discovery should complete quickly against the local server; summarization and vision startup should not regress existing responsiveness beyond local availability checks  
+**Constraints**: Preserve the exact three-file vault contract; local-only processing only; no outbound network calls except model downloads; keep summarization and vision configuration independent; freeze provider and model at task start; keep LM Studio scoped to local loopback server usage; UI remains thin and business logic stays in `MinuteCore`  
+**Scale/Scope**: Single-user desktop workflow covering onboarding, settings, capability-specific model readiness, reprocessing, summarization runtime selection, vision runtime selection, and local LM Studio model discovery for one machine at a time
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Output contract unchanged or updated docs/tests included. ✅ Unchanged three-file vault contract; plan adds regression coverage around provider selection without changing note, audio, or transcript paths.
+- Local-only processing preserved; no outbound network calls beyond model downloads. ✅ Preserved; LM Studio integration is scoped to a user-managed local loopback server.
+- Deterministic Markdown rendering maintained for any note changes. ✅ Preserved; provider choice changes runtime selection only, not renderer behavior or vault write contract.
+- MinuteCore tests added/updated for new behavior (renderer, file contracts, JSON validation). ✅ Planned for provider persistence, LM Studio discovery/validation, immutable task binding, and contract regression coverage.
+- Pipeline state machine and cancellation support respected for long-running work. ✅ Planned; provider selection is resolved before task start and long-running work remains behind existing coordinator boundaries.
+
+**Gate Status**: PASS (no justified violations)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-lm-studio-support/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+Minute/
+├── Sources/
+│   ├── Views/
+│   │   ├── Onboarding/
+│   │   │   ├── OnboardingView.swift
+│   │   │   └── OnboardingViewModel.swift
+│   │   └── Settings/
+│   │       ├── ModelsSettingsSection.swift
+│   │       ├── ModelsSettingsViewModel.swift
+│   │       └── InferenceCapabilityStatusView.swift
+│   └── ViewModels/
+│       ├── MeetingPipelineViewModel.swift
+│       └── ModelSetupLifecycleController.swift
+
+MinuteTests/
+├── OnboardingInferenceProviderTests.swift
+├── ModelsSettingsInferenceProviderTests.swift
+├── MeetingPipelineViewModelScreenContextAlertsTests.swift
+└── MeetingNotesBrowserViewModelReprocessingTests.swift
+
+MinuteCore/
+├── Package.swift
+├── Sources/
+│   ├── MinuteCore/
+│   │   ├── Configuration/
+│   │   │   └── AppConfiguration.swift
+│   │   ├── Domain/
+│   │   │   ├── InferenceCapability.swift
+│   │   │   ├── InferenceProvider.swift
+│   │   │   ├── CapabilityAvailabilityState.swift
+│   │   │   └── LMStudioModelDescriptor.swift
+│   │   ├── Pipeline/
+│   │   │   └── MeetingPipelineCoordinator.swift
+│   │   └── Services/
+│   │       ├── InferenceProviderSelectionStore.swift
+│   │       ├── InferenceRuntimeFactory.swift
+│   │       ├── DefaultModelManager.swift
+│   │       ├── ServiceProtocols.swift
+│   │       └── ProviderConnectionSettingsStore.swift
+│   ├── MinuteLlama/
+│   │   └── Services/
+│   ├── MinuteOllama/
+│   │   └── Services/
+│   └── MinuteLMStudio/
+│       └── Services/
+│           ├── LMStudioAPIClient.swift
+│           ├── LMStudioModelDiscoveryService.swift
+│           ├── LMStudioSummarizationService.swift
+│           └── LMStudioVisionInferenceService.swift
+└── Tests/
+    └── MinuteCoreTests/
+        ├── InferenceProviderSelectionStoreTests.swift
+        ├── InferenceRuntimeFactoryTests.swift
+        ├── LMStudioModelDiscoveryServiceTests.swift
+        └── OutputContractCoverageTests.swift
+```
+
+**Structure Decision**: Keep capability-neutral orchestration, persistence, and pipeline binding in `MinuteCore`, preserve existing built-in and Ollama runtime modules, and add a sibling `MinuteLMStudio` target for LM Studio-specific discovery, validation, and inference. The app target remains thin and imports runtime modules only where it builds live service factories and provider-facing UI state.
+
+## Phase 0 — Research (completed)
+
+See [research.md](../018-lm-studio-support/research.md).
+
+Key conclusions:
+- Use LM Studio's OpenAI-compatible local inference endpoints for summarization and vision.
+- Use local model-discovery endpoints with richer LM Studio metadata to validate model availability and vision capability.
+- Keep LM Studio scoped to a loopback-local server to stay within Minute's local-only constitution.
+- Add a dedicated `MinuteLMStudio` runtime target and generalize current Ollama-specific provider state where needed.
+
+## Phase 1 — Design & Contracts (completed)
+
+- Data model: [data-model.md](../018-lm-studio-support/data-model.md)
+- Internal contracts: [contracts/openapi.yaml](../018-lm-studio-support/contracts/openapi.yaml)
+- Validation and QA flow: [quickstart.md](../018-lm-studio-support/quickstart.md)
+
+## Phase 2 — Implementation Plan
+
+### 1. Extend provider domain and persisted settings
+
+- Add `LM Studio` to the provider catalog and user-facing provider descriptions.
+- Extend persisted configuration so each capability can retain built-in, Ollama, and LM Studio model references independently.
+- Add LM Studio local server settings with a loopback default and preserve existing upgraded-user defaults.
+- Refactor current Ollama-named persistence seams where necessary so the app does not accumulate duplicate advanced-provider state.
+
+### 2. Generalize runtime binding while preserving immutable per-task selection
+
+- Extend `InferenceRuntimeFactory` so summarization and vision can resolve `LM Studio` bindings without changing the existing task-start binding model.
+- Keep provider/model resolution frozen at task start for summarization, screen-context inference, and reprocessing flows.
+- Preserve built-in and Ollama behavior for users who never choose LM Studio.
+
+### 3. Add a dedicated `MinuteLMStudio` runtime integration
+
+- Add a new Swift package target for LM Studio discovery, validation, summarization, and vision inference.
+- Implement local server access through LM Studio's documented local endpoints.
+- Translate local server and model-availability failures into concise `MinuteError` user-facing states rather than raw transport errors.
+
+### 4. Add LM Studio readiness, discovery, and validation flows
+
+- Discover local LM Studio models from the configured local server.
+- Validate that the selected LM Studio model still exists and is appropriate for the selected capability.
+- Block vision configuration when the selected LM Studio model is not vision-capable.
+- Surface capability-specific readiness messages that remain clear whether the affected provider is built-in, Ollama, or LM Studio.
+
+### 5. Update onboarding and settings for third-provider parity
+
+- Extend onboarding and settings view models so summarization and vision each expose `Built-in`, `Ollama`, and `LM Studio`.
+- Surface LM Studio connection and model controls only when that provider is selected.
+- Preserve the distinction between summarization, vision, and transcription configuration.
+- Ensure provider copy remains understandable to advanced but non-developer users.
+
+### 6. Test plan (TDD, contract-first)
+
+- Add `MinuteCore` tests for provider enum expansion, persisted migration defaults, and independent provider/model retention across summarization and vision.
+- Add `MinuteCore` tests for LM Studio connection validation, model-discovery parsing, vision-capability rejection, and immutable task binding.
+- Add `MinuteTests` coverage for onboarding and settings exposure, persistence, readiness messaging, and provider switching.
+- Add regression tests confirming the deterministic three-file vault contract remains unchanged regardless of provider combination.
+
+## Post-Design Constitution Re-check
+
+- Output contract: unchanged; LM Studio affects runtime selection only and does not alter artifact count, paths, or atomic writes ✅
+- Local-only and privacy: preserved; LM Studio is scoped to a local loopback server and introduces no new remote dependency beyond allowed model downloads ✅
+- Determinism: note rendering remains unchanged and provider/model binding is frozen at task start to avoid mid-task drift ✅
+- Test-gated core logic: plan adds `MinuteCore` and app tests for persistence, discovery, validation, binding, and contract regressions ✅
+- State machine and cancellation: long-running work remains inside existing coordinator boundaries with no UI-thread blocking design ✅
+
+## Complexity Tracking
+
+No constitution violations are required for this feature.

--- a/specs/018-lm-studio-support/quickstart.md
+++ b/specs/018-lm-studio-support/quickstart.md
@@ -1,0 +1,134 @@
+# Quickstart: LM Studio Provider Support
+
+## Goal
+
+Validate that Minute can configure summarization and vision independently, using `Built-in`, `Ollama`, or `LM Studio` for each capability, while preserving the existing vault contract.
+
+This feature is intended for advanced users. Minute continues to treat summarization and screen-context vision as separate capabilities with separate provider and model choices, separate readiness state, and immutable per-run bindings once work starts.
+
+## Preconditions
+
+- The app is built from branch `018-lm-studio-support`.
+- A local vault is configured.
+- At least one built-in summarization model is available through the existing model-management path.
+- At least one built-in vision-capable model is available through the existing model-management path.
+- Ollama is installed locally for cross-provider regression scenarios.
+- LM Studio is installed locally and its local server is running on the configured local base URL for LM Studio-specific scenarios.
+- At least one LM Studio text-capable model is visible to the local LM Studio server for the happy-path summarization scenario.
+- At least one LM Studio vision-capable model is visible to the local LM Studio server for the happy-path vision scenario.
+
+## Validation Scenarios
+
+### 1. Choose LM Studio during onboarding
+
+1. Launch the app in a clean onboarding state.
+2. Move to the AI models step in onboarding.
+3. Verify the AI configuration shows separate controls for summarization and vision.
+4. Select `LM Studio` for summarization.
+5. Select `LM Studio`, `Built-in`, or `Ollama` for vision.
+6. Enter the LM Studio base URL and choose provider-appropriate model references.
+7. Complete onboarding.
+
+Expected result:
+- Onboarding exposes `LM Studio` anywhere summarization or vision provider choice is available.
+- The LM Studio connection details and selected model persist.
+- Summarization and vision remain independently configurable.
+- Onboarding blocks completion when the selected LM Studio configuration is invalid or unavailable.
+
+### 2. Change providers independently in settings
+
+1. Start with onboarding completed and built-in selected for both capabilities.
+2. Open settings and navigate to AI models.
+3. Change summarization to `LM Studio`.
+4. Leave vision on another provider, then switch vision to `LM Studio`.
+5. Close and reopen settings.
+
+Expected result:
+- Summarization and vision configuration persist across settings reloads.
+- Changing one capability does not erase or overwrite the other capability's saved selection.
+- Returning to `LM Studio` restores the previously saved LM Studio model selection for that capability unless the user changed it.
+
+### 3. Discover local LM Studio models
+
+1. Ensure the LM Studio local server is running with at least one compatible model visible.
+2. Open onboarding or settings with `LM Studio` selected.
+3. Trigger provider refresh if needed.
+4. Inspect the discovered LM Studio model list.
+
+Expected result:
+- The app lists models currently exposed by the local LM Studio server.
+- The selected model can be validated against the discovered identifiers.
+- The app can distinguish text-only and vision-capable models for readiness checks.
+- Discovery remains local-only.
+
+### 4. Reject a non-vision LM Studio model for screen context
+
+1. Select `LM Studio` for vision.
+2. Choose an LM Studio model that does not support vision work.
+3. Save or validate the vision configuration.
+
+Expected result:
+- The app blocks the vision selection.
+- The error explains that the selected model does not support vision.
+- Summarization configuration remains unchanged.
+
+### 5. Handle missing local LM Studio prerequisites cleanly
+
+1. Stop the LM Studio local server or choose a model that is no longer available.
+2. Open settings with `LM Studio` selected.
+3. Attempt to keep `LM Studio` selected for summarization or vision and start related work.
+
+Expected result:
+- The app reports a concise, actionable readiness error.
+- The error explains whether the local server is unavailable or the selected model is missing.
+- The app does not leak raw transport errors, transcript content, or captured image content.
+- The user can switch the affected capability back to another provider without losing unrelated settings.
+
+### 6. Bind provider choice at task start
+
+1. Start a meeting-processing run with one summarization configuration.
+2. While the run is still active, open settings and change summarization configuration to or from `LM Studio`.
+3. Let the in-flight run finish.
+4. Start a second run after the switch.
+5. Repeat the same pattern for active screen-context inference and the vision configuration.
+
+Expected result:
+- The in-flight task completes using the provider and model it started with.
+- The later task uses the newly selected provider and model.
+- No extra vault files are created and the existing three-file contract is preserved.
+
+## Suggested Test Commands
+
+Run MinuteCore tests:
+
+```bash
+swift test --package-path MinuteCore
+```
+
+Run app and integration tests:
+
+```bash
+xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug test
+```
+
+## Validation Results
+
+Validation was attempted on 2026-04-02.
+
+- `swift test --package-path MinuteCore`
+  - Blocked by upstream dependency compilation failures in the checked-out `FluidAudio` package.
+  - Observed failure area: strict-concurrency errors in `StreamingAsrManager.swift`.
+- `xcodebuild -project Minute.xcodeproj -scheme Minute -configuration Debug test`
+  - Blocked before project compilation by a local Xcode environment issue.
+  - Observed failure area: broken `IDESimulatorFoundation` plugin state with `xcodebuild` suggesting `-runFirstLaunch`.
+
+Feature-specific verification completed through targeted source inspection and updated unit-test coverage, but full automated regression remains pending until the local toolchain issues above are resolved.
+
+## Focused Test Additions
+
+- Provider enum and persistence migration to include `LM Studio`
+- LM Studio connection settings validation and persistence
+- LM Studio discovery parsing and vision-capability validation
+- Runtime factory/provider binding for summarization and vision tasks
+- Onboarding and settings provider-selection persistence and readiness messaging
+- Contract regression tests for unchanged three-file meeting output

--- a/specs/018-lm-studio-support/research.md
+++ b/specs/018-lm-studio-support/research.md
@@ -1,0 +1,94 @@
+# Research: LM Studio Provider Support
+
+**Feature Branch**: `018-lm-studio-support`  
+**Date**: 2026-04-02  
+**Spec**: [spec.md](../018-lm-studio-support/spec.md)
+
+## Decision 1: Use LM Studio's OpenAI-compatible local endpoints for summarization and vision
+
+**Decision**: Implement LM Studio inference through its OpenAI-compatible local server endpoints, using the same provider-binding flow for both summarization and vision.
+
+**Rationale**:
+- LM Studio documents OpenAI-compatible local endpoints for `GET /v1/models`, `POST /v1/responses`, and `POST /v1/chat/completions`, and explicitly states that chat completions support text and images.
+- Reusing OpenAI-style request and response shapes keeps the runtime boundary simple and avoids forcing `MinuteCore` to learn a provider-specific request dialect for every capability.
+- This preserves the existing Minute contract where provider resolution happens once at task start and the downstream summarization or vision service then behaves like any other local runtime.
+
+**Alternatives considered**:
+- Use LM Studio's SDKs directly: rejected because Minute already centers runtime integrations behind local service boundaries and Foundation networking is sufficient.
+- Use only `POST /v1/responses`: rejected for initial scope because chat completions already covers text and image inputs and matches the current app's provider-service split more directly.
+- Use a custom provider-specific prompt pipeline in the app target: rejected because orchestration belongs in `MinuteCore`, not the UI layer.
+
+## Decision 2: Use LM Studio model-discovery endpoints for readiness and capability validation
+
+**Decision**: Discover and validate LM Studio models through the local server's model-listing endpoints, using the richer LM Studio REST API metadata to distinguish text-only and vision-capable models.
+
+**Rationale**:
+- LM Studio's OpenAI-compatible `GET /v1/models` lists models visible to the server.
+- LM Studio's documented REST API v0 exposes `GET /api/v0/models` and `GET /api/v0/models/{model}` with richer metadata including model `type`, load `state`, and `max_context_length`.
+- The example model metadata distinguishes `llm` from `vlm`, which gives Minute a concrete local signal for rejecting non-vision LM Studio models when users configure screen-context vision.
+- Using local discovery preserves the advanced-user workflow already established for Ollama: validate what is currently available on the user's machine instead of guessing from model names.
+
+**Alternatives considered**:
+- Use only `GET /v1/models`: rejected because it is not sufficient on its own to reliably identify vision-capable models.
+- Infer vision support from model names: rejected because name-based heuristics are brittle and not a provider contract.
+- Skip readiness validation and fail only when inference starts: rejected because the spec requires actionable guidance before or at task start.
+
+## Decision 3: Keep LM Studio local-only and scoped to loopback by default
+
+**Decision**: Treat LM Studio as a loopback-local runtime for this feature, with a default base URL of `http://127.0.0.1:1234`, and do not plan support for remote LM Studio hosts in this scope.
+
+**Rationale**:
+- Minute's constitution permits outbound network access only for model downloads and requires local-first processing.
+- LM Studio documentation shows the local server on port `1234`; that gives the feature a clear parity default with the current Ollama base-URL flow.
+- Limiting scope to loopback keeps the privacy contract clear and avoids introducing a new category of networked inference behavior through an advanced-provider feature.
+
+**Alternatives considered**:
+- Allow any user-supplied LAN host: rejected because it conflicts with Minute's stricter local-only constitution.
+- Hardcode the default without exposing configuration: rejected because advanced users still need to point Minute at their local LM Studio server configuration.
+- Bundle or launch LM Studio from Minute: rejected because LM Studio remains user-managed infrastructure outside Minute's responsibility.
+
+## Decision 4: Add a dedicated `MinuteLMStudio` runtime target and keep provider-neutral orchestration in `MinuteCore`
+
+**Decision**: Implement LM Studio transport, discovery, validation, and service adapters in a new `MinuteLMStudio` package target while keeping selection, persistence, runtime binding, and capability orchestration in `MinuteCore`.
+
+**Rationale**:
+- The repository already uses runtime-specific targets such as `MinuteLlama` and `MinuteOllama`.
+- `InferenceRuntimeFactory` is already the central provider-binding seam; keeping it provider-neutral while adding LM Studio-specific builders matches the current architecture and minimizes UI coupling.
+- A dedicated target keeps provider-specific networking and response mapping out of the core domain layer.
+
+**Alternatives considered**:
+- Put LM Studio code directly in `MinuteCore`: rejected because it would mix provider-neutral orchestration with transport-specific behavior.
+- Extend `MinuteOllama` to also handle LM Studio: rejected because the providers have different discovery and request contracts.
+- Put LM Studio integration in the app target: rejected because runtime selection and validation must remain testable in `MinuteCore`.
+
+## Decision 5: Generalize advanced-provider persistence and readiness state instead of cloning Ollama-only structures
+
+**Decision**: Refactor the current Ollama-specific persistence and readiness seams into provider-neutral capability settings, while still allowing provider-specific discovery payloads behind those abstractions.
+
+**Rationale**:
+- The current `InferenceProviderSelectionStore`, `InferenceRuntimeFactory`, onboarding view model, and settings view model are provider-aware but still carry Ollama-specific fields and naming.
+- Adding LM Studio by duplicating `selectedOllama...`, `ollamaDiscoverySnapshot`, and Ollama-only storage keys would increase UI branching and make future provider work more expensive.
+- Provider-neutral state makes it easier to preserve the user-facing behavior required by the spec: separate summarization and vision configuration, actionable readiness, and stable in-flight task binding.
+
+**Alternatives considered**:
+- Add LM Studio as a second provider-specific path beside Ollama with mirrored fields: rejected because it would spread provider-specific branching across settings, onboarding, runtime factories, and persistence.
+- Replace the current advanced-provider model with one generic opaque string field: rejected because the app still needs explicit readiness, validation, and provider-specific guidance.
+
+## Decision 6: Keep initial LM Studio scope aligned with current advanced-provider ergonomics
+
+**Decision**: Scope the feature to user-managed local base URL plus model selection, without adding provider-specific download orchestration or authentication workflows in the first iteration.
+
+**Rationale**:
+- The feature request is to support LM Studio "just as" Ollama, which currently centers on choosing the provider, entering the local connection, selecting a local model, and surfacing readiness.
+- This keeps the feature bounded around provider parity rather than expanding into provider administration.
+- Existing deterministic note rendering, vault writing, and transcription behavior remain unchanged.
+
+**Alternatives considered**:
+- Add LM Studio model download management inside Minute: rejected because it expands scope beyond provider parity.
+- Add token-based authentication flows now: rejected because the current Minute advanced-provider flows do not include auth management and the feature can provide value without it.
+
+## References
+
+- LM Studio OpenAI Compatibility Endpoints: https://lmstudio.ai/docs/developer/openai-compat
+- LM Studio List Models (`GET /v1/models`): https://lmstudio.ai/docs/developer/openai-compat/models
+- LM Studio REST API v0: https://lmstudio.ai/docs/developer/rest/endpoints

--- a/specs/018-lm-studio-support/spec.md
+++ b/specs/018-lm-studio-support/spec.md
@@ -1,0 +1,138 @@
+# Feature Specification: LM Studio Provider Support
+
+**Feature Branch**: `018-lm-studio-support`  
+**Created**: 2026-04-02  
+**Status**: Draft  
+**Input**: User description: "spec prefix 018 LM Studio support. Just as ollama implementation but for LM Studio."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Choose LM Studio During AI Setup (Priority: P1)
+
+As an advanced user, I want to choose LM Studio for summarization and for screen-context vision during setup so I can use the local runtime stack I already manage.
+
+**Why this priority**: Setup is the first place advanced users expect to define their preferred inference provider, and LM Studio support has the most value when it is available from first use.
+
+**Independent Test**: Start from a clean app state, enter the setup flow, choose LM Studio for summarization and for vision, provide the required local LM Studio connection and model details, finish setup, and verify those selections are saved for later use.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is configuring AI behavior during setup, **When** the user opens provider choices for summarization, **Then** `LM Studio` appears alongside the existing local provider options.
+2. **Given** the user is configuring AI behavior during setup, **When** the user opens provider choices for screen-context vision, **Then** `LM Studio` appears alongside the existing local provider options.
+3. **Given** the user selects `LM Studio` for summarization or vision during setup, **When** the user enters the required local connection and model details and completes setup, **Then** future runs for that capability use the saved LM Studio selection.
+4. **Given** the user revisits the setup flow before confirmation, **When** the user changes a provider or model selection, **Then** only the latest selections are saved.
+
+---
+
+### User Story 2 - Manage LM Studio Configuration Later in Settings (Priority: P2)
+
+As an advanced user, I want to switch a capability to LM Studio later in settings and adjust its saved connection or model details without re-running onboarding.
+
+**Why this priority**: Advanced users often refine their local model setup after first launch, so the feature must remain fully manageable after onboarding.
+
+**Independent Test**: Open settings in an already configured app, switch either summarization or vision to LM Studio, adjust the saved local connection or model details, save the change, and verify the chosen capability uses the updated LM Studio selection without altering the other capability.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app has already been configured, **When** the user opens settings, **Then** summarization and vision each expose editable provider and model choices that include `LM Studio`.
+2. **Given** the user changes summarization to `LM Studio`, **When** the change is saved, **Then** the saved vision provider and model remain unchanged.
+3. **Given** the user changes vision to `LM Studio`, **When** the change is saved, **Then** the saved summarization provider and model remain unchanged.
+4. **Given** the user temporarily switches away from `LM Studio`, **When** the user returns to `LM Studio` later, **Then** the previously saved LM Studio details for that capability remain available unless the user replaces them.
+
+---
+
+### User Story 3 - Receive Clear Readiness Feedback for LM Studio (Priority: P3)
+
+As an advanced user, I want clear feedback when LM Studio is unavailable or a chosen model is unsuitable so I can fix the local configuration without guessing.
+
+**Why this priority**: Advanced-provider features fail in practice if users cannot tell whether the local runtime is reachable, correctly configured, or compatible with the task they selected.
+
+**Independent Test**: Configure LM Studio for summarization or vision with an unavailable local connection or an incompatible model, then verify that the app keeps the saved settings, blocks only the affected capability, and shows actionable guidance.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has selected `LM Studio` for a capability, **When** the app cannot reach the configured local LM Studio runtime, **Then** the app shows a clear message explaining that the local runtime is unavailable and how the user can correct the configuration.
+2. **Given** the user has selected `LM Studio` for vision, **When** the chosen LM Studio model cannot support vision work, **Then** the app blocks that vision configuration and explains what needs to change.
+3. **Given** an LM Studio configuration is temporarily unavailable, **When** the local runtime becomes available again, **Then** the app can use the saved LM Studio selection without requiring the user to enter it again.
+
+### Edge Cases
+
+- A user upgrades from a version that supports `Built-in` and `Ollama` only and must keep their existing behavior unless they actively choose `LM Studio`.
+- Summarization uses `LM Studio` while vision uses `Built-in` or `Ollama`, and each capability must remain independently editable.
+- Vision uses `LM Studio` while summarization stays on another provider, and the app must validate only the affected capability.
+- The saved LM Studio connection becomes unavailable between app launches, but the user must still be able to open settings and correct it.
+- A selected LM Studio model is no longer available locally, and the app must explain the issue without discarding the user's saved choice.
+- The user changes LM Studio settings while summarization or vision work is already in progress; the active work must keep its starting configuration and later work must use the updated one.
+- Adding LM Studio must not change transcription behavior or the deterministic three-file meeting output contract.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST offer `LM Studio` as a provider option for summarization.
+- **FR-002**: The system MUST offer `LM Studio` as a provider option for screen-context vision.
+- **FR-003**: The setup flow MUST present `LM Studio` anywhere users currently choose a local provider for summarization or vision.
+- **FR-004**: Settings MUST present `LM Studio` anywhere users currently choose a local provider for summarization or vision.
+- **FR-005**: The system MUST let users save the local LM Studio connection details needed to reach their LM Studio runtime.
+- **FR-006**: The system MUST let users save the LM Studio model selection separately for summarization and for vision.
+- **FR-007**: The system MUST persist LM Studio choices independently from `Built-in` and `Ollama` choices so switching one capability does not overwrite another capability's saved selection.
+- **FR-008**: The system MUST preserve existing `Built-in` and `Ollama` behavior for users who do not choose `LM Studio`.
+- **FR-009**: The system MUST assign non-disruptive defaults for upgraded users so existing summarization and vision behavior remains unchanged after LM Studio support is added.
+- **FR-010**: The system MUST show which provider and model are currently active for summarization and which are currently active for vision.
+- **FR-011**: The system MUST validate whether the saved LM Studio configuration is currently usable for the selected capability.
+- **FR-012**: The system MUST provide actionable user-facing guidance when the saved LM Studio runtime cannot be reached.
+- **FR-013**: The system MUST provide actionable user-facing guidance when the selected LM Studio model is unavailable for the chosen capability.
+- **FR-014**: The system MUST prevent a vision configuration from proceeding when the selected LM Studio model cannot perform vision work.
+- **FR-015**: The system MUST allow users to change summarization provider or model without changing vision provider or model.
+- **FR-016**: The system MUST allow users to change vision provider or model without changing summarization provider or model.
+- **FR-017**: The system MUST preserve previously entered LM Studio details for a capability when the user switches that capability to another provider and later returns to LM Studio.
+- **FR-018**: A summarization run already in progress MUST keep the provider and model it started with even if the user changes summarization settings before the run completes.
+- **FR-019**: A screen-context vision task already in progress MUST keep the provider and model it started with even if the user changes vision settings before the task completes.
+- **FR-020**: New summarization runs started after a configuration change MUST use the most recently saved summarization provider and model.
+- **FR-021**: New screen-context vision tasks started after a configuration change MUST use the most recently saved vision provider and model.
+- **FR-022**: The system MUST keep LM Studio configuration local to the device and MUST NOT require a cloud account or hosted service.
+- **FR-023**: The configuration experience MUST continue to distinguish summarization, vision, and transcription so users do not confuse the three responsibilities.
+- **FR-024**: The system MUST continue to support reprocessing or later note generation using the currently saved summarization provider and model, including when that provider is `LM Studio`.
+- **FR-025**: If screen context is disabled, the system MUST preserve the saved LM Studio vision configuration for later use without affecting summarization behavior.
+
+### Non-Functional Requirements *(mandatory)*
+
+- **NFR-001**: The feature MUST preserve local-only processing and avoid outbound network calls except model downloads explicitly initiated for supported local runtimes.
+- **NFR-002**: The feature MUST preserve deterministic note rendering and the existing three-file meeting output contract regardless of whether summarization or vision uses `Built-in`, `Ollama`, or `LM Studio`.
+- **NFR-003**: Provider validation, switching, and readiness checks MUST keep the app responsive and MUST NOT block primary user interactions.
+- **NFR-004**: User-facing LM Studio status and error messages MUST be concise, actionable, and must not expose raw transcript content or raw captured images by default.
+- **NFR-005**: The setup and settings experience MUST remain consistent with the app's existing information architecture and predictable macOS UX expectations.
+
+### Key Entities *(include if feature involves data)*
+
+- **Inference Capability**: A configurable AI task category, either `summarization` or `vision`, each with its own provider and model selection.
+- **Inference Provider**: A user-selectable local runtime option, including `Built-in`, `Ollama`, and `LM Studio`, used for one inference capability.
+- **Local Provider Configuration**: The saved local connection and model details needed for one capability to use a selected provider.
+- **Capability Readiness State**: The current availability and compatibility status for a capability's saved provider and model selection.
+- **Inference Run Context**: The per-task record of which provider and model were resolved when a summarization or vision task began.
+
+## Assumptions
+
+- LM Studio is treated as a local-first runtime option managed by the user, similar to other advanced local provider choices.
+- This feature extends the existing advanced provider workflow rather than replacing `Built-in` or `Ollama`.
+- Users who choose LM Studio are comfortable providing the local connection and model details required for their setup.
+- This feature covers provider selection, validation, persistence, and runtime choice, not changes to note structure, prompts, or vault file layout.
+
+## Dependencies
+
+- Existing onboarding and settings flows must continue to support separate configuration for summarization and vision.
+- The summarization and vision pipelines must continue to resolve provider and model choice at task start so in-flight work remains stable.
+- User-managed LM Studio installation, model availability, and local runtime setup remain outside Minute's direct control.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance testing, 100% of clean-install users can find and select `LM Studio` for summarization during setup without leaving the AI configuration flow.
+- **SC-002**: In acceptance testing, 100% of clean-install users can find and select `LM Studio` for vision during setup without leaving the AI configuration flow.
+- **SC-003**: In acceptance testing, 100% of existing users can switch either summarization or vision to `LM Studio` from settings in 45 seconds or less.
+- **SC-004**: In validation testing, 100% of unavailable or incompatible LM Studio configurations produce an actionable user-facing message before or at task start.
+- **SC-005**: In migration testing, 100% of upgraded users retain their pre-existing summarization and vision behavior until they actively choose `LM Studio`.
+- **SC-006**: In concurrency testing, 100% of in-progress summarization and vision tasks complete with the provider and model they started with even if the user changes settings mid-task.
+- **SC-007**: In usability validation, at least 90% of advanced test users correctly distinguish summarization, vision, and transcription configuration on first attempt after LM Studio is added.
+- **SC-008**: In release QA, adding LM Studio introduces zero regressions to the deterministic three-file vault output contract for processed meetings.

--- a/specs/018-lm-studio-support/tasks.md
+++ b/specs/018-lm-studio-support/tasks.md
@@ -1,0 +1,220 @@
+# Tasks: LM Studio Provider Support
+
+**Input**: Design documents from `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/`
+**Prerequisites**: `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/plan.md`, `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/spec.md`, `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/research.md`, `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/data-model.md`, `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/contracts/openapi.yaml`
+
+**Tests**: Tests are REQUIRED for this feature because the Minute constitution requires TDD and this feature changes `MinuteCore`, runtime-selection contracts, provider persistence, and deterministic-output safety.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Wire the package and project structure for the new LM Studio runtime surface.
+
+- [X] T001 Update package target and product wiring for `MinuteLMStudio` in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Package.swift`
+- [X] T002 Update app target package references for `MinuteLMStudio` in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute.xcodeproj/project.pbxproj`
+- [X] T003 [P] Create LM Studio runtime service scaffolding in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioModelDiscoveryService.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioSummarizationService.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioVisionInferenceService.swift`
+- [X] T004 [P] Create provider-neutral LM Studio scaffolding in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Domain/LMStudioModelDescriptor.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/ProviderConnectionSettingsStore.swift`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish shared provider, persistence, and runtime infrastructure that MUST be complete before any user story work begins.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [X] T005 [P] Add failing provider-expansion and migration coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/AppConfigurationTests.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/InferenceProviderSelectionStoreTests.swift`
+- [ ] T006 [P] Add failing runtime-binding and reprocessing coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/InferenceRuntimeFactoryTests.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/MeetingPipelineCoordinatorReprocessingTests.swift`
+- [X] T007 [P] Add failing deterministic-output and model-manager regression coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/OutputContractCoverageTests.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/DefaultModelManagerTests.swift`
+- [X] T008 Extend the shared provider catalog and readiness statuses for `LM Studio` in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Domain/InferenceProvider.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Domain/CapabilityAvailabilityState.swift`
+- [X] T009 Implement LM Studio defaults and provider-connection persistence in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/InferenceProviderSelectionStore.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/ProviderConnectionSettingsStore.swift`
+- [ ] T010 [P] Extend shared provider protocols, default-model orchestration, and base LM Studio client support in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/ServiceProtocols.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/DefaultModelManager.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift`
+- [ ] T011 Implement LM Studio task-binding and runtime-resolution paths in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/InferenceRuntimeFactory.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift`
+
+**Checkpoint**: Foundation ready. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Choose LM Studio During AI Setup (Priority: P1) 🎯 MVP
+
+**Goal**: Let advanced users choose `LM Studio` for summarization and vision during onboarding and ensure later summarization runs use the saved LM Studio summarization selection.
+
+**Independent Test**: Start from a clean app state, complete onboarding with `LM Studio` selected for summarization and vision, and verify that the saved summarization provider/model are used by a later summarization run.
+
+### Tests for User Story 1 (REQUIRED) ⚠️
+
+> **NOTE: Write these tests first, ensure they fail before implementation.**
+
+- [X] T012 [P] [US1] Add failing onboarding LM Studio selection coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/OnboardingInferenceProviderTests.swift`
+- [X] T013 [P] [US1] Add failing LM Studio summarization binding coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/InferenceRuntimeFactoryTests.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/MeetingPipelineCoordinatorTests.swift`
+
+### Implementation for User Story 1
+
+- [X] T014 [P] [US1] Implement LM Studio summarization service mapping in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioSummarizationService.swift`
+- [X] T015 [P] [US1] Add onboarding LM Studio provider, connection, and model state in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift`
+- [X] T016 [P] [US1] Add onboarding LM Studio controls and copy in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Onboarding/OnboardingView.swift`
+- [X] T017 [US1] Integrate saved LM Studio summarization binding into processing and reprocessing flows in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift`
+
+**Checkpoint**: User Story 1 is complete when onboarding can save LM Studio selections and later summarization uses the saved LM Studio configuration.
+
+---
+
+## Phase 4: User Story 2 - Manage LM Studio Configuration Later in Settings (Priority: P2)
+
+**Goal**: Let users switch summarization or vision to `LM Studio` in settings, keep capability settings independent, and preserve LM Studio selections when they switch providers.
+
+**Independent Test**: Open settings in an already configured app, change either summarization or vision to `LM Studio`, save a local connection and model, and verify that the changed capability updates without overwriting the other capability.
+
+### Tests for User Story 2 (REQUIRED) ⚠️
+
+- [X] T018 [P] [US2] Add failing settings LM Studio persistence coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/ModelsSettingsInferenceProviderTests.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/AppConfigurationTests.swift`
+- [ ] T019 [P] [US2] Add failing independent capability and reprocessing coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/MeetingNotesBrowserViewModelReprocessingTests.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/InferenceRuntimeFactoryTests.swift`
+
+### Implementation for User Story 2
+
+- [X] T020 [P] [US2] Implement LM Studio vision service mapping in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioVisionInferenceService.swift`
+- [X] T021 [P] [US2] Add settings LM Studio provider, connection, and preserved-selection state in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/ModelsSettingsSection.swift`
+- [X] T022 [P] [US2] Add settings LM Studio controls for summarization and vision in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/SummarizationProviderPicker.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/VisionProviderPicker.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/SettingsFieldComponents.swift`
+- [X] T023 [US2] Wire settings-driven LM Studio selection into screen-context and reprocessing flows in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift`
+- [X] T024 [US2] Preserve per-capability LM Studio selections when switching providers in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/InferenceProviderSelectionStore.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift`
+
+**Checkpoint**: User Story 2 is complete when settings can manage LM Studio for either capability without disturbing the other capability.
+
+---
+
+## Phase 5: User Story 3 - Receive Clear Readiness Feedback for LM Studio (Priority: P3)
+
+**Goal**: Discover local LM Studio models, validate readiness, reject incompatible vision models, and surface actionable recovery guidance without leaking internal errors.
+
+**Independent Test**: Configure LM Studio for summarization or vision with an unavailable local server or an incompatible model, then verify that the app keeps the saved settings, blocks only the affected capability, and shows actionable guidance.
+
+### Tests for User Story 3 (REQUIRED) ⚠️
+
+- [X] T025 [P] [US3] Add failing LM Studio discovery and validation coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/LMStudioAPIClientTests.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/LMStudioModelDiscoveryServiceTests.swift`
+- [X] T026 [P] [US3] Add failing readiness and alert coverage in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/ModelsSettingsInferenceProviderTests.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/OnboardingInferenceProviderTests.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/MeetingPipelineViewModelScreenContextAlertsTests.swift`
+
+### Implementation for User Story 3
+
+- [X] T027 [P] [US3] Implement LM Studio discovery endpoints and model metadata mapping in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioModelDiscoveryService.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Domain/LMStudioModelDescriptor.swift`
+- [X] T028 [P] [US3] Implement LM Studio capability validation and readiness-state evaluation in `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/InferenceRuntimeFactory.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Domain/CapabilityAvailabilityState.swift`
+- [X] T029 [US3] Surface settings readiness, refresh, and validation feedback in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/ModelsSettingsSection.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/InferenceCapabilityStatusView.swift`
+- [X] T030 [US3] Surface onboarding readiness and recovery feedback in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift` and `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Onboarding/OnboardingView.swift`
+- [ ] T031 [US3] Keep active summarization and vision tasks pinned to their starting LM Studio binding in `/Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift`, `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift`, and `/Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/ScreenContextCaptureService.swift`
+
+**Checkpoint**: User Story 3 is complete when LM Studio readiness failures are validated and explained cleanly without breaking saved configuration or in-flight work.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish documentation, validate contract alignment, and record full regression results.
+
+- [X] T032 [P] Update feature validation guidance and product documentation in `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/quickstart.md` and `/Users/roblibob/Projects/FLX/Minute/Minute/docs/overview.md`
+- [X] T033 [P] Reconcile internal contract and data-model docs with the implemented provider flows in `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/contracts/openapi.yaml` and `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/data-model.md`
+- [X] T034 Run regression validation commands and record results in `/Users/roblibob/Projects/FLX/Minute/Minute/specs/018-lm-studio-support/quickstart.md` after executing `swift test --package-path /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore` and `xcodebuild -project /Users/roblibob/Projects/FLX/Minute/Minute/Minute.xcodeproj -scheme Minute -configuration Debug test`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies. Start immediately.
+- **Foundational (Phase 2)**: Depends on Setup. Blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational. This is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational. It can begin after Phase 2, but it reuses the shared LM Studio provider infrastructure from Phase 2.
+- **User Story 3 (Phase 5)**: Depends on Foundational. It is best completed after US1 and US2 because it hardens both onboarding and settings flows.
+- **Polish (Phase 6)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories after Phase 2.
+- **US2 (P2)**: No hard dependency on US1 after Phase 2, but it assumes the shared LM Studio provider infrastructure already exists.
+- **US3 (P3)**: No hard dependency on US1 or US2 by design, but practically validates and hardens the flows delivered by both stories.
+
+### Within Each User Story
+
+- Tests MUST be written and fail before implementation.
+- Shared provider/runtime updates must land before UI wiring that depends on them.
+- View-model changes must precede view changes.
+- Processing and pipeline integration happen after persistence and service resolution exist.
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: T003 and T004 can run in parallel after T001 and T002 are underway.
+- **Foundational**: T005, T006, and T007 can run in parallel; T009 and T010 can run in parallel after T008 defines the shared provider surface.
+- **US1**: T012 and T013 can run in parallel; T014 and T015 can run in parallel; T016 follows T015.
+- **US2**: T018 and T019 can run in parallel; T020, T021, and T022 can run in parallel; T023 depends on T020 and T021; T024 depends on T021.
+- **US3**: T025 and T026 can run in parallel; T027 and T028 can run in parallel; T029 and T030 depend on T027 and T028.
+- **Polish**: T032 and T033 can run in parallel once implementation is stable.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add failing onboarding LM Studio selection coverage in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/OnboardingInferenceProviderTests.swift"
+Task: "Add failing LM Studio summarization binding coverage in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/InferenceRuntimeFactoryTests.swift and /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/MeetingPipelineCoordinatorTests.swift"
+
+Task: "Implement LM Studio summarization service mapping in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioSummarizationService.swift"
+Task: "Add onboarding LM Studio provider, connection, and model state in /Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Onboarding/OnboardingViewModel.swift"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add failing settings LM Studio persistence coverage in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/ModelsSettingsInferenceProviderTests.swift and /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/AppConfigurationTests.swift"
+Task: "Add failing independent capability and reprocessing coverage in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/MeetingNotesBrowserViewModelReprocessingTests.swift and /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/InferenceRuntimeFactoryTests.swift"
+
+Task: "Implement LM Studio vision service mapping in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioVisionInferenceService.swift"
+Task: "Add settings LM Studio provider, connection, and preserved-selection state in /Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/ModelsSettingsViewModel.swift and /Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/ModelsSettingsSection.swift"
+Task: "Add settings LM Studio controls for summarization and vision in /Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/SummarizationProviderPicker.swift, /Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/VisionProviderPicker.swift, and /Users/roblibob/Projects/FLX/Minute/Minute/Minute/Sources/Views/Settings/SettingsFieldComponents.swift"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Add failing LM Studio discovery and validation coverage in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/LMStudioAPIClientTests.swift and /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Tests/MinuteCoreTests/LMStudioModelDiscoveryServiceTests.swift"
+Task: "Add failing readiness and alert coverage in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/ModelsSettingsInferenceProviderTests.swift, /Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/OnboardingInferenceProviderTests.swift, and /Users/roblibob/Projects/FLX/Minute/Minute/MinuteTests/MeetingPipelineViewModelScreenContextAlertsTests.swift"
+
+Task: "Implement LM Studio discovery endpoints and model metadata mapping in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift, /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioModelDiscoveryService.swift, and /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Domain/LMStudioModelDescriptor.swift"
+Task: "Implement LM Studio capability validation and readiness-state evaluation in /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Services/InferenceRuntimeFactory.swift and /Users/roblibob/Projects/FLX/Minute/Minute/MinuteCore/Sources/MinuteCore/Domain/CapabilityAvailabilityState.swift"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Stop and validate onboarding-driven LM Studio selection independently.
+
+### Incremental Delivery
+
+1. Setup and Foundational establish the shared provider, persistence, and runtime infrastructure.
+2. Deliver US1 to make LM Studio selectable and usable from onboarding.
+3. Deliver US2 to make LM Studio fully manageable from settings and reprocessing flows.
+4. Deliver US3 to harden discovery, readiness, validation, and error handling.
+5. Finish with documentation alignment and full regression validation.
+
+### Parallel Team Strategy
+
+1. One developer handles package/runtime scaffolding while another writes failing tests during Phases 1 and 2.
+2. After Phase 2:
+   - Developer A: US1 onboarding and summarization tasks.
+   - Developer B: US2 settings and vision tasks.
+   - Developer C: US3 discovery and readiness tasks after the shared LM Studio client exists.
+
+---
+
+## Notes
+
+- All tasks follow the required checklist format: checkbox, task ID, optional `[P]`, required `[US#]` label for story tasks, and exact file paths.
+- The recommended MVP scope is **User Story 1 only**.
+- Each user story remains independently testable once Phase 2 is complete.


### PR DESCRIPTION
This pull request introduces support for LM Studio as a new local inference provider alongside Ollama, updating the app's architecture, configuration, and UI to accommodate LM Studio for both summarization and vision tasks. The changes generalize provider and connection management, add new builders and discovery services for LM Studio, and update onboarding and settings to allow configuration of LM Studio endpoints.

**Support for LM Studio as a local inference provider:**

- Added `MinuteLMStudio` as a dependency in the Xcode project, updated build phases, and included it in the frameworks and Swift package dependencies (`Minute.xcodeproj/project.pbxproj`). [[1]](diffhunk://#diff-7c1855f081a970869b999935af8f9e5abc800d67afe9ca2640ea74f369a79814R12) [[2]](diffhunk://#diff-7c1855f081a970869b999935af8f9e5abc800d67afe9ca2640ea74f369a79814R109) [[3]](diffhunk://#diff-7c1855f081a970869b999935af8f9e5abc800d67afe9ca2640ea74f369a79814R242) [[4]](diffhunk://#diff-7c1855f081a970869b999935af8f9e5abc800d67afe9ca2640ea74f369a79814R905-R909)
- Updated documentation to reflect LM Studio support in the specification history and active technologies (`specs/AGENTS.md`).

**Generalization of provider and connection management:**

- Replaced the Ollama-specific endpoint store with a generalized `ProviderConnectionSettingsStore` for managing both Ollama and LM Studio endpoints in view models (`MeetingPipelineViewModel.swift`, `MeetingNotesBrowserViewModel.swift`). [[1]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL554-R555) [[2]](diffhunk://#diff-20fd93307da41ca9988a76d430f5fd894a35e5177cd25ff6f311a254f6701c29L990-R991)
- Updated builder closures and runtime factories to accept both Ollama and LM Studio, adding new summarization and vision builders for LM Studio (`MeetingPipelineViewModel.swift`, `MeetingNotesBrowserViewModel.swift`). [[1]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL563-R577) [[2]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eR600-R610) [[3]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL604-R624) [[4]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL615-R646) [[5]](diffhunk://#diff-20fd93307da41ca9988a76d430f5fd894a35e5177cd25ff6f311a254f6701c29R1001) [[6]](diffhunk://#diff-20fd93307da41ca9988a76d430f5fd894a35e5177cd25ff6f311a254f6701c29L1011-R1014) [[7]](diffhunk://#diff-20fd93307da41ca9988a76d430f5fd894a35e5177cd25ff6f311a254f6701c29R1023-R1033)

**UI and onboarding improvements:**

- Extended the onboarding view to include configuration for the LM Studio base URL, mirroring the Ollama configuration experience (`OnboardingView.swift`).

**Model discovery and validation enhancements:**

- Added LM Studio model discovery and validation logic to the pipeline, allowing users to select and validate LM Studio models for summarization and vision (`MeetingPipelineViewModel.swift`). [[1]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL563-R577) [[2]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eR753-R759)

**Error handling and lifecycle management:**

- Improved error handling and lifecycle management for screen context inference, including handling for LM Studio inference unavailability and terminal failures (`MeetingPipelineViewModel.swift`). [[1]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL1676-R1733) [[2]](diffhunk://#diff-6b1c10a411d1eaef7d462ea39bcb863f5eb2e4a38ec10c2c6b40982e8e63a66eL1799-R1882)

These changes collectively enable LM Studio as a first-class local inference provider, aligning its integration with the existing Ollama architecture and enhancing the app's flexibility for local model serving.