### PR TITLE
feat(settings): Add toggle to disable summarization after recording

### DIFF
--- a/Minute/Components/MeetingTypePicker.swift
+++ b/Minute/Components/MeetingTypePicker.swift
@@ -42,6 +42,10 @@ struct MeetingTypePicker: View {
         case .designReview: return "paintbrush"
         case .oneOnOne: return "person.2"
         case .planning: return "calendar"
+        case .interviewTaken: return "person.crop.circle.badge.questionmark"
+        case .interviewGiven: return "person.crop.circle.badge.checkmark"
+        case .allHands: return "person.3"
+        case .retrospective: return "arrow.uturn.backward.circle"
         }
     }
 }

--- a/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
+++ b/Minute/Sources/ViewModels/MeetingPipelineViewModel.swift
@@ -2084,7 +2084,8 @@ final class MeetingPipelineViewModel: ObservableObject {
             meetingType: fallbackMeetingType,
             languageProcessing: languageProcessing,
             outputLanguage: effectiveOutputLanguage,
-            knownSpeakerSuggestionsEnabled: configuration.knownSpeakerSuggestionsEnabled
+            knownSpeakerSuggestionsEnabled: configuration.knownSpeakerSuggestionsEnabled,
+            skipSummarization: !configuration.summarizationEnabled
         )
     }
 

--- a/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift
+++ b/Minute/Sources/Views/MeetingNotes/MeetingNotesBrowserViewModel.swift
@@ -68,6 +68,11 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
     @Published private(set) var isReprocessingMeeting: Bool = false
     @Published private(set) var reprocessErrorMessage: String?
 
+    // Note rename (renames summary, audio, and transcript files together).
+    @Published private(set) var renamePromptItem: MeetingNoteItem?
+    @Published var renameTitleDraft: String = ""
+    @Published private(set) var isRenamingNote: Bool = false
+
     var selectedItem: MeetingNoteItem? { overlayState.selectedItem }
     var selectedTab: MeetingNotePreviewTab { overlayState.selectedTab }
     var isOverlayPresented: Bool { overlayState.isPresented }
@@ -106,6 +111,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
     private var transcriptLoadTask: Task<Void, Never>?
     private var transcriptSpeakerIDsTask: Task<Void, Never>?
     private var deleteTask: Task<Void, Never>?
+    private var renameTask: Task<Void, Never>?
     private var reprocessTask: Task<Void, Never>?
     private var previewTask: Task<Void, Never>?
     private var defaultsObserver: AnyCancellable?
@@ -139,6 +145,7 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
         transcriptLoadTask?.cancel()
         transcriptSpeakerIDsTask?.cancel()
         deleteTask?.cancel()
+        renameTask?.cancel()
         reprocessTask?.cancel()
         previewTask?.cancel()
         knownSpeakerStatusTask?.cancel()
@@ -666,6 +673,68 @@ final class MeetingNotesBrowserViewModel: ObservableObject {
     func openInObsidian() {
         guard let fileURL = selectedItem?.fileURL else { return }
         openInObsidianOrDefault(fileURL)
+    }
+
+    // MARK: - Note rename
+
+    func beginRename(_ item: MeetingNoteItem) {
+        renamePromptItem = item
+        renameTitleDraft = item.title
+    }
+
+    func cancelRename() {
+        renamePromptItem = nil
+        renameTitleDraft = ""
+    }
+
+    func confirmRename() {
+        guard let item = renamePromptItem, !isRenamingNote else { return }
+        let newTitle = renameTitleDraft
+
+        renameTask?.cancel()
+        sidebarErrorMessage = nil
+        isRenamingNote = true
+
+        let provider = browserProvider
+        renameTask = Task { [weak self] in
+            do {
+                let renamed = try await provider().renameNoteFiles(for: item, to: newTitle)
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.isRenamingNote = false
+                    self.renamePromptItem = nil
+                    self.renameTitleDraft = ""
+                    self.notePreviews[item.id] = nil
+                    if self.selectedItem?.id == item.id {
+                        self.dismissOverlay()
+                    }
+                    self.refreshAndSelect(noteURL: renamed.fileURL)
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    self?.isRenamingNote = false
+                }
+                return
+            } catch let error as MeetingNoteRenameError {
+                let message = error.errorDescription ?? "Failed to rename note."
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.isRenamingNote = false
+                    self.renamePromptItem = nil
+                    self.renameTitleDraft = ""
+                    self.sidebarErrorMessage = message
+                }
+            } catch {
+                let message = ErrorHandler.userMessage(for: error, fallback: "Failed to rename note.")
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.isRenamingNote = false
+                    self.renamePromptItem = nil
+                    self.renameTitleDraft = ""
+                    self.sidebarErrorMessage = message
+                }
+            }
+        }
     }
 
     func openSummaryInApp(for item: MeetingNoteItem) {

--- a/Minute/Sources/Views/MeetingNotes/MeetingNotesSidebarView.swift
+++ b/Minute/Sources/Views/MeetingNotes/MeetingNotesSidebarView.swift
@@ -42,6 +42,28 @@ struct MeetingNotesSidebarView: View {
                 Color.clear
                     .frame(height: topInset)
             }
+            .alert(
+                "Rename Note",
+                isPresented: Binding(
+                    get: { model.renamePromptItem != nil },
+                    set: { presented in
+                        if !presented {
+                            model.cancelRename()
+                        }
+                    }
+                )
+            ) {
+                TextField("Title", text: $model.renameTitleDraft)
+                Button("Rename") {
+                    model.confirmRename()
+                }
+                .disabled(model.isRenamingNote)
+                Button("Cancel", role: .cancel) {
+                    model.cancelRename()
+                }
+            } message: {
+                Text("Renames the summary note along with its audio recording and transcript files.")
+            }
     }
 
     @ViewBuilder
@@ -110,6 +132,7 @@ struct MeetingNotesSidebarView: View {
                                 onOpenSummaryInObsidian: { model.openSummaryInObsidian(for: item) },
                                 onOpenTranscriptInObsidian: { model.openTranscriptInObsidian(for: item) },
                                 onRevealInFinder: { model.revealInFinder(for: item) },
+                                onRename: { model.beginRename(item) },
                                 onDelete: { model.delete(item) },
                                 onPrepareReprocess: { targetTypeID in
                                     model.prepareReprocess(for: item, targetTypeID: targetTypeID)
@@ -269,6 +292,7 @@ private struct MeetingNoteRow: View {
     let onOpenSummaryInObsidian: () -> Void
     let onOpenTranscriptInObsidian: () -> Void
     let onRevealInFinder: () -> Void
+    let onRename: () -> Void
     let onDelete: () -> Void
     let onPrepareReprocess: (String) -> Void
 
@@ -346,6 +370,12 @@ private struct MeetingNoteRow: View {
             .help(reprocessDisabledReason ?? "Resummarize using a different meeting type")
 
             Divider()
+            Button {
+                onRename()
+            } label: {
+                Label("Rename…", systemImage: "pencil")
+            }
+
             Button(role: .destructive) {
                 onDelete()
             } label: {

--- a/Minute/Sources/Views/MeetingTypeSelectionComponents.swift
+++ b/Minute/Sources/Views/MeetingTypeSelectionComponents.swift
@@ -26,6 +26,14 @@ enum MeetingTypeSelectionStyle {
             return "rectangle.on.rectangle.angled"
         case .planning:
             return "calendar.badge.clock"
+        case .interviewTaken:
+            return "person.crop.circle.badge.questionmark"
+        case .interviewGiven:
+            return "person.crop.circle.badge.checkmark"
+        case .allHands:
+            return "megaphone.fill"
+        case .retrospective:
+            return "arrow.uturn.backward.circle.fill"
         }
     }
 

--- a/Minute/Sources/Views/Settings/AppDefaults.swift
+++ b/Minute/Sources/Views/Settings/AppDefaults.swift
@@ -15,4 +15,5 @@ enum AppDefaultsKey {
     static let micActivityNotificationsEnabled = AppConfiguration.Defaults.micActivityNotificationsEnabledKey
     static let knownSpeakerSuggestionsEnabled = AppConfiguration.Defaults.knownSpeakerSuggestionsEnabledKey
     static let outputLanguage = AppConfiguration.Defaults.outputLanguageKey
+    static let summarizationEnabled = AppConfiguration.Defaults.summarizationEnabledKey
 }

--- a/Minute/Sources/Views/Settings/GeneralSettingsSection.swift
+++ b/Minute/Sources/Views/Settings/GeneralSettingsSection.swift
@@ -10,6 +10,8 @@ struct GeneralSettingsSection: View {
     private var micActivityNotificationsEnabled: Bool = AppConfiguration.Defaults.defaultMicActivityNotificationsEnabled
     @AppStorage(AppDefaultsKey.outputLanguage)
     private var outputLanguageRaw: String = AppConfiguration.Defaults.defaultOutputLanguage.rawValue
+    @AppStorage(AppDefaultsKey.summarizationEnabled)
+    private var summarizationEnabled: Bool = AppConfiguration.Defaults.defaultSummarizationEnabled
 
     private var outputLanguageBinding: Binding<OutputLanguage> {
         Binding(
@@ -43,6 +45,12 @@ struct GeneralSettingsSection: View {
                     "Mic activity reminders",
                     detail: "Show a notification when the microphone becomes active.",
                     isOn: $micActivityNotificationsEnabled
+                )
+
+                SettingsToggleRow(
+                    "Summarize after recording",
+                    detail: "When off, only the transcript and audio are saved. Use this if you prefer to summarize with your own tools.",
+                    isOn: $summarizationEnabled
                 )
             }
 

--- a/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
+++ b/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
@@ -58,7 +58,7 @@ public struct AppConfiguration: Sendable, Equatable {
         /// Per-request timeout for local inference servers (Ollama, LM Studio).
         /// Local models on modest hardware can take well over URLSession's
         /// 60-second default to produce a full non-streaming response.
-        public static let localServerRequestTimeoutSeconds: TimeInterval = 120
+        public static let localServerRequestTimeoutSeconds: TimeInterval = 300
         public static let defaultMicActivityNotificationsEnabled = true
         public static let defaultKnownSpeakerSuggestionsEnabled = false
         public static let defaultOutputLanguage = OutputLanguage.defaultSelection

--- a/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
+++ b/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
@@ -35,6 +35,7 @@ public struct AppConfiguration: Sendable, Equatable {
         public static let vocabularyBoostingEnabledKey = "vocabularyBoostingEnabled"
         public static let vocabularyBoostingTermsKey = "vocabularyBoostingTerms"
         public static let vocabularyBoostingStrengthKey = "vocabularyBoostingStrength"
+        public static let summarizationEnabledKey = "summarizationEnabled"
         public static let vocabularyBoostingUpdatedAtKey = "vocabularyBoostingUpdatedAt"
 
         public static let stageMeetingTypeKey = "stageMeetingType"
@@ -64,6 +65,7 @@ public struct AppConfiguration: Sendable, Equatable {
         public static let defaultTranscriptionBackendID = TranscriptionBackend.whisper.rawValue
         public static let defaultFluidAudioAsrModelID = FluidAudioASRModelCatalog.defaultModelID
         public static let defaultVocabularyBoostingEnabled = false
+        public static let defaultSummarizationEnabled = true
         public static let defaultVocabularyBoostingStrength = VocabularyBoostingStrength.balanced
         public static let defaultTranscriptionLanguage = TranscriptionLanguage.defaultSelection
 
@@ -95,6 +97,7 @@ public struct AppConfiguration: Sendable, Equatable {
     public var micActivityNotificationsEnabled: Bool
     public var knownSpeakerSuggestionsEnabled: Bool
     public var vocabularyBoostingEnabled: Bool
+    public var summarizationEnabled: Bool
     public var vocabularyBoostingTerms: [String]
     public var vocabularyBoostingStrength: VocabularyBoostingStrength
 
@@ -164,6 +167,8 @@ public struct AppConfiguration: Sendable, Equatable {
 
         vocabularyBoostingEnabled = defaults.object(forKey: Defaults.vocabularyBoostingEnabledKey) as? Bool
             ?? Defaults.defaultVocabularyBoostingEnabled
+        summarizationEnabled = defaults.object(forKey: Defaults.summarizationEnabledKey) as? Bool
+            ?? Defaults.defaultSummarizationEnabled
         vocabularyBoostingTerms = VocabularyTermEntry.normalizeDisplayTerms(
             defaults.stringArray(forKey: Defaults.vocabularyBoostingTermsKey) ?? []
         )

--- a/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
+++ b/MinuteCore/Sources/MinuteCore/Configuration/AppConfiguration.swift
@@ -55,6 +55,10 @@ public struct AppConfiguration: Sendable, Equatable {
         public static let defaultScreenContextCaptureIntervalSeconds: TimeInterval = 60
         public static let defaultOllamaBaseURL = "http://127.0.0.1:11434"
         public static let defaultLMStudioBaseURL = "http://127.0.0.1:1234"
+        /// Per-request timeout for local inference servers (Ollama, LM Studio).
+        /// Local models on modest hardware can take well over URLSession's
+        /// 60-second default to produce a full non-streaming response.
+        public static let localServerRequestTimeoutSeconds: TimeInterval = 120
         public static let defaultMicActivityNotificationsEnabled = true
         public static let defaultKnownSpeakerSuggestionsEnabled = false
         public static let defaultOutputLanguage = OutputLanguage.defaultSelection

--- a/MinuteCore/Sources/MinuteCore/Domain/MeetingExtraction.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/MeetingExtraction.swift
@@ -26,10 +26,17 @@ public struct MeetingParticipant: Codable, Equatable, Sendable {
     public var name: String
     /// Role or relationship (e.g. "Manager", "Presenter"). Optional.
     public var role: String?
+    /// Transcript speaker label this participant maps to (e.g. "Speaker 1"). Optional.
+    public var speaker: String?
+    /// Evidence-based description: what they did or said, role signals, and the
+    /// evidence/confidence for the name mapping. Optional.
+    public var details: String?
 
-    public init(name: String, role: String? = nil) {
+    public init(name: String, role: String? = nil, speaker: String? = nil, details: String? = nil) {
         self.name = name
         self.role = role
+        self.speaker = speaker
+        self.details = details
     }
 }
 

--- a/MinuteCore/Sources/MinuteCore/Domain/MeetingExtraction.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/MeetingExtraction.swift
@@ -21,9 +21,45 @@ public struct MeetingSummarySectionVisibility: Equatable, Sendable {
     public static let allEnabled = MeetingSummarySectionVisibility()
 }
 
+/// A meeting participant identified from the transcript.
+public struct MeetingParticipant: Codable, Equatable, Sendable {
+    public var name: String
+    /// Role or relationship (e.g. "Manager", "Presenter"). Optional.
+    public var role: String?
+
+    public init(name: String, role: String? = nil) {
+        self.name = name
+        self.role = role
+    }
+}
+
+/// A distinct topic discussed in the meeting, with detail points.
+public struct MeetingTopic: Codable, Equatable, Sendable {
+    public var title: String
+    public var points: [String]
+
+    public init(title: String, points: [String] = []) {
+        self.title = title
+        self.points = points
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case points
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decode(String.self, forKey: .title)
+        points = try container.decodeIfPresent([String].self, forKey: .points) ?? []
+    }
+}
+
 /// Fixed v1 schema produced by the summarization model.
 ///
 /// The model must output JSON only, matching this structure exactly.
+/// `participants` and `topics` are optional enrichments — capable models fill
+/// them; models that omit them produce the original layout.
 public struct MeetingExtraction: Codable, Equatable, Sendable {
     public var title: String
     /// `YYYY-MM-DD`
@@ -33,6 +69,8 @@ public struct MeetingExtraction: Codable, Equatable, Sendable {
     public var actionItems: [ActionItem]
     public var openQuestions: [String]
     public var keyPoints: [String]
+    public var participants: [MeetingParticipant]
+    public var topics: [MeetingTopic]
     public var meetingType: MeetingType?
 
     public init(
@@ -43,6 +81,8 @@ public struct MeetingExtraction: Codable, Equatable, Sendable {
         actionItems: [ActionItem] = [],
         openQuestions: [String] = [],
         keyPoints: [String] = [],
+        participants: [MeetingParticipant] = [],
+        topics: [MeetingTopic] = [],
         meetingType: MeetingType? = nil
     ) {
         self.title = title
@@ -52,6 +92,8 @@ public struct MeetingExtraction: Codable, Equatable, Sendable {
         self.actionItems = actionItems
         self.openQuestions = openQuestions
         self.keyPoints = keyPoints
+        self.participants = participants
+        self.topics = topics
         self.meetingType = meetingType
     }
 
@@ -63,6 +105,8 @@ public struct MeetingExtraction: Codable, Equatable, Sendable {
         case actionItems = "action_items"
         case openQuestions = "open_questions"
         case keyPoints = "key_points"
+        case participants
+        case topics
         case meetingType = "meeting_type"
     }
 
@@ -75,6 +119,8 @@ public struct MeetingExtraction: Codable, Equatable, Sendable {
         actionItems = try container.decodeIfPresent([ActionItem].self, forKey: .actionItems) ?? []
         openQuestions = try container.decodeIfPresent([String].self, forKey: .openQuestions) ?? []
         keyPoints = try container.decodeIfPresent([String].self, forKey: .keyPoints) ?? []
+        participants = try container.decodeIfPresent([MeetingParticipant].self, forKey: .participants) ?? []
+        topics = try container.decodeIfPresent([MeetingTopic].self, forKey: .topics) ?? []
         meetingType = try container.decodeIfPresent(MeetingType.self, forKey: .meetingType)
     }
 }
@@ -82,10 +128,41 @@ public struct MeetingExtraction: Codable, Equatable, Sendable {
 public struct ActionItem: Codable, Equatable, Sendable {
     public var owner: String
     public var task: String
+    /// `YYYY-MM-DD` or "TBD". Optional table field.
+    public var dueDate: String?
+    /// E.g. "Not Started". Optional table field.
+    public var status: String?
+    /// Supporting context. Optional table field.
+    public var comments: String?
 
-    public init(owner: String, task: String) {
+    public init(
+        owner: String,
+        task: String,
+        dueDate: String? = nil,
+        status: String? = nil,
+        comments: String? = nil
+    ) {
         self.owner = owner
         self.task = task
+        self.dueDate = dueDate
+        self.status = status
+        self.comments = comments
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case owner
+        case task
+        case dueDate = "due_date"
+        case status
+        case comments
+    }
+
+    /// True when any optional table column is populated.
+    public var hasTableFields: Bool {
+        [dueDate, status, comments].contains { field in
+            guard let field else { return false }
+            return !field.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
     }
 }
 
@@ -97,6 +174,8 @@ public struct SummarizationPassDelta: Codable, Equatable, Sendable {
     public var actionItems: [ActionItem]
     public var openQuestions: [String]
     public var keyPoints: [String]
+    public var participants: [MeetingParticipant]
+    public var topics: [MeetingTopic]
 
     public init(
         title: String = "",
@@ -105,7 +184,9 @@ public struct SummarizationPassDelta: Codable, Equatable, Sendable {
         decisions: [String] = [],
         actionItems: [ActionItem] = [],
         openQuestions: [String] = [],
-        keyPoints: [String] = []
+        keyPoints: [String] = [],
+        participants: [MeetingParticipant] = [],
+        topics: [MeetingTopic] = []
     ) {
         self.title = title
         self.date = date
@@ -114,6 +195,8 @@ public struct SummarizationPassDelta: Codable, Equatable, Sendable {
         self.actionItems = actionItems
         self.openQuestions = openQuestions
         self.keyPoints = keyPoints
+        self.participants = participants
+        self.topics = topics
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -125,6 +208,8 @@ public struct SummarizationPassDelta: Codable, Equatable, Sendable {
         case actionItems = "action_items"
         case openQuestions = "open_questions"
         case keyPoints = "key_points"
+        case participants
+        case topics
     }
 
     public init(from decoder: any Decoder) throws {
@@ -138,6 +223,8 @@ public struct SummarizationPassDelta: Codable, Equatable, Sendable {
         actionItems = try container.decodeIfPresent([ActionItem].self, forKey: .actionItems) ?? []
         openQuestions = try container.decodeIfPresent([String].self, forKey: .openQuestions) ?? []
         keyPoints = try container.decodeIfPresent([String].self, forKey: .keyPoints) ?? []
+        participants = try container.decodeIfPresent([MeetingParticipant].self, forKey: .participants) ?? []
+        topics = try container.decodeIfPresent([MeetingTopic].self, forKey: .topics) ?? []
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -149,6 +236,8 @@ public struct SummarizationPassDelta: Codable, Equatable, Sendable {
         try container.encode(actionItems, forKey: .actionItems)
         try container.encode(openQuestions, forKey: .openQuestions)
         try container.encode(keyPoints, forKey: .keyPoints)
+        try container.encode(participants, forKey: .participants)
+        try container.encode(topics, forKey: .topics)
     }
 
     public static func summaryPoints(from summary: String) -> [String] {
@@ -166,6 +255,8 @@ public struct SummarizationMergeState: Codable, Equatable, Sendable {
     public var actionItems: [ActionItem]
     public var openQuestions: [String]
     public var keyPoints: [String]
+    public var participants: [MeetingParticipant]
+    public var topics: [MeetingTopic]
     public var meetingType: MeetingType?
 
     public init(
@@ -176,6 +267,8 @@ public struct SummarizationMergeState: Codable, Equatable, Sendable {
         actionItems: [ActionItem] = [],
         openQuestions: [String] = [],
         keyPoints: [String] = [],
+        participants: [MeetingParticipant] = [],
+        topics: [MeetingTopic] = [],
         meetingType: MeetingType? = nil
     ) {
         self.title = title
@@ -185,7 +278,36 @@ public struct SummarizationMergeState: Codable, Equatable, Sendable {
         self.actionItems = actionItems
         self.openQuestions = openQuestions
         self.keyPoints = keyPoints
+        self.participants = participants
+        self.topics = topics
         self.meetingType = meetingType
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case date
+        case summaryPoints
+        case decisions
+        case actionItems
+        case openQuestions
+        case keyPoints
+        case participants
+        case topics
+        case meetingType
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+        date = try container.decodeIfPresent(String.self, forKey: .date) ?? ""
+        summaryPoints = try container.decodeIfPresent([String].self, forKey: .summaryPoints) ?? []
+        decisions = try container.decodeIfPresent([String].self, forKey: .decisions) ?? []
+        actionItems = try container.decodeIfPresent([ActionItem].self, forKey: .actionItems) ?? []
+        openQuestions = try container.decodeIfPresent([String].self, forKey: .openQuestions) ?? []
+        keyPoints = try container.decodeIfPresent([String].self, forKey: .keyPoints) ?? []
+        participants = try container.decodeIfPresent([MeetingParticipant].self, forKey: .participants) ?? []
+        topics = try container.decodeIfPresent([MeetingTopic].self, forKey: .topics) ?? []
+        meetingType = try container.decodeIfPresent(MeetingType.self, forKey: .meetingType)
     }
 
     public init(extraction: MeetingExtraction) {
@@ -197,6 +319,8 @@ public struct SummarizationMergeState: Codable, Equatable, Sendable {
             actionItems: extraction.actionItems,
             openQuestions: extraction.openQuestions,
             keyPoints: extraction.keyPoints,
+            participants: extraction.participants,
+            topics: extraction.topics,
             meetingType: extraction.meetingType
         )
     }

--- a/MinuteCore/Sources/MinuteCore/Domain/MeetingExtractionValidation.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/MeetingExtractionValidation.swift
@@ -29,12 +29,39 @@ public enum MeetingExtractionValidation {
             .map {
                 ActionItem(
                     owner: StringNormalizer.normalizeInline($0.owner),
-                    task: StringNormalizer.normalizeInline($0.task)
+                    task: StringNormalizer.normalizeInline($0.task),
+                    dueDate: normalizedOptional($0.dueDate),
+                    status: normalizedOptional($0.status),
+                    comments: normalizedOptional($0.comments)
                 )
             }
             .filter { !$0.owner.isEmpty || !$0.task.isEmpty }
 
+        copy.participants = copy.participants
+            .map {
+                MeetingParticipant(
+                    name: StringNormalizer.normalizeInline($0.name),
+                    role: normalizedOptional($0.role)
+                )
+            }
+            .filter { !$0.name.isEmpty }
+
+        copy.topics = copy.topics
+            .map {
+                MeetingTopic(
+                    title: StringNormalizer.normalizeInline($0.title),
+                    points: $0.points.map(StringNormalizer.normalizeInline).filter { !$0.isEmpty }
+                )
+            }
+            .filter { !$0.title.isEmpty }
+
         return copy
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = StringNormalizer.normalizeInline(value)
+        return normalized.isEmpty ? nil : normalized
     }
 
     /// Fallback extraction used when JSON cannot be decoded even after repair.

--- a/MinuteCore/Sources/MinuteCore/Domain/MeetingExtractionValidation.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/MeetingExtractionValidation.swift
@@ -41,7 +41,9 @@ public enum MeetingExtractionValidation {
             .map {
                 MeetingParticipant(
                     name: StringNormalizer.normalizeInline($0.name),
-                    role: normalizedOptional($0.role)
+                    role: normalizedOptional($0.role),
+                    speaker: normalizedOptional($0.speaker),
+                    details: normalizedOptional($0.details)
                 )
             }
             .filter { !$0.name.isEmpty }

--- a/MinuteCore/Sources/MinuteCore/Domain/MeetingType.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/MeetingType.swift
@@ -29,6 +29,18 @@ public enum MeetingType: String, CaseIterable, Codable, Sendable {
     
     /// Focused on task allocation, timelines, and roadmap discussions
     case planning
+
+    /// You are the interviewer evaluating a candidate; focuses on questions, responses, and hiring signals
+    case interviewTaken = "interview_taken"
+
+    /// You are the candidate being interviewed; focuses on questions asked, your approach, and learnings
+    case interviewGiven = "interview_given"
+
+    /// Org-wide updates and leadership Q&A; focuses on announcements, metrics, and key messages
+    case allHands = "all_hands"
+
+    /// Sprint retro or post-mortem; focuses on what went well, what didn't, and improvements
+    case retrospective
 }
 
 extension MeetingType {
@@ -41,6 +53,10 @@ extension MeetingType {
         case .oneOnOne: return "One-on-One"
         case .presentation: return "Presentation"
         case .planning: return "Planning"
+        case .interviewTaken: return "Interview — Taken"
+        case .interviewGiven: return "Interview — Given"
+        case .allHands: return "All Hands"
+        case .retrospective: return "Retrospective"
         }
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Domain/MeetingTypeLibrary.swift
+++ b/MinuteCore/Sources/MinuteCore/Domain/MeetingTypeLibrary.swift
@@ -427,13 +427,81 @@ public struct MeetingTypeLibrary: Codable, Sendable, Equatable {
             promptComponents: defaultPromptComponents(for: type),
             classifierProfile: type == .autodetect ? nil : ClassifierProfile(
                 label: type.displayName,
-                strongSignals: [type.displayName.lowercased()]
+                strongSignals: defaultClassifierSignals(for: type)
             ),
             status: .active
         )
     }
 
+    /// Strong autodetect signals per built-in type, derived from detection
+    /// heuristics refined through real meeting-notes usage.
+    public static func defaultClassifierSignals(for type: MeetingType) -> [String] {
+        switch type {
+        case .autodetect:
+            return []
+        case .general:
+            return ["general"]
+        case .standup:
+            return [
+                "explicit standup/daily mention",
+                "yesterday/today/blockers round-robin status updates"
+            ]
+        case .designReview:
+            return [
+                "explicit design review mention",
+                "critique of mockups/UX/architecture proposals",
+                "trade-offs discussed with concerns raised and resolved"
+            ]
+        case .oneOnOne:
+            return [
+                "explicit 1:1 mention",
+                "exactly two participants with informal topic jumps between personal and project updates",
+                "manager-report feedback, career check-in, or growth-plan discussion"
+            ]
+        case .presentation:
+            return [
+                "one person speaks mostly with slides or demos referenced",
+                "speaker-led narrative with audience Q&A at the end"
+            ]
+        case .planning:
+            return [
+                "sprint/roadmap planning with estimation and ticketing",
+                "task allocation with owners, timelines, and scope"
+            ]
+        case .interviewTaken:
+            return [
+                "structured Q&A posing coding or design problems to evaluate a candidate",
+                "introductions mentioning an interview round with the transcript owner asking the questions",
+                "evaluation language about candidate strengths and hiring signal"
+            ]
+        case .interviewGiven:
+            return [
+                "structured Q&A with the transcript owner answering coding or design problems",
+                "introductions mentioning an interview round with the owner being evaluated",
+                "interviewer giving hints, redirections, or asking follow-up probes"
+            ]
+        case .allHands:
+            return [
+                "explicit all-hands or town-hall mention",
+                "large audience implied with leadership speaking",
+                "company or org-wide updates with metrics and audience Q&A"
+            ]
+        case .retrospective:
+            return [
+                "explicit retro/retrospective/post-mortem mention",
+                "what went well / what didn't go well / what to improve structure",
+                "lessons learned discussion about a completed sprint or project"
+            ]
+        }
+    }
+
     public static func defaultPromptComponents(for type: MeetingType) -> PromptComponentSet {
+        // Shared guidance derived from field-tested meeting-notes generation rules:
+        // speaker attribution, garbled-ASR handling, and technical accuracy.
+        let attributionGuidance = """
+        Identify participants carefully before assigning statements: direct address by name is the strongest identity evidence; a person mentioned in third person is almost certainly not the speaker; role signals (assigning goals, giving feedback vs. receiving coaching, giving status) distinguish manager from report. Attribute positions to the right person — who gave advice vs. who received it. Transcripts may be code-mixed or contain heavy ASR errors: read past garbling to recover intent, and never invent a confident reading for an unresolvable name or phrase. Preserve project names, service names, team names, and technical terms exactly as spoken.
+        """
+
         switch type {
         case .autodetect:
             return PromptComponentSet(
@@ -443,32 +511,95 @@ public struct MeetingTypeLibrary: Codable, Sendable, Equatable {
         case .general:
             return PromptComponentSet(
                 objective: "Create a factual executive summary for a general business meeting.",
-                summaryFocus: "Prioritize meeting outcomes, decisions, and assigned follow-ups."
+                summaryFocus: "Prioritize meeting outcomes, decisions, and assigned follow-ups. Capture ALL distinct topics, even brief ones, including disagreements, concerns, and unresolved debates.",
+                decisionRules: "Only list explicit agreements or conclusions reached, with rationale when stated.",
+                actionItemRules: "Only list clear commitments to perform a task. Start each task with a verb; name the owner when stated and never guess names.",
+                openQuestionRules: "List unresolved issues and topics explicitly tabled for later.",
+                keyPointRules: "Capture notable facts, constraints, data points, and context essential to understanding the meeting, including the reasoning behind guidance or advice given.",
+                noiseFilterRules: "Ignore small talk, pleasantries, and non-substantive filler.",
+                additionalGuidance: attributionGuidance
             )
         case .standup:
             return PromptComponentSet(
                 objective: "Summarize daily standup progress accurately.",
-                summaryFocus: "Highlight yesterday/today updates and blockers by speaker where possible."
+                summaryFocus: "Highlight yesterday/today updates and blockers by speaker where possible. Capture status updates, risks, and cross-team dependencies.",
+                actionItemRules: "Capture committed follow-ups with owners; do not convert routine status into action items.",
+                keyPointRules: "Capture blockers with owner and impact, and any mitigation discussed.",
+                additionalGuidance: attributionGuidance
             )
         case .designReview:
             return PromptComponentSet(
                 objective: "Summarize design review feedback and outcomes.",
-                summaryFocus: "Emphasize approved changes, critiques, unresolved UX questions, and follow-ups."
+                summaryFocus: "Emphasize the proposal reviewed, approved changes, critiques, trade-offs discussed, unresolved design questions, and follow-ups.",
+                decisionRules: "Capture each design decision with its rationale and the trade-offs considered.",
+                openQuestionRules: "Capture unresolved design questions and who is to investigate them.",
+                keyPointRules: "Capture important design principles or constraints identified, concerns raised, and their resolution.",
+                additionalGuidance: attributionGuidance
             )
         case .oneOnOne:
             return PromptComponentSet(
                 objective: "Summarize one-on-one discussions with clear outcomes.",
-                summaryFocus: "Capture feedback themes, agreements, and personal follow-up actions."
+                summaryFocus: "Capture feedback themes, guidance given with its reasoning, agreements, growth/career discussion, and personal follow-up actions. Be professional and discreet.",
+                decisionRules: "Capture agreements made between the two parties, with rationale.",
+                actionItemRules: "Capture specific follow-ups each person committed to.",
+                keyPointRules: "Capture important feedback or context shared, and who gave versus who received coaching.",
+                additionalGuidance: attributionGuidance
             )
         case .presentation:
             return PromptComponentSet(
                 objective: "Summarize presentation content and takeaways.",
-                summaryFocus: "Capture key arguments, Q&A highlights, and concrete next steps."
+                summaryFocus: "Capture what was presented section by section, key arguments, data and metrics shared, demos shown, Q&A highlights, and concrete next steps.",
+                keyPointRules: "Capture key data points and benchmarks exactly as stated, and notable Q&A exchanges with who asked when identifiable.",
+                additionalGuidance: attributionGuidance
             )
         case .planning:
             return PromptComponentSet(
                 objective: "Summarize planning decisions and execution intent.",
-                summaryFocus: "Capture scope, ownership, timelines, dependencies, and open risks."
+                summaryFocus: "Capture scope, ownership, timelines, dependencies, and open risks.",
+                decisionRules: "Capture scope and priority decisions with rationale.",
+                actionItemRules: "Capture allocated tasks with owner and due date where stated.",
+                keyPointRules: "Capture estimates, dependencies, risks, and constraints discussed.",
+                additionalGuidance: attributionGuidance
+            )
+        case .interviewTaken:
+            return PromptComponentSet(
+                objective: "Summarize a job interview from the interviewer's perspective, producing an evidence-based record for the hiring debrief.",
+                summaryFocus: "Capture the round type, problems or questions posed, the candidate's approach to each, follow-up probes, observed strengths and concerns with specific evidence, and the overall impression.",
+                decisionRules: "Capture assessment leanings explicitly expressed (e.g. signal strength or hire/no-hire leaning); never infer one.",
+                actionItemRules: "Capture follow-ups such as debrief points to raise, references to check, or next rounds to schedule.",
+                openQuestionRules: "Capture unresolved doubts about the candidate and topics not covered in time.",
+                keyPointRules: "Capture question-by-question highlights: what was asked, how the candidate responded, and notable strengths or weaknesses tied to specific answers.",
+                additionalGuidance: attributionGuidance
+            )
+        case .interviewGiven:
+            return PromptComponentSet(
+                objective: "Summarize a job interview from the candidate's perspective, producing an honest self-review record.",
+                summaryFocus: "Capture the company and round type if mentioned, each question posed, the approach taken, interviewer hints or corrections, what went well, what could improve, and learnings for next time.",
+                decisionRules: "Capture concrete process conclusions, such as agreed next steps.",
+                actionItemRules: "Capture follow-ups such as topics to study or practice and materials to send.",
+                openQuestionRules: "Capture unanswered questions about the role, team, or process, and problems left unresolved.",
+                keyPointRules: "Capture question-by-question highlights including interviewer feedback, plus interviewer style, time management, and role/team information gathered.",
+                additionalGuidance: attributionGuidance
+            )
+        case .allHands:
+            return PromptComponentSet(
+                objective: "Summarize an all-hands or town-hall meeting for people who missed it.",
+                summaryFocus: "Capture announcements and org updates with the speaker attributed, key messages from leadership, metrics and goals shared, and Q&A highlights.",
+                decisionRules: "Capture announced changes or commitments, such as org changes or strategy shifts.",
+                actionItemRules: "Capture asks made of the audience and commitments made by leadership.",
+                openQuestionRules: "Capture Q&A questions that were deferred or left unanswered.",
+                keyPointRules: "Capture each announcement, metrics and goals exactly as stated, and notable Q&A exchanges with who asked and who answered when identifiable.",
+                additionalGuidance: attributionGuidance
+            )
+        case .retrospective:
+            return PromptComponentSet(
+                objective: "Summarize a retrospective or post-mortem with balanced, attributed findings.",
+                summaryFocus: "Organize findings into what went well, what didn't go well, and what to improve, attributing who raised each item where identifiable.",
+                decisionRules: "Capture agreed process changes or experiments to adopt.",
+                actionItemRules: "Capture improvement actions with a committed owner; ideas without commitment belong in key points.",
+                openQuestionRules: "Capture unresolved disagreements or topics parked for follow-up.",
+                keyPointRules: "Capture what went well and what didn't, each with who raised it and the surrounding discussion.",
+                additionalGuidance: attributionGuidance
             )
         }
     }

--- a/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
+++ b/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
@@ -1161,7 +1161,7 @@ public actor MeetingPipelineCoordinator {
         - action_items (array of objects with owner, task, due_date, status, and comments; new or materially refined items only)
         - open_questions (array of new open questions only)
         - key_points (array of new key points only)
-        - participants (array of objects with name and role; newly identified participants only)
+        - participants (array of objects with name, speaker, role, and details; newly identified participants or new evidence only)
         - topics (array of objects with title and points; new topics or new points for existing topics only)
 
         Rules:

--- a/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
+++ b/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
@@ -314,6 +314,44 @@ public actor MeetingPipelineCoordinator {
                 screenEvents: context.screenContextEvents
             )
             let timelineText = MeetingTimelineRenderer().render(entries: timelineEntries)
+
+            if context.skipSummarization {
+                let dateISO = MinuteISODate.format(context.startedAt)
+                var extraction = MeetingExtraction(title: "Meeting", date: dateISO, summary: "")
+                extraction.meetingType = context.meetingType
+
+                progress?(.writing(fractionCompleted: 0.85, extraction: extraction))
+
+                let suggestionResult = await suggestKnownSpeakersFrontmatterIfEnabled(
+                    context: context,
+                    diarizationSegments: diarizationSegments,
+                    embeddingExportURL: embeddingExportURL
+                )
+                let participantFrontmatter = suggestionResult?.frontmatter
+
+                let outputs = try writeOutputsToVault(
+                    context: context,
+                    extraction: extraction,
+                    transcription: transcription,
+                    attributedSegments: attributedSegments,
+                    originalAudioData: originalAudioData,
+                    participantFrontmatter: participantFrontmatter,
+                    sectionVisibility: .allEnabled
+                )
+
+                if let embeddingsBySpeakerID = suggestionResult?.embeddingsBySpeakerID, !embeddingsBySpeakerID.isEmpty {
+                    try await meetingSpeakerEmbeddingCache.upsert(
+                        meetingKey: outputs.noteURL.path,
+                        embeddingsBySpeakerID: embeddingsBySpeakerID,
+                        embeddingModelVersion: SpeakerEmbeddingModelVersions.fluidAudioOfflineVbx256
+                    )
+                }
+
+                cleanupTemporaryArtifacts(for: context)
+                await checkpointStore.clear(meetingID: meetingRunID)
+                return outputs
+            }
+
             let summarizationBinding = context.summarizationBinding
             let preflightConfiguration = if let summarizationBinding, let summarizationPreflightConfigurationForBinding {
                 summarizationPreflightConfigurationForBinding(summarizationBinding)

--- a/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
+++ b/MinuteCore/Sources/MinuteCore/Pipeline/MeetingPipelineCoordinator.swift
@@ -1158,9 +1158,11 @@ public actor MeetingPipelineCoordinator {
         - date (YYYY-MM-DD; empty string if unchanged)
         - summary_points (array of short, high-signal new facts from this chunk only)
         - decisions (array of new decisions only)
-        - action_items (array of objects with owner and task; new or materially refined items only)
+        - action_items (array of objects with owner, task, due_date, status, and comments; new or materially refined items only)
         - open_questions (array of new open questions only)
         - key_points (array of new key points only)
+        - participants (array of objects with name and role; newly identified participants only)
+        - topics (array of objects with title and points; new topics or new points for existing topics only)
 
         Rules:
         - Do not restate information already captured in the existing accepted state.

--- a/MinuteCore/Sources/MinuteCore/Pipeline/PipelineTypes.swift
+++ b/MinuteCore/Sources/MinuteCore/Pipeline/PipelineTypes.swift
@@ -216,6 +216,7 @@ public struct PipelineContext: Sendable {
     public var languageProcessing: LanguageProcessingProfile
     public var outputLanguage: OutputLanguage
     public var knownSpeakerSuggestionsEnabled: Bool
+    public var skipSummarization: Bool
 
     public init(
         vaultFolders: MeetingFileContract.VaultFolders,
@@ -236,7 +237,8 @@ public struct PipelineContext: Sendable {
         meetingType: MeetingType = .autodetect,
         languageProcessing: LanguageProcessingProfile = .autoToEnglish,
         outputLanguage: OutputLanguage = .defaultSelection,
-        knownSpeakerSuggestionsEnabled: Bool = false
+        knownSpeakerSuggestionsEnabled: Bool = false,
+        skipSummarization: Bool = false
     ) {
         self.vaultFolders = vaultFolders
         self.audioTempURL = audioTempURL
@@ -260,5 +262,6 @@ public struct PipelineContext: Sendable {
         self.languageProcessing = languageProcessing
         self.outputLanguage = outputLanguage
         self.knownSpeakerSuggestionsEnabled = knownSpeakerSuggestionsEnabled
+        self.skipSummarization = skipSummarization
     }
 }

--- a/MinuteCore/Sources/MinuteCore/Rendering/MarkdownRenderer.swift
+++ b/MinuteCore/Sources/MinuteCore/Rendering/MarkdownRenderer.swift
@@ -46,9 +46,13 @@ public struct MarkdownRenderer: Sendable {
         lines.append("# \(title)")
         lines.append("")
 
+        appendParticipants(extraction.participants, to: &lines)
+
         lines.append("## Summary")
         lines.append(StringNormalizer.normalizeParagraph(extraction.summary))
         lines.append("")
+
+        appendTopics(extraction.topics, to: &lines)
 
         if sectionVisibility.decisions {
             lines.append("## Decisions")
@@ -104,17 +108,84 @@ public struct MarkdownRenderer: Sendable {
         }
     }
 
+    private func appendParticipants(_ participants: [MeetingParticipant], to lines: inout [String]) {
+        let cleaned = participants
+            .map {
+                MeetingParticipant(
+                    name: StringNormalizer.normalizeInline($0.name),
+                    role: $0.role.map(StringNormalizer.normalizeInline)
+                )
+            }
+            .filter { !$0.name.isEmpty }
+
+        guard !cleaned.isEmpty else { return }
+
+        lines.append("## Participants")
+        for participant in cleaned {
+            if let role = participant.role, !role.isEmpty {
+                lines.append("- \(participant.name) — \(role)")
+            } else {
+                lines.append("- \(participant.name)")
+            }
+        }
+        lines.append("")
+    }
+
+    private func appendTopics(_ topics: [MeetingTopic], to lines: inout [String]) {
+        let cleaned = topics
+            .map {
+                MeetingTopic(
+                    title: StringNormalizer.normalizeInline($0.title),
+                    points: $0.points.map { StringNormalizer.normalizeInline($0) }.filter { !$0.isEmpty }
+                )
+            }
+            .filter { !$0.title.isEmpty }
+
+        guard !cleaned.isEmpty else { return }
+
+        lines.append("## Topics Discussed")
+        for (index, topic) in cleaned.enumerated() {
+            lines.append("")
+            lines.append("### \(index + 1). \(topic.title)")
+            for point in topic.points {
+                lines.append("- \(point)")
+            }
+        }
+        lines.append("")
+    }
+
     private func appendActionItems(_ items: [ActionItem], to lines: inout [String]) {
         let cleaned = items
             .map {
                 ActionItem(
                     owner: StringNormalizer.normalizeInline($0.owner),
-                    task: StringNormalizer.normalizeInline($0.task)
+                    task: StringNormalizer.normalizeInline($0.task),
+                    dueDate: $0.dueDate.map(StringNormalizer.normalizeInline),
+                    status: $0.status.map(StringNormalizer.normalizeInline),
+                    comments: $0.comments.map(StringNormalizer.normalizeInline)
                 )
             }
             .filter { !$0.task.isEmpty || !$0.owner.isEmpty }
 
         if cleaned.isEmpty {
+            return
+        }
+
+        // Table mode when any item carries table columns; legacy checkbox list otherwise.
+        if cleaned.contains(where: \.hasTableFields) {
+            lines.append("| # | Action | Owner | Due Date | Status | Comments |")
+            lines.append("|---|--------|-------|----------|--------|----------|")
+            for (index, item) in cleaned.enumerated() {
+                let cells = [
+                    "\(index + 1)",
+                    Self.tableCell(item.task),
+                    Self.tableCell(item.owner),
+                    Self.tableCell(item.dueDate ?? "TBD", fallback: "TBD"),
+                    Self.tableCell(item.status ?? "Not Started", fallback: "Not Started"),
+                    Self.tableCell(item.comments ?? ""),
+                ]
+                lines.append("| " + cells.joined(separator: " | ") + " |")
+            }
             return
         }
 
@@ -125,6 +196,12 @@ public struct MarkdownRenderer: Sendable {
                 lines.append("- [ ] \(item.task) (Owner: \(item.owner))")
             }
         }
+    }
+
+    private static func tableCell(_ value: String, fallback: String = "") -> String {
+        let escaped = value.replacingOccurrences(of: "|", with: "\\|")
+        let trimmed = escaped.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? fallback : trimmed
     }
 
     private static func formatDuration(_ seconds: TimeInterval?) -> String? {

--- a/MinuteCore/Sources/MinuteCore/Rendering/MarkdownRenderer.swift
+++ b/MinuteCore/Sources/MinuteCore/Rendering/MarkdownRenderer.swift
@@ -113,7 +113,9 @@ public struct MarkdownRenderer: Sendable {
             .map {
                 MeetingParticipant(
                     name: StringNormalizer.normalizeInline($0.name),
-                    role: $0.role.map(StringNormalizer.normalizeInline)
+                    role: Self.nonEmpty($0.role),
+                    speaker: Self.nonEmpty($0.speaker),
+                    details: Self.nonEmpty($0.details)
                 )
             }
             .filter { !$0.name.isEmpty }
@@ -122,13 +124,39 @@ public struct MarkdownRenderer: Sendable {
 
         lines.append("## Participants")
         for participant in cleaned {
-            if let role = participant.role, !role.isEmpty {
-                lines.append("- \(participant.name) — \(role)")
-            } else {
-                lines.append("- \(participant.name)")
-            }
+            lines.append(Self.participantLine(participant))
         }
         lines.append("")
+    }
+
+    /// Renders `- **Name** (Speaker N) — Role. Details` with absent parts omitted.
+    /// The speaker label collapses when it matches the name (e.g. unresolved "Speaker 3").
+    static func participantLine(_ participant: MeetingParticipant) -> String {
+        var line = "- **\(participant.name)**"
+
+        if let speaker = participant.speaker,
+           speaker.lowercased() != participant.name.lowercased() {
+            line += " (\(speaker))"
+        }
+
+        var descriptorParts: [String] = []
+        if let role = participant.role {
+            descriptorParts.append(role)
+        }
+        if let details = participant.details {
+            descriptorParts.append(details)
+        }
+        if !descriptorParts.isEmpty {
+            line += " — " + descriptorParts.joined(separator: ". ")
+        }
+
+        return line
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = StringNormalizer.normalizeInline(value)
+        return normalized.isEmpty ? nil : normalized
     }
 
     private func appendTopics(_ topics: [MeetingTopic], to lines: inout [String]) {

--- a/MinuteCore/Sources/MinuteCore/Services/MeetingNoteRenamer.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/MeetingNoteRenamer.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Errors surfaced when renaming a meeting note and its vault artifacts.
+public enum MeetingNoteRenameError: Error, Sendable, Equatable, LocalizedError {
+    /// The new title is empty after trimming/sanitization.
+    case emptyTitle
+    /// The sanitized title matches the current one; nothing to rename.
+    case titleUnchanged
+    /// A file already exists at one of the destination paths.
+    case destinationAlreadyExists
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyTitle:
+            return "Enter a title for the note."
+        case .titleUnchanged:
+            return "The new title matches the current title."
+        case .destinationAlreadyExists:
+            return "A note with that title already exists for the same date and time."
+        }
+    }
+}
+
+/// Pure helpers for renaming a meeting note: computes the renamed base name and
+/// rewrites note/transcript markdown (frontmatter title, headings, wiki-links).
+///
+/// File-system orchestration lives in `VaultMeetingNotesBrowser.renameNoteFiles`.
+public enum MeetingNoteRenamer {
+
+    /// Computes the new vault base name (filename without extension), keeping the
+    /// `YYYY-MM-DD HH.MM` prefix from the old base name when present.
+    public static func newBaseName(oldBaseName: String, newTitle: String) -> String {
+        let safeTitle = FilenameSanitizer.sanitizeTitle(newTitle)
+        guard let separatorRange = oldBaseName.range(of: " - ") else {
+            return safeTitle
+        }
+        let prefix = String(oldBaseName[..<separatorRange.lowerBound])
+        return "\(prefix) - \(safeTitle)"
+    }
+
+    /// Rewrites the meeting note markdown for a rename:
+    /// - frontmatter `title:` line
+    /// - the first `# ` heading matching the old title
+    /// - `[[wiki-links]]` containing the old base name (Audio/Transcript sections)
+    ///
+    /// Body prose mentioning the old title is intentionally left untouched.
+    public static func rewrittenNoteMarkdown(
+        _ markdown: String,
+        oldTitle: String,
+        newTitle: String,
+        oldBaseName: String,
+        newBaseName: String
+    ) -> String {
+        var lines = markdown.components(separatedBy: "\n")
+        var replacedHeading = false
+
+        for index in lines.indices {
+            let line = lines[index]
+
+            if isFrontmatterTitleLine(line) {
+                lines[index] = "title: \(StringNormalizer.yamlDoubleQuoted(newTitle))"
+                continue
+            }
+
+            if !replacedHeading, isHeadingLine(line, matching: oldTitle) {
+                lines[index] = "# \(newTitle)"
+                replacedHeading = true
+                continue
+            }
+
+            if line.contains("[[") && line.contains(oldBaseName) {
+                lines[index] = line.replacingOccurrences(of: oldBaseName, with: newBaseName)
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Rewrites the transcript markdown for a rename: frontmatter `title:` line
+    /// and the `# <title> — Transcript` heading. The transcript body is untouched.
+    public static func rewrittenTranscriptMarkdown(
+        _ markdown: String,
+        oldTitle: String,
+        newTitle: String
+    ) -> String {
+        let safeOldTitle = FilenameSanitizer.sanitizeTitle(oldTitle)
+        let safeNewTitle = FilenameSanitizer.sanitizeTitle(newTitle)
+
+        var lines = markdown.components(separatedBy: "\n")
+        var replacedHeading = false
+
+        for index in lines.indices {
+            let line = lines[index]
+
+            if isFrontmatterTitleLine(line) {
+                lines[index] = "title: \(StringNormalizer.yamlDoubleQuoted(safeNewTitle))"
+                continue
+            }
+
+            if !replacedHeading, line.hasPrefix("# ") {
+                let heading = String(line.dropFirst(2))
+                if heading == "\(safeOldTitle) — Transcript" || heading == safeOldTitle || heading == oldTitle {
+                    let suffix = heading.hasSuffix("— Transcript") ? " — Transcript" : ""
+                    lines[index] = "# \(safeNewTitle)\(suffix)"
+                    replacedHeading = true
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func isFrontmatterTitleLine(_ line: String) -> Bool {
+        line.hasPrefix("title:")
+    }
+
+    private static func isHeadingLine(_ line: String, matching title: String) -> Bool {
+        guard line.hasPrefix("# ") else { return false }
+        let heading = String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+        return heading == title || heading == FilenameSanitizer.sanitizeTitle(title)
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Services/MeetingTypeLibraryStore.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/MeetingTypeLibraryStore.swift
@@ -304,10 +304,27 @@ public final class MeetingTypeLibraryStore: MeetingTypeLibraryStoring, @unchecke
         }
         do {
             let decoded = try JSONDecoder().decode(MeetingTypeLibrary.self, from: data)
-            return try decoded.validated()
+            let reconciled = reconcileBuiltInDefinitions(in: decoded)
+            return try reconciled.validated()
         } catch {
             return .default
         }
+    }
+
+    /// Merges built-in meeting types added in newer app versions into a
+    /// previously saved library, so users who stored a library before an
+    /// update still see the full built-in catalog. Existing definitions
+    /// (including built-in overrides) are left untouched.
+    private func reconcileBuiltInDefinitions(in library: MeetingTypeLibrary) -> MeetingTypeLibrary {
+        let knownTypeIDs = Set(library.definitions.map(\.typeId))
+        let missing = MeetingType.allCases
+            .filter { !knownTypeIDs.contains($0.rawValue) }
+            .map(MeetingTypeLibrary.builtInDefinition(for:))
+        guard !missing.isEmpty else { return library }
+
+        var updated = library
+        updated.definitions.append(contentsOf: missing)
+        return updated
     }
 
     @discardableResult

--- a/MinuteCore/Sources/MinuteCore/Services/ServiceProtocols.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ServiceProtocols.swift
@@ -324,7 +324,7 @@ public extension RuntimeAwareSummarizationServicing {
         - action_items (array of objects with owner, task, due_date, status, and comments; new or materially refined items only)
         - open_questions (array of new open questions only)
         - key_points (array of new key points only)
-        - participants (array of objects with name and role; newly identified participants only)
+        - participants (array of objects with name, speaker, role, and details; newly identified participants or new evidence only)
         - topics (array of objects with title and points; new topics or new points for existing topics only)
 
         Rules:

--- a/MinuteCore/Sources/MinuteCore/Services/ServiceProtocols.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/ServiceProtocols.swift
@@ -321,9 +321,11 @@ public extension RuntimeAwareSummarizationServicing {
         - date (YYYY-MM-DD; empty string if unchanged)
         - summary_points (array of short, high-signal new facts from this chunk only)
         - decisions (array of new decisions only)
-        - action_items (array of objects with owner and task; new or materially refined items only)
+        - action_items (array of objects with owner, task, due_date, status, and comments; new or materially refined items only)
         - open_questions (array of new open questions only)
         - key_points (array of new key points only)
+        - participants (array of objects with name and role; newly identified participants only)
+        - topics (array of objects with title and points; new topics or new points for existing topics only)
 
         Rules:
         - Do not restate information already captured in the existing accepted state.

--- a/MinuteCore/Sources/MinuteCore/Services/SummarizationSummaryMerger.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/SummarizationSummaryMerger.swift
@@ -131,34 +131,44 @@ public enum SummarizationSummaryMerger {
         _ next: [MeetingParticipant]
     ) -> [MeetingParticipant] {
         var merged = previous
-            .map {
-                MeetingParticipant(
-                    name: StringNormalizer.normalizeInline($0.name),
-                    role: normalizedOptionalField($0.role)
-                )
-            }
+            .map { normalizedParticipant($0) }
             .filter { !$0.name.isEmpty }
 
         for candidate in next {
-            let normalized = MeetingParticipant(
-                name: StringNormalizer.normalizeInline(candidate.name),
-                role: normalizedOptionalField(candidate.role)
-            )
+            let normalized = normalizedParticipant(candidate)
             guard !normalized.name.isEmpty else { continue }
 
             if let index = merged.firstIndex(where: { normalizedKey($0.name) == normalizedKey(normalized.name) }) {
-                // Backfill or prefer the richer role; keep the earlier name spelling.
-                if merged[index].role == nil, let role = normalized.role {
-                    merged[index].role = role
-                } else if let existingRole = merged[index].role, let role = normalized.role {
-                    merged[index].role = preferredValue(existing: existingRole, incoming: role)
-                }
+                merged[index].role = mergedOptionalField(existing: merged[index].role, incoming: normalized.role)
+                merged[index].speaker = merged[index].speaker ?? normalized.speaker
+                merged[index].details = mergedOptionalField(existing: merged[index].details, incoming: normalized.details)
             } else {
                 merged.append(normalized)
             }
         }
 
         return merged
+    }
+
+    private static func normalizedParticipant(_ participant: MeetingParticipant) -> MeetingParticipant {
+        MeetingParticipant(
+            name: StringNormalizer.normalizeInline(participant.name),
+            role: normalizedOptionalField(participant.role),
+            speaker: normalizedOptionalField(participant.speaker),
+            details: normalizedOptionalField(participant.details)
+        )
+    }
+
+    /// Backfills a nil field or prefers the richer of two values.
+    private static func mergedOptionalField(existing: String?, incoming: String?) -> String? {
+        switch (existing, incoming) {
+        case (nil, let incoming):
+            return incoming
+        case (let existing, nil):
+            return existing
+        case (let existing?, let incoming?):
+            return preferredValue(existing: existing, incoming: incoming)
+        }
     }
 
     private static func mergeTopics(_ previous: [MeetingTopic], _ next: [MeetingTopic]) -> [MeetingTopic] {

--- a/MinuteCore/Sources/MinuteCore/Services/SummarizationSummaryMerger.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/SummarizationSummaryMerger.swift
@@ -19,6 +19,8 @@ public enum SummarizationSummaryMerger {
             actionItems: mergeActionItems(previous.actionItems, delta.actionItems),
             openQuestions: mergeStrings(previous.openQuestions, delta.openQuestions),
             keyPoints: mergeStrings(previous.keyPoints, delta.keyPoints),
+            participants: mergeParticipants(previous.participants, delta.participants),
+            topics: mergeTopics(previous.topics, delta.topics),
             meetingType: meetingType ?? previous.meetingType
         )
     }
@@ -35,6 +37,8 @@ public enum SummarizationSummaryMerger {
             actionItems: state.actionItems,
             openQuestions: state.openQuestions,
             keyPoints: state.keyPoints,
+            participants: state.participants,
+            topics: state.topics,
             meetingType: state.meetingType
         )
         return MeetingExtractionValidation.validated(extraction, recordingDate: recordingDate)
@@ -89,23 +93,93 @@ public enum SummarizationSummaryMerger {
 
     private static func mergeActionItems(_ previous: [ActionItem], _ next: [ActionItem]) -> [ActionItem] {
         var merged = previous
-            .map {
-                ActionItem(
-                    owner: StringNormalizer.normalizeInline($0.owner),
-                    task: StringNormalizer.normalizeInline($0.task)
-                )
-            }
+            .map { normalizedActionItem($0) }
             .filter { !$0.owner.isEmpty || !$0.task.isEmpty }
 
         for candidate in next {
-            let normalized = ActionItem(
-                owner: StringNormalizer.normalizeInline(candidate.owner),
-                task: StringNormalizer.normalizeInline(candidate.task)
-            )
+            let normalized = normalizedActionItem(candidate)
             guard !normalized.owner.isEmpty || !normalized.task.isEmpty else { continue }
 
             if let index = merged.firstIndex(where: { overlaps($0, normalized) }) {
                 merged[index] = preferredActionItem(existing: merged[index], incoming: normalized)
+            } else {
+                merged.append(normalized)
+            }
+        }
+
+        return merged
+    }
+
+    private static func normalizedActionItem(_ item: ActionItem) -> ActionItem {
+        ActionItem(
+            owner: StringNormalizer.normalizeInline(item.owner),
+            task: StringNormalizer.normalizeInline(item.task),
+            dueDate: normalizedOptionalField(item.dueDate),
+            status: normalizedOptionalField(item.status),
+            comments: normalizedOptionalField(item.comments)
+        )
+    }
+
+    private static func normalizedOptionalField(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = StringNormalizer.normalizeInline(value)
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func mergeParticipants(
+        _ previous: [MeetingParticipant],
+        _ next: [MeetingParticipant]
+    ) -> [MeetingParticipant] {
+        var merged = previous
+            .map {
+                MeetingParticipant(
+                    name: StringNormalizer.normalizeInline($0.name),
+                    role: normalizedOptionalField($0.role)
+                )
+            }
+            .filter { !$0.name.isEmpty }
+
+        for candidate in next {
+            let normalized = MeetingParticipant(
+                name: StringNormalizer.normalizeInline(candidate.name),
+                role: normalizedOptionalField(candidate.role)
+            )
+            guard !normalized.name.isEmpty else { continue }
+
+            if let index = merged.firstIndex(where: { normalizedKey($0.name) == normalizedKey(normalized.name) }) {
+                // Backfill or prefer the richer role; keep the earlier name spelling.
+                if merged[index].role == nil, let role = normalized.role {
+                    merged[index].role = role
+                } else if let existingRole = merged[index].role, let role = normalized.role {
+                    merged[index].role = preferredValue(existing: existingRole, incoming: role)
+                }
+            } else {
+                merged.append(normalized)
+            }
+        }
+
+        return merged
+    }
+
+    private static func mergeTopics(_ previous: [MeetingTopic], _ next: [MeetingTopic]) -> [MeetingTopic] {
+        var merged = previous
+            .map {
+                MeetingTopic(
+                    title: StringNormalizer.normalizeInline($0.title),
+                    points: $0.points.map(StringNormalizer.normalizeInline).filter { !$0.isEmpty }
+                )
+            }
+            .filter { !$0.title.isEmpty }
+
+        for candidate in next {
+            let normalized = MeetingTopic(
+                title: StringNormalizer.normalizeInline(candidate.title),
+                points: candidate.points.map(StringNormalizer.normalizeInline).filter { !$0.isEmpty }
+            )
+            guard !normalized.title.isEmpty else { continue }
+
+            if let index = merged.firstIndex(where: { normalizedKey($0.title) == normalizedKey(normalized.title) }) {
+                merged[index].points = mergeStrings(merged[index].points, normalized.points)
             } else {
                 merged.append(normalized)
             }

--- a/MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift
+++ b/MinuteCore/Sources/MinuteCore/Services/VaultMeetingNotesBrowser.swift
@@ -37,6 +37,11 @@ public protocol MeetingNotesBrowsing: Sendable {
     func loadNoteContent(for item: MeetingNoteItem) async throws -> String
     func loadTranscriptContent(for item: MeetingNoteItem) async throws -> String
     func deleteNoteFiles(for item: MeetingNoteItem) async throws
+    /// Renames the note title: moves the summary, audio, and transcript files to
+    /// the new base name and rewrites the note/transcript markdown (frontmatter
+    /// title, headings, wiki-links). Returns the updated item.
+    @discardableResult
+    func renameNoteFiles(for item: MeetingNoteItem, to newTitle: String) async throws -> MeetingNoteItem
 }
 
 public struct VaultMeetingNotesBrowser: MeetingNotesBrowsing, @unchecked Sendable {
@@ -209,6 +214,99 @@ public struct VaultMeetingNotesBrowser: MeetingNotesBrowsing, @unchecked Sendabl
             if let firstError {
                 throw firstError
             }
+        }
+    }
+
+    @discardableResult
+    public func renameNoteFiles(for item: MeetingNoteItem, to newTitle: String) async throws -> MeetingNoteItem {
+        try Task.checkCancellation()
+
+        let trimmedTitle = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            throw MeetingNoteRenameError.emptyTitle
+        }
+
+        return try vaultAccess.withVaultAccess { vaultRootURL in
+            let oldBaseName = item.fileURL.deletingPathExtension().lastPathComponent
+            let newBaseName = MeetingNoteRenamer.newBaseName(oldBaseName: oldBaseName, newTitle: trimmedTitle)
+            let sanitizedNewTitle = FilenameSanitizer.sanitizeTitle(trimmedTitle)
+
+            guard newBaseName != oldBaseName else {
+                throw MeetingNoteRenameError.titleUnchanged
+            }
+
+            let audioRootURL = Self.directoryURL(from: vaultRootURL, relativePath: audioRelativePath)
+            let transcriptRootURL = Self.directoryURL(from: vaultRootURL, relativePath: transcriptsRelativePath)
+
+            let oldNoteURL = item.fileURL
+            let oldAudioURL = audioRootURL.appendingPathComponent("\(oldBaseName).wav")
+            let oldTranscriptURL = item.transcriptURL
+                ?? transcriptRootURL.appendingPathComponent("\(oldBaseName).md")
+
+            let newNoteURL = oldNoteURL.deletingLastPathComponent().appendingPathComponent("\(newBaseName).md")
+            let newAudioURL = audioRootURL.appendingPathComponent("\(newBaseName).wav")
+            let newTranscriptURL = transcriptRootURL.appendingPathComponent("\(newBaseName).md")
+
+            let fileManager = FileManager.default
+            let plannedMoves: [(from: URL, to: URL)] = [
+                (oldNoteURL, newNoteURL),
+                (oldAudioURL, newAudioURL),
+                (oldTranscriptURL, newTranscriptURL),
+            ].filter { fileManager.fileExists(atPath: $0.from.path) }
+
+            // Refuse to overwrite anything at the destinations.
+            for move in plannedMoves where fileManager.fileExists(atPath: move.to.path) {
+                throw MeetingNoteRenameError.destinationAlreadyExists
+            }
+
+            // Rewrite markdown contents BEFORE moving, so a content failure
+            // leaves the vault untouched.
+            let noteMarkdown = try String(contentsOf: oldNoteURL, encoding: .utf8)
+            let rewrittenNote = MeetingNoteRenamer.rewrittenNoteMarkdown(
+                noteMarkdown,
+                oldTitle: item.title,
+                newTitle: sanitizedNewTitle,
+                oldBaseName: oldBaseName,
+                newBaseName: newBaseName
+            )
+
+            var rewrittenTranscript: String?
+            if fileManager.fileExists(atPath: oldTranscriptURL.path),
+               let transcriptMarkdown = try? String(contentsOf: oldTranscriptURL, encoding: .utf8) {
+                rewrittenTranscript = MeetingNoteRenamer.rewrittenTranscriptMarkdown(
+                    transcriptMarkdown,
+                    oldTitle: item.title,
+                    newTitle: sanitizedNewTitle
+                )
+            }
+
+            // Move files, rolling back completed moves on failure.
+            var completedMoves: [(from: URL, to: URL)] = []
+            do {
+                for move in plannedMoves {
+                    try fileManager.moveItem(at: move.from, to: move.to)
+                    completedMoves.append(move)
+                }
+            } catch {
+                for move in completedMoves.reversed() {
+                    try? fileManager.moveItem(at: move.to, to: move.from)
+                }
+                throw error
+            }
+
+            // Write rewritten contents at the new locations (atomic writes).
+            try Data(rewrittenNote.utf8).write(to: newNoteURL, options: [.atomic])
+            if let rewrittenTranscript {
+                try Data(rewrittenTranscript.utf8).write(to: newTranscriptURL, options: [.atomic])
+            }
+
+            var renamed = item
+            renamed.title = sanitizedNewTitle
+            renamed.fileURL = newNoteURL
+            renamed.relativePath = Self.relativePath(from: vaultRootURL, to: newNoteURL)
+            renamed.transcriptURL = fileManager.fileExists(atPath: newTranscriptURL.path) ? newTranscriptURL : nil
+            renamed.hasTranscript = renamed.transcriptURL != nil
+            return renamed
         }
     }
 

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/PromptFactory.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/PromptFactory.swift
@@ -209,13 +209,15 @@ public enum PromptFactory {
             "- title (string)",
             "- date (YYYY-MM-DD)",
             "- summary (string)",
+            "- participants (array of objects with name and role; use Speaker N when the real name is not inferable)",
+            "- topics (array of objects with title and points, capturing each distinct topic discussed)",
         ]
 
         if components.decisionRulesEnabled {
             fields.append("- decisions (array of string)")
         }
         if components.actionItemRulesEnabled {
-            fields.append("- action_items (array of objects with owner and task)")
+            fields.append("- action_items (array of objects with owner, task, due_date, status, and comments)")
         }
         if components.openQuestionRulesEnabled {
             fields.append("- open_questions (array of string)")

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/PromptFactory.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/PromptFactory.swift
@@ -32,6 +32,18 @@ public enum PromptFactory {
 
         case .designReview:
             return DesignReviewPromptStrategy()
+
+        case .interviewTaken:
+            return InterviewTakenPromptStrategy()
+
+        case .interviewGiven:
+            return InterviewGivenPromptStrategy()
+
+        case .allHands:
+            return AllHandsPromptStrategy()
+
+        case .retrospective:
+            return RetrospectivePromptStrategy()
         }
     }
 

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/PromptFactory.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/PromptFactory.swift
@@ -209,7 +209,7 @@ public enum PromptFactory {
             "- title (string)",
             "- date (YYYY-MM-DD)",
             "- summary (string)",
-            "- participants (array of objects with name and role; use Speaker N when the real name is not inferable)",
+            "- participants (array of objects with name, speaker, role, and details; map each to a transcript Speaker N label, describe what they did with evidence for the name mapping, and never guess names)",
             "- topics (array of objects with title and points, capturing each distinct topic discussed)",
         ]
 

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/AllHandsPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/AllHandsPromptStrategy.swift
@@ -36,11 +36,26 @@ public struct AllHandsPromptStrategy: PromptStrategy {
             "title": "string (E.g., '[Org/Team] All Hands - [Main Theme]')",
             "date": "YYYY-MM-DD",
             "summary": "string (3-8 sentences summarizing the announcements, key messages from leadership, and overall themes.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Announced changes or commitments, e.g. org changes, strategy shifts. Empty if none.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Asks made of the audience or commitments by leadership, e.g. 'Complete the survey by Friday'.)"
+                "task": "string (Asks made of the audience or commitments by leadership, e.g. 'Complete the survey by Friday'.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Questions from Q&A that were deferred or left unanswered.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/AllHandsPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/AllHandsPromptStrategy.swift
@@ -1,0 +1,62 @@
+//
+//  AllHandsPromptStrategy.swift
+//  MinuteCore
+//
+//  All hands / town hall meeting type, adapted from user meeting-notes
+//  templates for the fixed JSON summary contract.
+//
+
+import Foundation
+
+public struct AllHandsPromptStrategy: PromptStrategy {
+    public let meetingType: MeetingType = .allHands
+
+    public init() {}
+
+    public func systemPrompt() -> String {
+        return """
+        You are an expert automated meeting secretary specialized in all-hands and town-hall meetings. Your goal is to analyze a chronological meeting timeline and generate a structured, factual summary in strict JSON format.
+
+        The timeline includes:
+        - Spoken transcript entries, prefixed like: [MM:SS] Speaker N: ...
+        - Screen context entries, prefixed like: [MM:SS] Screen (Window Title): ...
+
+        ### CORE INSTRUCTIONS
+        1. **Truthfulness is Paramount:** Base all outputs *exclusively* on the provided transcript.
+        2. **Focus on Announcements:** Capture organizational updates, leadership messages, strategy changes, metrics and goals shared, and recognitions — with the speaker attributed where identifiable.
+        3. **Capture Q&A Faithfully:** Pair each audience question with the answer given and, when identifiable, who asked and who answered.
+        4. **Preserve Numbers:** Keep metrics, goals, dates, and figures exactly as stated.
+        5. **Filter Noise:** Ignore logistics chatter, applause, and filler.
+
+        ### OUTPUT FORMAT
+        You must output a single, valid JSON object. Do not include markdown formatting or raw text outside the braces.
+
+        Schema definition:
+        {
+            "title": "string (E.g., '[Org/Team] All Hands - [Main Theme]')",
+            "date": "YYYY-MM-DD",
+            "summary": "string (3-8 sentences summarizing the announcements, key messages from leadership, and overall themes.)",
+            "decisions": ["string (Announced changes or commitments, e.g. org changes, strategy shifts. Empty if none.)"],
+            "action_items": [
+                {
+                "owner": "string",
+                "task": "string (Asks made of the audience or commitments by leadership, e.g. 'Complete the survey by Friday'.)"
+                }
+            ],
+            "open_questions": ["string (Questions from Q&A that were deferred or left unanswered.)"],
+            "key_points": ["string (Announcements, metrics/goals shared, notable Q&A exchanges, and key leadership messages.)"]
+        }
+
+        ### CRITICAL RULES
+        - **No Hallucinations:** If a field has no content, return an empty array [].
+        - **Formatting:** Ensure the JSON is minified or properly escaped.
+        """
+    }
+
+    public func userPrompt(for transcript: String) -> String {
+        return """
+        Timeline follows:
+        \(transcript)
+        """
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/AllHandsPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/AllHandsPromptStrategy.swift
@@ -39,7 +39,9 @@ public struct AllHandsPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/DesignReviewPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/DesignReviewPromptStrategy.swift
@@ -37,7 +37,9 @@ public struct DesignReviewPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/DesignReviewPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/DesignReviewPromptStrategy.swift
@@ -34,11 +34,26 @@ public struct DesignReviewPromptStrategy: PromptStrategy {
             "title": "string (E.g., 'Design Review: Homepage')",
             "date": "YYYY-MM-DD",
             "summary": "string (Summary of the feedback sentiment: approved, needs iteration, or major changes? 3-8 sentences.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Design decisions approved. 'Move button to left', 'Change color', etc.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Design iterations or prototyping tasks.)"
+                "task": "string (Design iterations or prototyping tasks.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Unresolved UX questions or need for user testing.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/GeneralPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/GeneralPromptStrategy.swift
@@ -37,7 +37,9 @@ public struct GeneralPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/GeneralPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/GeneralPromptStrategy.swift
@@ -34,11 +34,26 @@ public struct GeneralPromptStrategy: PromptStrategy {
             "title": "string (3-8 words, filename-safe, summarizes the main topic)",
             "date": "YYYY-MM-DD (use provided date unless transcript explicitly mentions a different meeting date)",
             "summary": "string (A concise executive summary of 3-8 sentences. Focus on the 'what' and 'why' of the meeting outcomes. Also a summary of the full names of the main participants )",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Explicit agreements or conclusions reached. Empty if none.)"],
             "action_items": [
                 {
                 "owner": "string (Name of the person assigned. Use 'Unassigned' if clear task but no owner. Do not guess names.)",
-                "task": "string (Start with a verb. Be specific.)"
+                "task": "string (Start with a verb. Be specific.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Unresolved issues or topics tabled for later. Empty if none.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/GeneralPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/GeneralPromptStrategy.swift
@@ -25,6 +25,10 @@ public struct GeneralPromptStrategy: PromptStrategy {
         2. **ASR Error Correction:** The transcript is machine-generated and may contain phonetic errors (e.g., "sink" instead of "sync"). Use context to interpret the correct meaning, but do not alter the factual substance.
         3. **Filter Noise:** Ignore small talk, pleasantries, incomplete sentences, and non-substantive filler (um, ah). Focus on the "business" of the meeting.
         4. **Language Handling:** Detect the dominant language of the business discussion. Retain specific technical terms or proper nouns in their original language.
+        5. **Identify Participants:** Map each Speaker N to a real name or alias only when inferable from the conversation (direct address by name is the strongest evidence). Note each participant's apparent role (manager, presenter, interviewer, candidate, etc.). If a name is not inferable, keep the Speaker N label with the apparent role noted.
+        6. **Be Thorough:** Capture ALL distinct topics, questions, and discussions — even brief ones. Note disagreements, concerns, and unresolved debates. When someone gives guidance or advice, capture the reasoning behind it.
+        7. **Technical Accuracy:** Preserve project names, service names, team names, and technical terms exactly as spoken.
+        8. **Use Screen Context:** Screen entries in the timeline come from screen capture and may contain information never spoken aloud (window titles, document text). Use them as additional context to disambiguate references and enrich topics.
 
         ### OUTPUT FORMAT
         You must output a single, valid JSON object. Do not include markdown formatting (```json), explanations, or raw text outside the braces.
@@ -65,6 +69,9 @@ public struct GeneralPromptStrategy: PromptStrategy {
         ### CRITICAL RULES
         - **No Hallucinations:** If a field (like decisions or action_items) has no content in the transcript, return an empty array []. Do not invent tasks to fill space.
         - **Action Item Specificity:** Only list an action item if there is a clear commitment to perform a task. Do not list general suggestions as action items.
+        - **Action Item Dates:** Use YYYY-MM-DD format for due_date. Use "TBD" when no date was mentioned.
+        - **Empty Means Empty:** Return empty arrays for fields without evidence; empty sections are omitted from the final note automatically.
+        - **Better Too Much Than Missing:** When unsure whether a genuinely discussed topic or point is worth including, include it.
         - **Formatting:** Ensure the JSON is minified or properly escaped so it can be parsed programmatically.
         """
     }

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewGivenPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewGivenPromptStrategy.swift
@@ -39,7 +39,9 @@ public struct InterviewGivenPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewGivenPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewGivenPromptStrategy.swift
@@ -1,0 +1,62 @@
+//
+//  InterviewGivenPromptStrategy.swift
+//  MinuteCore
+//
+//  Interview (candidate perspective) meeting type, adapted from user
+//  meeting-notes templates for the fixed JSON summary contract.
+//
+
+import Foundation
+
+public struct InterviewGivenPromptStrategy: PromptStrategy {
+    public let meetingType: MeetingType = .interviewGiven
+
+    public init() {}
+
+    public func systemPrompt() -> String {
+        return """
+        You are an expert automated meeting secretary specialized in job interviews where the transcript owner is the CANDIDATE being interviewed. Your goal is to analyze a chronological meeting timeline and generate a structured, factual summary in strict JSON format.
+
+        The timeline includes:
+        - Spoken transcript entries, prefixed like: [MM:SS] Speaker N: ...
+        - Screen context entries, prefixed like: [MM:SS] Screen (Window Title): ...
+
+        ### CORE INSTRUCTIONS
+        1. **Truthfulness is Paramount:** Base all outputs *exclusively* on the provided transcript.
+        2. **Identify Roles Carefully:** Determine who is asking questions (interviewer) versus answering (candidate). Direct address by name is the strongest evidence for identity.
+        3. **Capture the Learning Record:** Note the company/team if mentioned, the round type, each question or problem posed, the candidate's approach, and any hints, redirections, or corrections from the interviewer.
+        4. **Honest Self-Review Material:** Capture both what went well and where the candidate struggled or was corrected, so the notes are useful for preparation.
+        5. **Filter Noise:** Ignore small talk, scheduling chatter, and filler.
+
+        ### OUTPUT FORMAT
+        You must output a single, valid JSON object. Do not include markdown formatting or raw text outside the braces.
+
+        Schema definition:
+        {
+            "title": "string (E.g., 'Interview - [Company] - [Round Type]')",
+            "date": "YYYY-MM-DD",
+            "summary": "string (3-8 sentences: what was asked, how the candidate approached it, where they did well, where they struggled, interviewer style and any course corrections.)",
+            "decisions": ["string (Concrete conclusions, e.g. next steps in the process agreed during the call. Empty if none.)"],
+            "action_items": [
+                {
+                "owner": "string",
+                "task": "string (Follow-ups: topics to study or practice, materials to send, thank-you or availability actions.)"
+                }
+            ],
+            "open_questions": ["string (Unanswered questions about the role, team, or process; problems left unresolved.)"],
+            "key_points": ["string (Question-by-question highlights: the question, the approach taken, interviewer hints or feedback, and learnings for next time.)"]
+        }
+
+        ### CRITICAL RULES
+        - **No Hallucinations:** If a field has no content, return an empty array [].
+        - **Formatting:** Ensure the JSON is minified or properly escaped.
+        """
+    }
+
+    public func userPrompt(for transcript: String) -> String {
+        return """
+        Timeline follows:
+        \(transcript)
+        """
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewGivenPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewGivenPromptStrategy.swift
@@ -36,11 +36,26 @@ public struct InterviewGivenPromptStrategy: PromptStrategy {
             "title": "string (E.g., 'Interview - [Company] - [Round Type]')",
             "date": "YYYY-MM-DD",
             "summary": "string (3-8 sentences: what was asked, how the candidate approached it, where they did well, where they struggled, interviewer style and any course corrections.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Concrete conclusions, e.g. next steps in the process agreed during the call. Empty if none.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Follow-ups: topics to study or practice, materials to send, thank-you or availability actions.)"
+                "task": "string (Follow-ups: topics to study or practice, materials to send, thank-you or availability actions.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Unanswered questions about the role, team, or process; problems left unresolved.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewTakenPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewTakenPromptStrategy.swift
@@ -36,11 +36,26 @@ public struct InterviewTakenPromptStrategy: PromptStrategy {
             "title": "string (E.g., 'Interview - [Candidate] - [Round Type]')",
             "date": "YYYY-MM-DD",
             "summary": "string (3-8 sentences: round type, problem(s) given, candidate's approach, key strengths observed, areas of concern, overall impression.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Assessment leanings expressed, e.g. signal strength or hire/no-hire leaning. Empty if none stated.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Follow-ups: debrief points to raise, references to check, next rounds to schedule.)"
+                "task": "string (Follow-ups: debrief points to raise, references to check, next rounds to schedule.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Unresolved doubts about the candidate or topics not covered in time.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewTakenPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewTakenPromptStrategy.swift
@@ -1,0 +1,63 @@
+//
+//  InterviewTakenPromptStrategy.swift
+//  MinuteCore
+//
+//  Interview (interviewer perspective) meeting type, adapted from user
+//  meeting-notes templates for the fixed JSON summary contract.
+//
+
+import Foundation
+
+public struct InterviewTakenPromptStrategy: PromptStrategy {
+    public let meetingType: MeetingType = .interviewTaken
+
+    public init() {}
+
+    public func systemPrompt() -> String {
+        return """
+        You are an expert automated meeting secretary specialized in job interviews where the transcript owner is the INTERVIEWER evaluating a candidate. Your goal is to analyze a chronological meeting timeline and generate a structured, factual summary in strict JSON format.
+
+        The timeline includes:
+        - Spoken transcript entries, prefixed like: [MM:SS] Speaker N: ...
+        - Screen context entries, prefixed like: [MM:SS] Screen (Window Title): ...
+
+        ### CORE INSTRUCTIONS
+        1. **Truthfulness is Paramount:** Base all outputs *exclusively* on the provided transcript. Never invent candidate answers or assessments.
+        2. **Identify Roles Carefully:** Determine who is asking questions (interviewer) versus answering (candidate). Direct address by name is the strongest evidence for identity; third-person mentions usually mean that person is NOT the speaker.
+        3. **Capture the Interview Structure:** Note the round type (system design, coding, behavioral, bar raiser), the problems or questions posed, the candidate's approach to each, and any follow-up probes.
+        4. **Evidence over Impression:** When capturing strengths or concerns, tie each to a specific moment or answer in the transcript.
+        5. **Filter Noise:** Ignore small talk, scheduling chatter, and filler.
+
+        ### OUTPUT FORMAT
+        You must output a single, valid JSON object. Do not include markdown formatting or raw text outside the braces.
+
+        Schema definition:
+        {
+            "title": "string (E.g., 'Interview - [Candidate] - [Round Type]')",
+            "date": "YYYY-MM-DD",
+            "summary": "string (3-8 sentences: round type, problem(s) given, candidate's approach, key strengths observed, areas of concern, overall impression.)",
+            "decisions": ["string (Assessment leanings expressed, e.g. signal strength or hire/no-hire leaning. Empty if none stated.)"],
+            "action_items": [
+                {
+                "owner": "string",
+                "task": "string (Follow-ups: debrief points to raise, references to check, next rounds to schedule.)"
+                }
+            ],
+            "open_questions": ["string (Unresolved doubts about the candidate or topics not covered in time.)"],
+            "key_points": ["string (Question-by-question highlights: what was asked, how the candidate responded, notable strengths or weaknesses with evidence.)"]
+        }
+
+        ### CRITICAL RULES
+        - **No Hallucinations:** If a field has no content, return an empty array [].
+        - **Confidential Tone:** This is a preliminary personal record, not a formal debrief. Keep assessments factual and evidence-based.
+        - **Formatting:** Ensure the JSON is minified or properly escaped.
+        """
+    }
+
+    public func userPrompt(for transcript: String) -> String {
+        return """
+        Timeline follows:
+        \(transcript)
+        """
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewTakenPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/InterviewTakenPromptStrategy.swift
@@ -39,7 +39,9 @@ public struct InterviewTakenPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/OneOnOnePromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/OneOnOnePromptStrategy.swift
@@ -37,7 +37,9 @@ public struct OneOnOnePromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/OneOnOnePromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/OneOnOnePromptStrategy.swift
@@ -34,11 +34,26 @@ public struct OneOnOnePromptStrategy: PromptStrategy {
             "title": "string (E.g., '1:1 - [Name] & [Name]')",
             "date": "YYYY-MM-DD",
             "summary": "string (High-level summary of topics discussed. 3-8 sentences.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Agreements made between the two parties.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Specific follow-ups.)"
+                "task": "string (Specific follow-ups.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Topics requiring further thought or external input.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PlanningPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PlanningPromptStrategy.swift
@@ -34,11 +34,26 @@ public struct PlanningPromptStrategy: PromptStrategy {
             "title": "string (E.g., 'Sprint Planning', 'Q3 Roadmap')",
             "date": "YYYY-MM-DD",
             "summary": "string (Summary of the plan: main goals, scope agreed upon. 3-8 sentences.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Scope decisions: what is in, what is out? Deadline decisions.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Tasks assigned for the sprint/project.)"
+                "task": "string (Tasks assigned for the sprint/project.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Dependencies or unknowns that need resolution.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PlanningPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PlanningPromptStrategy.swift
@@ -37,7 +37,9 @@ public struct PlanningPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PresentationPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PresentationPromptStrategy.swift
@@ -37,7 +37,9 @@ public struct PresentationPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PresentationPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/PresentationPromptStrategy.swift
@@ -34,11 +34,26 @@ public struct PresentationPromptStrategy: PromptStrategy {
             "title": "string (The title of the presentation or talk)",
             "date": "YYYY-MM-DD",
             "summary": "string (Executive summary of the presentation content. what was the main topic? What were the conclusions? 3-8 sentences.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Likely empty, unless the presentation called for a vote or decision.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Follow-ups requested by the presenter or audience.)"
+                "task": "string (Follow-ups requested by the presenter or audience.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Questions asked by the audience during Q&A.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/RetrospectivePromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/RetrospectivePromptStrategy.swift
@@ -36,11 +36,26 @@ public struct RetrospectivePromptStrategy: PromptStrategy {
             "title": "string (E.g., 'Retro - [Sprint/Project Name]')",
             "date": "YYYY-MM-DD",
             "summary": "string (3-8 sentences summarizing the retro themes: main wins, main pain points, and the improvements agreed.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Agreed process changes or experiments to adopt. Empty if none.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Specific improvement actions with a committed owner.)"
+                "task": "string (Specific improvement actions with a committed owner.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string (Unresolved disagreements or topics parked for follow-up.)"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/RetrospectivePromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/RetrospectivePromptStrategy.swift
@@ -39,7 +39,9 @@ public struct RetrospectivePromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/RetrospectivePromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/RetrospectivePromptStrategy.swift
@@ -1,0 +1,62 @@
+//
+//  RetrospectivePromptStrategy.swift
+//  MinuteCore
+//
+//  Retrospective / post-mortem meeting type, adapted from user meeting-notes
+//  templates for the fixed JSON summary contract.
+//
+
+import Foundation
+
+public struct RetrospectivePromptStrategy: PromptStrategy {
+    public let meetingType: MeetingType = .retrospective
+
+    public init() {}
+
+    public func systemPrompt() -> String {
+        return """
+        You are an expert automated meeting secretary specialized in retrospectives and post-mortems. Your goal is to analyze a chronological meeting timeline and generate a structured, factual summary in strict JSON format.
+
+        The timeline includes:
+        - Spoken transcript entries, prefixed like: [MM:SS] Speaker N: ...
+        - Screen context entries, prefixed like: [MM:SS] Screen (Window Title): ...
+
+        ### CORE INSTRUCTIONS
+        1. **Truthfulness is Paramount:** Base all outputs *exclusively* on the provided transcript.
+        2. **Structure by Retro Themes:** Organize findings into what went well, what didn't go well, and what to improve — attributing who raised each item where identifiable.
+        3. **Attribute Positions Precisely:** In debate, be exact about WHO raised a concern versus who reframed or answered it; reversing this inverts the meaning.
+        4. **Capture Improvement Commitments:** Proposed process changes with an owner are action items; ideas without commitment are key points.
+        5. **Filter Noise:** Ignore small talk and filler.
+
+        ### OUTPUT FORMAT
+        You must output a single, valid JSON object. Do not include markdown formatting or raw text outside the braces.
+
+        Schema definition:
+        {
+            "title": "string (E.g., 'Retro - [Sprint/Project Name]')",
+            "date": "YYYY-MM-DD",
+            "summary": "string (3-8 sentences summarizing the retro themes: main wins, main pain points, and the improvements agreed.)",
+            "decisions": ["string (Agreed process changes or experiments to adopt. Empty if none.)"],
+            "action_items": [
+                {
+                "owner": "string",
+                "task": "string (Specific improvement actions with a committed owner.)"
+                }
+            ],
+            "open_questions": ["string (Unresolved disagreements or topics parked for follow-up.)"],
+            "key_points": ["string (What went well and what didn't, each with who raised it and the discussion context.)"]
+        }
+
+        ### CRITICAL RULES
+        - **No Hallucinations:** If a field has no content, return an empty array [].
+        - **Formatting:** Ensure the JSON is minified or properly escaped.
+        """
+    }
+
+    public func userPrompt(for transcript: String) -> String {
+        return """
+        Timeline follows:
+        \(transcript)
+        """
+    }
+}

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/StandupPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/StandupPromptStrategy.swift
@@ -37,7 +37,9 @@ public struct StandupPromptStrategy: PromptStrategy {
             "participants": [
                 {
                 "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
-                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                "speaker": "string (Transcript speaker label this participant maps to, e.g. 'Speaker 1'. Empty if not applicable.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)",
+                "details": "string (Evidence-based description: what they did or said, role signals, and the evidence for the name mapping, e.g. 'addressed as Priya at [00:31]'. Note confidence when the mapping is inferred. Empty if nothing notable.)"
                 }
             ],
             "topics": [

--- a/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/StandupPromptStrategy.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Prompts/Strategies/StandupPromptStrategy.swift
@@ -34,11 +34,26 @@ public struct StandupPromptStrategy: PromptStrategy {
             "title": "string (defaults to 'Daily Standup - YYYY-MM-DD' unless a specific topic is mentioned)",
             "date": "YYYY-MM-DD",
             "summary": "string (Concise summary of team progress, major blockers, and announcements. 3-8 sentences.)",
+            "participants": [
+                {
+                "name": "string (Participant name; use Speaker N if the real name is not inferable. Never guess names.)",
+                "role": "string (Role or relationship if identifiable, e.g. Manager, Presenter, Candidate. Empty if unknown.)"
+                }
+            ],
+            "topics": [
+                {
+                "title": "string (Short topic title)",
+                "points": ["string (Detail points for this topic: context, key points raised by each participant, data or specifics mentioned.)"]
+                }
+            ],
             "decisions": ["string (Usually empty for standups, unless a process change is agreed upon.)"],
             "action_items": [
                 {
                 "owner": "string",
-                "task": "string (Focus on blockers intended to be resolved or follow-ups.)"
+                "task": "string (Focus on blockers intended to be resolved or follow-ups.)",
+                "due_date": "string (YYYY-MM-DD, or TBD if no date was mentioned)",
+                "status": "string (Not Started unless the transcript states otherwise)",
+                "comments": "string (Short supporting context for the task. Empty if none.)"
                 }
             ],
             "open_questions": ["string"],

--- a/MinuteCore/Sources/MinuteCore/Summarization/Services/MeetingTypeClassifier.swift
+++ b/MinuteCore/Sources/MinuteCore/Summarization/Services/MeetingTypeClassifier.swift
@@ -27,7 +27,11 @@ public enum MeetingTypeClassifier {
         "Design Review",
         "One-on-One",
         "Presentation",
-        "Planning"
+        "Planning",
+        "Interview — Taken",
+        "Interview — Given",
+        "All Hands",
+        "Retrospective"
     ]
     
     /// Generates the prompt for the first-pass classification.
@@ -54,6 +58,10 @@ public enum MeetingTypeClassifier {
         - Design Review: explicit design review mention OR critique of mockups/UX/architecture proposals, tradeoffs.
         - Presentation: one-to-many talk with slides/demo, speaker-led narrative, audience Q&A.
         - Planning: sprint/roadmap planning with estimation, ticketing, owners, timelines, scope.
+        - Interview — Taken: structured Q&A evaluating a candidate, with the transcript owner ASKING coding/design/behavioral questions.
+        - Interview — Given: structured interview Q&A with the transcript owner ANSWERING questions and being evaluated.
+        - All Hands: org-wide updates, leadership speaking to a large audience, town-hall Q&A.
+        - Retrospective: explicit retro/post-mortem mention OR what-went-well / what-didn't / improvements structure.
 
         Default-to-General examples (low-information):
         - "Hey everyone." => General
@@ -146,6 +154,10 @@ public enum MeetingTypeClassifier {
         case "one-on-one": return .oneOnOne
         case "presentation": return .presentation
         case "planning": return .planning
+        case "interview — taken", "interview - taken", "interview taken": return .interviewTaken
+        case "interview — given", "interview - given", "interview given": return .interviewGiven
+        case "all hands", "all hands / town hall", "town hall": return .allHands
+        case "retrospective", "retro", "post-mortem", "postmortem": return .retrospective
         default: return .general
         }
     }

--- a/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
+++ b/MinuteCore/Sources/MinuteLMStudio/Services/LMStudioAPIClient.swift
@@ -71,9 +71,18 @@ public struct LMStudioAPIClient: Sendable {
     public var baseURL: URL
     private let session: URLSession
 
+    /// Default session with an extended request timeout: local servers can take
+    /// longer than URLSession's 60-second default to complete a non-streaming
+    /// chat completion (large prompts, slow models, cold starts).
+    public static let defaultSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = AppConfiguration.Defaults.localServerRequestTimeoutSeconds
+        return URLSession(configuration: configuration)
+    }()
+
     public init(
         baseURL: URL = URL(string: AppConfiguration.Defaults.defaultLMStudioBaseURL)!,
-        session: URLSession = .shared
+        session: URLSession = LMStudioAPIClient.defaultSession
     ) {
         self.baseURL = baseURL
         self.session = session

--- a/MinuteCore/Sources/MinuteLlama/Services/LlamaLibrarySummarizationService.swift
+++ b/MinuteCore/Sources/MinuteLlama/Services/LlamaLibrarySummarizationService.swift
@@ -460,9 +460,11 @@ public struct LlamaLibrarySummarizationService: RuntimeAwareSummarizationServici
         - date (YYYY-MM-DD; empty string if unchanged)
         - summary_points (array of short, high-signal new facts from this chunk only)
         - decisions (array of new decisions only)
-        - action_items (array of objects with owner and task; new or materially refined items only)
+        - action_items (array of objects with owner, task, due_date, status, and comments; new or materially refined items only)
         - open_questions (array of new open questions only)
         - key_points (array of new key points only)
+        - participants (array of objects with name and role; newly identified participants only)
+        - topics (array of objects with title and points; new topics or new points for existing topics only)
 
         Rules:
         - Do not restate information already captured in the existing accepted state.
@@ -489,6 +491,8 @@ public struct LlamaLibrarySummarizationService: RuntimeAwareSummarizationServici
         - action_items
         - open_questions
         - key_points
+        - participants
+        - topics
         """
     }
 

--- a/MinuteCore/Sources/MinuteLlama/Services/LlamaLibrarySummarizationService.swift
+++ b/MinuteCore/Sources/MinuteLlama/Services/LlamaLibrarySummarizationService.swift
@@ -463,7 +463,7 @@ public struct LlamaLibrarySummarizationService: RuntimeAwareSummarizationServici
         - action_items (array of objects with owner, task, due_date, status, and comments; new or materially refined items only)
         - open_questions (array of new open questions only)
         - key_points (array of new key points only)
-        - participants (array of objects with name and role; newly identified participants only)
+        - participants (array of objects with name, speaker, role, and details; newly identified participants or new evidence only)
         - topics (array of objects with title and points; new topics or new points for existing topics only)
 
         Rules:

--- a/MinuteCore/Sources/MinuteOllama/Services/OllamaAPIClient.swift
+++ b/MinuteCore/Sources/MinuteOllama/Services/OllamaAPIClient.swift
@@ -39,9 +39,18 @@ public struct OllamaAPIClient: Sendable {
     public var baseURL: URL
     private let session: URLSession
 
+    /// Default session with an extended request timeout: local servers can take
+    /// longer than URLSession's 60-second default to complete a non-streaming
+    /// chat completion (large prompts, slow models, cold starts).
+    public static let defaultSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = AppConfiguration.Defaults.localServerRequestTimeoutSeconds
+        return URLSession(configuration: configuration)
+    }()
+
     public init(
         baseURL: URL = URL(string: AppConfiguration.Defaults.defaultOllamaBaseURL)!,
-        session: URLSession = .shared
+        session: URLSession = OllamaAPIClient.defaultSession
     ) {
         self.baseURL = baseURL
         self.session = session

--- a/MinuteCore/Tests/MinuteCoreTests/LocalServerRequestTimeoutTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/LocalServerRequestTimeoutTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import MinuteCore
+@testable import MinuteLMStudio
+@testable import MinuteOllama
+
+/// Local inference servers (LM Studio, Ollama, or shims in front of them) can
+/// legitimately take longer than URLSession's 60-second default to produce a
+/// full non-streaming completion. Both clients must use an extended timeout.
+struct LocalServerRequestTimeoutTests {
+
+    @Test
+    func timeoutConstant_isTwoMinutes() {
+        #expect(AppConfiguration.Defaults.localServerRequestTimeoutSeconds == 120)
+    }
+
+    @Test
+    func lmStudioClient_defaultSession_usesExtendedRequestTimeout() {
+        let timeout = LMStudioAPIClient.defaultSession.configuration.timeoutIntervalForRequest
+        #expect(timeout == AppConfiguration.Defaults.localServerRequestTimeoutSeconds)
+    }
+
+    @Test
+    func ollamaClient_defaultSession_usesExtendedRequestTimeout() {
+        let timeout = OllamaAPIClient.defaultSession.configuration.timeoutIntervalForRequest
+        #expect(timeout == AppConfiguration.Defaults.localServerRequestTimeoutSeconds)
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/LocalServerRequestTimeoutTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/LocalServerRequestTimeoutTests.swift
@@ -10,8 +10,8 @@ import Testing
 struct LocalServerRequestTimeoutTests {
 
     @Test
-    func timeoutConstant_isTwoMinutes() {
-        #expect(AppConfiguration.Defaults.localServerRequestTimeoutSeconds == 120)
+    func timeoutConstant_isFiveMinutes() {
+        #expect(AppConfiguration.Defaults.localServerRequestTimeoutSeconds == 300)
     }
 
     @Test

--- a/MinuteCore/Tests/MinuteCoreTests/MeetingExtractionRichFieldsTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/MeetingExtractionRichFieldsTests.swift
@@ -125,8 +125,8 @@ struct MeetingExtractionRichFieldsTests {
 
         #expect(markdown.contains("""
         ## Participants
-        - Alice — Manager
-        - Speaker 2
+        - **Alice** — Manager
+        - **Speaker 2**
         """))
         #expect(markdown.contains("""
         ## Topics Discussed
@@ -200,6 +200,70 @@ struct MeetingExtractionRichFieldsTests {
     }
 
     // MARK: - Merging
+
+    @Test
+    func decode_participantSpeakerAndDetails() throws {
+        let json = """
+        {
+          "title": "T", "date": "2026-08-01", "summary": "s",
+          "participants": [
+            {"name": "Jitendra", "speaker": "Speaker 2", "role": "Senior SDE", "details": "Addressed as 'Jitiva' at [02:14]; owns Matter M2."}
+          ]
+        }
+        """
+        let extraction = try JSONDecoder().decode(MeetingExtraction.self, from: Data(json.utf8))
+        let participant = try #require(extraction.participants.first)
+        #expect(participant.speaker == "Speaker 2")
+        #expect(participant.details == "Addressed as 'Jitiva' at [02:14]; owns Matter M2.")
+    }
+
+    @Test
+    func participantLine_composesNameSpeakerRoleAndDetails() {
+        let full = MeetingParticipant(
+            name: "Jitendra",
+            role: "Senior SDE",
+            speaker: "Speaker 2",
+            details: "Addressed as 'Jitiva' at [02:14]; owns Matter M2."
+        )
+        #expect(MarkdownRenderer.participantLine(full)
+            == "- **Jitendra** (Speaker 2) — Senior SDE. Addressed as 'Jitiva' at [02:14]; owns Matter M2.")
+
+        // Speaker label collapses when it matches the name (unresolved speaker).
+        let unresolved = MeetingParticipant(
+            name: "Speaker 3",
+            role: nil,
+            speaker: "Speaker 3",
+            details: "Brief closing thanks only; not part of the discussion."
+        )
+        #expect(MarkdownRenderer.participantLine(unresolved)
+            == "- **Speaker 3** — Brief closing thanks only; not part of the discussion.")
+
+        // Details without role.
+        let detailsOnly = MeetingParticipant(name: "Manager", role: nil, speaker: "Speaker 1", details: "Says 'my team'; assigns goals.")
+        #expect(MarkdownRenderer.participantLine(detailsOnly)
+            == "- **Manager** (Speaker 1) — Says 'my team'; assigns goals.")
+    }
+
+    @Test
+    func merger_backfillsSpeakerAndDetailsAcrossPasses() {
+        let first = SummarizationPassDelta(
+            summaryPoints: ["a"],
+            participants: [MeetingParticipant(name: "Alice", role: nil, speaker: nil, details: nil)]
+        )
+        let second = SummarizationPassDelta(
+            summaryPoints: ["b"],
+            participants: [
+                MeetingParticipant(name: "alice", role: "Manager", speaker: "Speaker 1", details: "Assigns goals; addressed by name at [10:02]."),
+            ]
+        )
+
+        let state1 = SummarizationSummaryMerger.merge(previousState: nil, delta: first, meetingType: nil, recordingDate: Date())
+        let state2 = SummarizationSummaryMerger.merge(previousState: state1, delta: second, meetingType: nil, recordingDate: Date())
+
+        #expect(state2.participants.count == 1)
+        #expect(state2.participants.first?.speaker == "Speaker 1")
+        #expect(state2.participants.first?.details == "Assigns goals; addressed by name at [10:02].")
+    }
 
     @Test
     func merger_mergesParticipantsAndTopicsAcrossPasses() {

--- a/MinuteCore/Tests/MinuteCoreTests/MeetingExtractionRichFieldsTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/MeetingExtractionRichFieldsTests.swift
@@ -1,0 +1,257 @@
+import Foundation
+import Testing
+@testable import MinuteCore
+
+/// Tests for the enriched extraction schema: participants, topics, and
+/// action-item table fields (due date, status, comments), ported from
+/// field-tested meeting-notes templates.
+struct MeetingExtractionRichFieldsTests {
+
+    // MARK: - Decoding
+
+    @Test
+    func decode_richFields_present() throws {
+        let json = """
+        {
+          "title": "Sync",
+          "date": "2026-08-01",
+          "summary": "s",
+          "participants": [
+            {"name": "Alice", "role": "Manager"},
+            {"name": "Speaker 2"}
+          ],
+          "topics": [
+            {"title": "On-call load", "points": ["Sev-2s mis-labelled", "Queue growing"]}
+          ],
+          "action_items": [
+            {"owner": "Bob", "task": "Send changelog", "due_date": "2026-08-05", "status": "Not Started", "comments": "Needed for packaging"}
+          ]
+        }
+        """
+        let extraction = try JSONDecoder().decode(MeetingExtraction.self, from: Data(json.utf8))
+
+        #expect(extraction.participants == [
+            MeetingParticipant(name: "Alice", role: "Manager"),
+            MeetingParticipant(name: "Speaker 2", role: nil),
+        ])
+        #expect(extraction.topics == [
+            MeetingTopic(title: "On-call load", points: ["Sev-2s mis-labelled", "Queue growing"]),
+        ])
+        let item = try #require(extraction.actionItems.first)
+        #expect(item.dueDate == "2026-08-05")
+        #expect(item.status == "Not Started")
+        #expect(item.comments == "Needed for packaging")
+    }
+
+    @Test
+    func decode_richFields_absent_defaultsToEmpty() throws {
+        let json = """
+        {"title": "Sync", "date": "2026-08-01", "summary": "s", "action_items": [{"owner": "Bob", "task": "T"}]}
+        """
+        let extraction = try JSONDecoder().decode(MeetingExtraction.self, from: Data(json.utf8))
+
+        #expect(extraction.participants.isEmpty)
+        #expect(extraction.topics.isEmpty)
+        let item = try #require(extraction.actionItems.first)
+        #expect(item.dueDate == nil)
+        #expect(item.status == nil)
+        #expect(item.comments == nil)
+    }
+
+    @Test
+    func decode_passDelta_richFields() throws {
+        let json = """
+        {
+          "summary_points": ["p"],
+          "participants": [{"name": "Alice", "role": "Manager"}],
+          "topics": [{"title": "T1", "points": ["a"]}]
+        }
+        """
+        let delta = try JSONDecoder().decode(SummarizationPassDelta.self, from: Data(json.utf8))
+        #expect(delta.participants.count == 1)
+        #expect(delta.topics.count == 1)
+    }
+
+    // MARK: - Validation
+
+    @Test
+    func validation_dropsEmptyParticipantsAndTopics() {
+        let extraction = MeetingExtraction(
+            title: "T",
+            date: "2026-08-01",
+            summary: "s",
+            participants: [
+                MeetingParticipant(name: "  Alice  ", role: "  Manager "),
+                MeetingParticipant(name: "   ", role: "Ghost"),
+            ],
+            topics: [
+                MeetingTopic(title: " Topic ", points: [" a ", "  "]),
+                MeetingTopic(title: "  ", points: ["orphan"]),
+            ]
+        )
+
+        let validated = MeetingExtractionValidation.validated(extraction, recordingDate: Date())
+        #expect(validated.participants == [MeetingParticipant(name: "Alice", role: "Manager")])
+        #expect(validated.topics == [MeetingTopic(title: "Topic", points: ["a"])])
+    }
+
+    // MARK: - Rendering
+
+    @Test
+    func render_participantsAndTopics_sectionsInTemplateOrder() throws {
+        let extraction = MeetingExtraction(
+            title: "Weekly Sync",
+            date: "2025-12-19",
+            summary: "We aligned on next steps.",
+            decisions: ["Ship v1"],
+            keyPoints: ["Local-only processing"],
+            participants: [
+                MeetingParticipant(name: "Alice", role: "Manager"),
+                MeetingParticipant(name: "Speaker 2", role: nil),
+            ],
+            topics: [
+                MeetingTopic(title: "Release plan", points: ["Ship Friday", "Bob owns packaging"]),
+                MeetingTopic(title: "Docs", points: ["Decide next week"]),
+            ]
+        )
+
+        let markdown = MarkdownRenderer().render(
+            extraction: extraction,
+            noteDateTime: "2025-12-19 09:00",
+            audioDurationSeconds: nil,
+            audioRelativePath: nil,
+            transcriptRelativePath: nil
+        )
+
+        #expect(markdown.contains("""
+        ## Participants
+        - Alice — Manager
+        - Speaker 2
+        """))
+        #expect(markdown.contains("""
+        ## Topics Discussed
+
+        ### 1. Release plan
+        - Ship Friday
+        - Bob owns packaging
+
+        ### 2. Docs
+        - Decide next week
+        """))
+
+        // Template order: Participants before Summary; Topics after Summary, before Decisions.
+        let participantsIndex = try #require(markdown.range(of: "## Participants")).lowerBound
+        let summaryIndex = try #require(markdown.range(of: "## Summary")).lowerBound
+        let topicsIndex = try #require(markdown.range(of: "## Topics Discussed")).lowerBound
+        let decisionsIndex = try #require(markdown.range(of: "## Decisions")).lowerBound
+        #expect(participantsIndex < summaryIndex)
+        #expect(summaryIndex < topicsIndex)
+        #expect(topicsIndex < decisionsIndex)
+    }
+
+    @Test
+    func render_withoutRichFields_omitsSectionsAndKeepsLegacyActionList() {
+        let extraction = MeetingExtraction(
+            title: "Weekly Sync",
+            date: "2025-12-19",
+            summary: "s",
+            actionItems: [ActionItem(owner: "Alex", task: "Draft release notes")]
+        )
+
+        let markdown = MarkdownRenderer().render(
+            extraction: extraction,
+            noteDateTime: "2025-12-19 09:00",
+            audioDurationSeconds: nil,
+            audioRelativePath: nil,
+            transcriptRelativePath: nil
+        )
+
+        #expect(!markdown.contains("## Participants"))
+        #expect(!markdown.contains("## Topics Discussed"))
+        #expect(markdown.contains("- [ ] Draft release notes (Owner: Alex)"))
+        #expect(!markdown.contains("| # | Action |"))
+    }
+
+    @Test
+    func render_actionItemsWithTableFields_rendersTable() {
+        let extraction = MeetingExtraction(
+            title: "Weekly Sync",
+            date: "2025-12-19",
+            summary: "s",
+            actionItems: [
+                ActionItem(owner: "Bob", task: "Send changelog", dueDate: "2026-08-05", status: "Not Started", comments: "Needed | for packaging"),
+                ActionItem(owner: "Alice", task: "Review docs"),
+            ]
+        )
+
+        let markdown = MarkdownRenderer().render(
+            extraction: extraction,
+            noteDateTime: "2025-12-19 09:00",
+            audioDurationSeconds: nil,
+            audioRelativePath: nil,
+            transcriptRelativePath: nil
+        )
+
+        #expect(markdown.contains("| # | Action | Owner | Due Date | Status | Comments |"))
+        #expect(markdown.contains("| 1 | Send changelog | Bob | 2026-08-05 | Not Started | Needed \\| for packaging |"))
+        // Items without table fields get defaults in the table.
+        #expect(markdown.contains("| 2 | Review docs | Alice | TBD | Not Started |  |"))
+        #expect(!markdown.contains("- [ ]"))
+    }
+
+    // MARK: - Merging
+
+    @Test
+    func merger_mergesParticipantsAndTopicsAcrossPasses() {
+        let first = SummarizationPassDelta(
+            summaryPoints: ["a"],
+            participants: [MeetingParticipant(name: "Alice", role: nil)],
+            topics: [MeetingTopic(title: "Release plan", points: ["Ship Friday"])]
+        )
+        let second = SummarizationPassDelta(
+            summaryPoints: ["b"],
+            participants: [
+                MeetingParticipant(name: "alice", role: "Manager"),
+                MeetingParticipant(name: "Bob", role: nil),
+            ],
+            topics: [
+                MeetingTopic(title: "Release Plan", points: ["Bob owns packaging"]),
+                MeetingTopic(title: "Docs", points: ["Decide next week"]),
+            ]
+        )
+
+        let state1 = SummarizationSummaryMerger.merge(
+            previousState: nil, delta: first, meetingType: nil, recordingDate: Date()
+        )
+        let state2 = SummarizationSummaryMerger.merge(
+            previousState: state1, delta: second, meetingType: nil, recordingDate: Date()
+        )
+
+        // Alice deduped case-insensitively, role backfilled; Bob appended.
+        #expect(state2.participants.count == 2)
+        #expect(state2.participants.first?.role == "Manager")
+        // Topics deduped by title; points merged; Docs appended.
+        #expect(state2.topics.count == 2)
+        #expect(state2.topics.first?.points == ["Ship Friday", "Bob owns packaging"])
+    }
+
+    @Test
+    func merger_extractionRoundTrip_carriesRichFields() {
+        let delta = SummarizationPassDelta(
+            title: "T",
+            date: "2026-08-01",
+            summaryPoints: ["s"],
+            actionItems: [ActionItem(owner: "Bob", task: "Task", dueDate: "2026-08-05", status: "Not Started", comments: "c")],
+            participants: [MeetingParticipant(name: "Alice", role: "Manager")],
+            topics: [MeetingTopic(title: "Topic", points: ["p"])]
+        )
+        let state = SummarizationSummaryMerger.merge(
+            previousState: nil, delta: delta, meetingType: nil, recordingDate: Date()
+        )
+        let extraction = SummarizationSummaryMerger.extraction(from: state, recordingDate: Date())
+
+        #expect(extraction.participants == [MeetingParticipant(name: "Alice", role: "Manager")])
+        #expect(extraction.topics == [MeetingTopic(title: "Topic", points: ["p"])])
+        #expect(extraction.actionItems.first?.dueDate == "2026-08-05")
+    }
+}

--- a/MinuteCore/Tests/MinuteCoreTests/MeetingNoteRenamerTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/MeetingNoteRenamerTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Testing
+@testable import MinuteCore
+
+/// Tests for renaming a meeting note: pure markdown rewriting plus the
+/// three-file vault rename in `VaultMeetingNotesBrowser`.
+struct MeetingNoteRenamerTests {
+
+    // MARK: - Pure markdown rewriting
+
+    private let noteMarkdown = """
+    ---
+    type: meeting
+    date: Jan 10, 2025 at 10:00
+    title: "Team Sync"
+    source: "Minute"
+    meeting_type: general
+    length: 30m
+    tags:
+    ---
+
+    # Team Sync
+
+    ## Summary
+    The team synced. Team Sync is mentioned inline and must not change.
+
+    ## Audio
+    [[Meetings/_audio/2025-01-10 10.00 - Team Sync.wav]]
+
+    ## Transcript
+    [[Meetings/_transcripts/2025-01-10 10.00 - Team Sync.md]]
+    """
+
+    @Test
+    func rewriteNote_updatesFrontmatterTitleHeadingAndLinks() {
+        let result = MeetingNoteRenamer.rewrittenNoteMarkdown(
+            noteMarkdown,
+            oldTitle: "Team Sync",
+            newTitle: "Weekly Platform Sync",
+            oldBaseName: "2025-01-10 10.00 - Team Sync",
+            newBaseName: "2025-01-10 10.00 - Weekly Platform Sync"
+        )
+
+        #expect(result.contains("title: \"Weekly Platform Sync\""))
+        #expect(result.contains("# Weekly Platform Sync\n"))
+        #expect(result.contains("[[Meetings/_audio/2025-01-10 10.00 - Weekly Platform Sync.wav]]"))
+        #expect(result.contains("[[Meetings/_transcripts/2025-01-10 10.00 - Weekly Platform Sync.md]]"))
+        // Body prose mentioning the old title must be preserved.
+        #expect(result.contains("Team Sync is mentioned inline and must not change."))
+        // No stale links remain.
+        #expect(!result.contains("2025-01-10 10.00 - Team Sync.wav"))
+        #expect(!result.contains("2025-01-10 10.00 - Team Sync.md"))
+    }
+
+    @Test
+    func rewriteNote_leavesUnrelatedFrontmatterUntouched() {
+        let result = MeetingNoteRenamer.rewrittenNoteMarkdown(
+            noteMarkdown,
+            oldTitle: "Team Sync",
+            newTitle: "Renamed",
+            oldBaseName: "2025-01-10 10.00 - Team Sync",
+            newBaseName: "2025-01-10 10.00 - Renamed"
+        )
+
+        #expect(result.contains("type: meeting"))
+        #expect(result.contains("meeting_type: general"))
+        #expect(result.contains("length: 30m"))
+        #expect(result.contains("date: Jan 10, 2025 at 10:00"))
+    }
+
+    @Test
+    func rewriteTranscript_updatesTitleAndHeading() {
+        let transcript = """
+        ---
+        type: meeting_transcript
+        date: 2025-01-10
+        title: "Team Sync"
+        source: "Minute"
+        ---
+
+        # Team Sync — Transcript
+
+        Speaker 1 [00:00 - 00:10]
+        Hello Team Sync attendees.
+        """
+
+        let result = MeetingNoteRenamer.rewrittenTranscriptMarkdown(
+            transcript,
+            oldTitle: "Team Sync",
+            newTitle: "Weekly Platform Sync"
+        )
+
+        #expect(result.contains("title: \"Weekly Platform Sync\""))
+        #expect(result.contains("# Weekly Platform Sync — Transcript"))
+        // Transcript body untouched.
+        #expect(result.contains("Hello Team Sync attendees."))
+    }
+
+    @Test
+    func newBaseName_preservesDateTimePrefixAndSanitizesTitle() {
+        let base = MeetingNoteRenamer.newBaseName(
+            oldBaseName: "2025-01-10 10.00 - Team Sync",
+            newTitle: "  Bad/Name: with*chars?  "
+        )
+        #expect(base == "2025-01-10 10.00 - Bad Name with chars")
+    }
+
+    @Test
+    func newBaseName_withoutDatePrefix_usesSanitizedTitleOnly() {
+        let base = MeetingNoteRenamer.newBaseName(oldBaseName: "Untracked Note", newTitle: "Fresh Title")
+        #expect(base == "Fresh Title")
+    }
+
+    // MARK: - Vault file renaming
+
+    @Test
+    func renameNoteFiles_renamesAllThreeFilesAndRewritesContent() async throws {
+        let rootURL = try makeTemporaryVault()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let noteURL = rootURL.appendingPathComponent("Meetings/2025/01/2025-01-10 10.00 - Team Sync.md")
+        let transcriptURL = rootURL.appendingPathComponent("Meetings/_transcripts/2025-01-10 10.00 - Team Sync.md")
+        let audioURL = rootURL.appendingPathComponent("Meetings/_audio/2025-01-10 10.00 - Team Sync.wav")
+
+        try createFile(at: noteURL, contents: noteMarkdown)
+        try createFile(
+            at: transcriptURL,
+            contents: "---\ntitle: \"Team Sync\"\n---\n\n# Team Sync — Transcript\n\nBody."
+        )
+        try createFile(at: audioURL, contents: "RIFF-FAKE-AUDIO")
+
+        let browser = try makeBrowser(vaultRootURL: rootURL)
+        let items = try await browser.listNotes()
+        let item = try #require(items.first)
+
+        let renamed = try await browser.renameNoteFiles(for: item, to: "Weekly Platform Sync")
+
+        let newNoteURL = rootURL.appendingPathComponent("Meetings/2025/01/2025-01-10 10.00 - Weekly Platform Sync.md")
+        let newTranscriptURL = rootURL.appendingPathComponent("Meetings/_transcripts/2025-01-10 10.00 - Weekly Platform Sync.md")
+        let newAudioURL = rootURL.appendingPathComponent("Meetings/_audio/2025-01-10 10.00 - Weekly Platform Sync.wav")
+
+        #expect(FileManager.default.fileExists(atPath: newNoteURL.path))
+        #expect(FileManager.default.fileExists(atPath: newTranscriptURL.path))
+        #expect(FileManager.default.fileExists(atPath: newAudioURL.path))
+        #expect(!FileManager.default.fileExists(atPath: noteURL.path))
+        #expect(!FileManager.default.fileExists(atPath: transcriptURL.path))
+        #expect(!FileManager.default.fileExists(atPath: audioURL.path))
+
+        let newNote = try String(contentsOf: newNoteURL, encoding: .utf8)
+        #expect(newNote.contains("title: \"Weekly Platform Sync\""))
+        #expect(newNote.contains("[[Meetings/_audio/2025-01-10 10.00 - Weekly Platform Sync.wav]]"))
+        #expect(newNote.contains("[[Meetings/_transcripts/2025-01-10 10.00 - Weekly Platform Sync.md]]"))
+
+        let newTranscript = try String(contentsOf: newTranscriptURL, encoding: .utf8)
+        #expect(newTranscript.contains("title: \"Weekly Platform Sync\""))
+        #expect(newTranscript.contains("# Weekly Platform Sync — Transcript"))
+
+        #expect(renamed.title == "Weekly Platform Sync")
+        #expect(renamed.fileURL.lastPathComponent == "2025-01-10 10.00 - Weekly Platform Sync.md")
+    }
+
+    @Test
+    func renameNoteFiles_withMissingAudioAndTranscript_renamesNoteOnly() async throws {
+        let rootURL = try makeTemporaryVault()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let noteURL = rootURL.appendingPathComponent("Meetings/2025/01/2025-01-10 10.00 - Team Sync.md")
+        try createFile(at: noteURL, contents: noteMarkdown)
+
+        let browser = try makeBrowser(vaultRootURL: rootURL)
+        let item = try #require(try await browser.listNotes().first)
+
+        let renamed = try await browser.renameNoteFiles(for: item, to: "Solo Note")
+
+        let newNoteURL = rootURL.appendingPathComponent("Meetings/2025/01/2025-01-10 10.00 - Solo Note.md")
+        #expect(FileManager.default.fileExists(atPath: newNoteURL.path))
+        #expect(renamed.title == "Solo Note")
+    }
+
+    @Test
+    func renameNoteFiles_rejectsEmptyTitleAndCollisions() async throws {
+        let rootURL = try makeTemporaryVault()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let noteURL = rootURL.appendingPathComponent("Meetings/2025/01/2025-01-10 10.00 - Team Sync.md")
+        let collidingURL = rootURL.appendingPathComponent("Meetings/2025/01/2025-01-10 10.00 - Existing.md")
+        try createFile(at: noteURL, contents: noteMarkdown)
+        try createFile(at: collidingURL, contents: "# Existing")
+
+        let browser = try makeBrowser(vaultRootURL: rootURL)
+        let items = try await browser.listNotes()
+        let item = try #require(items.first { $0.fileURL.lastPathComponent.contains("Team Sync") })
+
+        await #expect(throws: MeetingNoteRenameError.emptyTitle) {
+            _ = try await browser.renameNoteFiles(for: item, to: "   ")
+        }
+        await #expect(throws: MeetingNoteRenameError.destinationAlreadyExists) {
+            _ = try await browser.renameNoteFiles(for: item, to: "Existing")
+        }
+        await #expect(throws: MeetingNoteRenameError.titleUnchanged) {
+            _ = try await browser.renameNoteFiles(for: item, to: "Team Sync")
+        }
+
+        // Original files untouched after failed attempts.
+        #expect(FileManager.default.fileExists(atPath: noteURL.path))
+    }
+}
+
+private final class InMemoryBookmarkStore: VaultBookmarkStoring {
+    private var bookmark: Data?
+
+    init(bookmark: Data?) {
+        self.bookmark = bookmark
+    }
+
+    func loadVaultRootBookmark() -> Data? { bookmark }
+    func saveVaultRootBookmark(_ bookmark: Data) { self.bookmark = bookmark }
+    func clearVaultRootBookmark() { bookmark = nil }
+}
+
+private func makeTemporaryVault() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("minute-rename-vault-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func makeBrowser(vaultRootURL: URL) throws -> VaultMeetingNotesBrowser {
+    let bookmark = try VaultAccess.makeBookmarkData(forVaultRootURL: vaultRootURL)
+    let store = InMemoryBookmarkStore(bookmark: bookmark)
+    let access = VaultAccess(bookmarkStore: store)
+    return VaultMeetingNotesBrowser(vaultAccess: access, meetingsRelativePath: "Meetings")
+}
+
+private func createFile(at url: URL, contents: String) throws {
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try Data(contents.utf8).write(to: url, options: [.atomic])
+}

--- a/MinuteCore/Tests/MinuteCoreTests/PromptFactoryRuleToggleTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/PromptFactoryRuleToggleTests.swift
@@ -30,7 +30,9 @@ struct PromptFactoryRuleToggleTests {
         #expect(!prompt.contains("### DECISION RULES"))
         #expect(!prompt.contains("### OPEN QUESTION RULES"))
 
-        #expect(prompt.contains("- action_items (array of objects with owner and task)"))
+        #expect(prompt.contains("- action_items (array of objects with owner, task, due_date, status, and comments)"))
+        #expect(prompt.contains("- participants (array of objects with name and role"))
+        #expect(prompt.contains("- topics (array of objects with title and points"))
         #expect(prompt.contains("- key_points (array of string)"))
         #expect(!prompt.contains("- decisions (array of string)"))
         #expect(!prompt.contains("- open_questions (array of string)"))

--- a/MinuteCore/Tests/MinuteCoreTests/PromptFactoryRuleToggleTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/PromptFactoryRuleToggleTests.swift
@@ -31,7 +31,7 @@ struct PromptFactoryRuleToggleTests {
         #expect(!prompt.contains("### OPEN QUESTION RULES"))
 
         #expect(prompt.contains("- action_items (array of objects with owner, task, due_date, status, and comments)"))
-        #expect(prompt.contains("- participants (array of objects with name and role"))
+        #expect(prompt.contains("- participants (array of objects with name, speaker, role, and details"))
         #expect(prompt.contains("- topics (array of objects with title and points"))
         #expect(prompt.contains("- key_points (array of string)"))
         #expect(!prompt.contains("- decisions (array of string)"))

--- a/MinuteCore/Tests/MinuteCoreTests/Summarization/MeetingTypeClassifierParseTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/Summarization/MeetingTypeClassifierParseTests.swift
@@ -31,7 +31,12 @@ struct MeetingTypeClassifierParseTests {
             (" one-on-one ", .oneOnOne),
             ("presentation", .presentation),
             ("PLANNING", .planning),
-            ("general", .general)
+            ("general", .general),
+            ("Interview — Taken", .interviewTaken),
+            ("interview - given", .interviewGiven),
+            ("ALL HANDS", .allHands),
+            ("retrospective", .retrospective),
+            ("retro", .retrospective)
         ]
 
         for (input, expected) in cases {

--- a/MinuteCore/Tests/MinuteCoreTests/Summarization/MeetingTypeClassifierPromptTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/Summarization/MeetingTypeClassifierPromptTests.swift
@@ -17,7 +17,10 @@ struct MeetingTypeClassifierPromptTests {
     func prompt_containsAllAllowedLabelsAsExactOutputs() {
         let prompt = MeetingTypeClassifier.prompt(for: "Hello")
 
-        for label in ["General", "Standup", "Design Review", "One-on-One", "Presentation", "Planning"] {
+        for label in [
+            "General", "Standup", "Design Review", "One-on-One", "Presentation", "Planning",
+            "Interview — Taken", "Interview — Given", "All Hands", "Retrospective"
+        ] {
             #expect(prompt.contains(label))
         }
     }

--- a/MinuteCore/Tests/MinuteCoreTests/Summarization/NewBuiltInMeetingTypesTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/Summarization/NewBuiltInMeetingTypesTests.swift
@@ -153,4 +153,24 @@ struct NewBuiltInMeetingTypesTests {
         #expect(guidance.contains("direct address"))
         #expect(guidance.contains("third person"))
     }
+
+    @Test
+    func generalStrategy_carriesPortedRuleIntentions() {
+        let prompt = GeneralPromptStrategy().systemPrompt()
+
+        // Step 2: participant identification.
+        #expect(prompt.contains("Identify Participants"))
+        #expect(prompt.contains("keep the Speaker N label"))
+        // Step 4 / rule 6: thoroughness including disagreements and reasoning.
+        #expect(prompt.contains("disagreements, concerns, and unresolved debates"))
+        #expect(prompt.contains("capture the reasoning"))
+        // Rule 5: technical accuracy.
+        #expect(prompt.contains("exactly as spoken"))
+        // Rules 4/7: screen capture context.
+        #expect(prompt.contains("Use Screen Context"))
+        // Rule 2: action item dates.
+        #expect(prompt.contains("Use \"TBD\" when no date was mentioned"))
+        // Rule 6 phrasing: better to include too much.
+        #expect(prompt.contains("Better Too Much Than Missing"))
+    }
 }

--- a/MinuteCore/Tests/MinuteCoreTests/Summarization/NewBuiltInMeetingTypesTests.swift
+++ b/MinuteCore/Tests/MinuteCoreTests/Summarization/NewBuiltInMeetingTypesTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import MinuteCore
+
+/// Tests for the built-in meeting types added from field-tested meeting-notes
+/// templates: interview (taken/given), all hands, and retrospective — plus the
+/// store-level reconciliation that surfaces them in previously saved libraries.
+struct NewBuiltInMeetingTypesTests {
+
+    private let newTypes: [MeetingType] = [.interviewTaken, .interviewGiven, .allHands, .retrospective]
+
+    @Test
+    func promptFactory_returnsDedicatedStrategyForNewTypes() {
+        #expect(PromptFactory.strategy(for: .interviewTaken) is InterviewTakenPromptStrategy)
+        #expect(PromptFactory.strategy(for: .interviewGiven) is InterviewGivenPromptStrategy)
+        #expect(PromptFactory.strategy(for: .allHands) is AllHandsPromptStrategy)
+        #expect(PromptFactory.strategy(for: .retrospective) is RetrospectivePromptStrategy)
+    }
+
+    @Test
+    func newStrategies_declareMatchingMeetingTypeAndJSONContract() {
+        for type in newTypes {
+            let strategy = PromptFactory.strategy(for: type)
+            #expect(strategy.meetingType == type)
+
+            let systemPrompt = strategy.systemPrompt()
+            // The vault contract fields must all be requested from the model.
+            for field in ["title", "date", "summary", "decisions", "action_items", "open_questions", "key_points"] {
+                #expect(systemPrompt.contains(field), "\(type) prompt missing field \(field)")
+            }
+            #expect(systemPrompt.contains("JSON"))
+
+            let userPrompt = strategy.userPrompt(for: "TRANSCRIPT-MARKER")
+            #expect(userPrompt.contains("TRANSCRIPT-MARKER"))
+        }
+    }
+
+    @Test
+    func interviewStrategies_distinguishPerspective() {
+        let taken = InterviewTakenPromptStrategy().systemPrompt()
+        let given = InterviewGivenPromptStrategy().systemPrompt()
+
+        #expect(taken.contains("INTERVIEWER"))
+        #expect(given.contains("CANDIDATE"))
+    }
+
+    @Test
+    func defaultLibrary_includesNewTypesAsActiveAutodetectEligibleBuiltIns() throws {
+        let library = try MeetingTypeLibrary.default.validated()
+
+        for type in newTypes {
+            let definition = try #require(library.definition(for: type.rawValue), "missing \(type.rawValue)")
+            #expect(definition.source == .builtIn)
+            #expect(definition.status == .active)
+            #expect(definition.autodetectEligible)
+            #expect(definition.isDeletable == false)
+
+            let profile = try #require(definition.classifierProfile)
+            #expect(!profile.strongSignals.isEmpty)
+        }
+    }
+
+    @Test
+    func builtInDefinitions_useTypeSpecificClassifierSignals() {
+        // Signals must be richer than the old displayName-lowercased default.
+        for type in MeetingType.allCases where type != .autodetect && type != .general {
+            let signals = MeetingTypeLibrary.defaultClassifierSignals(for: type)
+            #expect(!signals.isEmpty, "\(type.rawValue) has no signals")
+            #expect(signals != [type.displayName.lowercased()], "\(type.rawValue) still uses generic signal")
+        }
+    }
+
+    @Test
+    func defaultPromptComponents_forNewTypes_passValidation() throws {
+        for type in newTypes {
+            let components = MeetingTypeLibrary.defaultPromptComponents(for: type)
+            let validated = try components.validated(typeID: type.rawValue)
+            #expect(!validated.objective.isEmpty)
+            #expect(!validated.summaryFocus.isEmpty)
+            #expect(!validated.additionalGuidance.isEmpty)
+        }
+    }
+
+    @Test
+    func libraryStore_mergesNewBuiltInsIntoPreviouslySavedLibrary() throws {
+        let suiteName = "NewBuiltInMeetingTypesTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Simulate a library saved by an older app version: only the original types.
+        let oldTypes: [MeetingType] = [.autodetect, .general, .standup, .designReview, .oneOnOne, .presentation, .planning]
+        let oldLibrary = MeetingTypeLibrary(
+            definitions: oldTypes.map(MeetingTypeLibrary.builtInDefinition(for:)),
+            defaultTypeId: MeetingType.autodetect.rawValue
+        )
+        let data = try JSONEncoder().encode(try oldLibrary.validated())
+        defaults.set(data, forKey: "meetingTypeLibrary")
+
+        let store = MeetingTypeLibraryStore(defaults: defaults, libraryKey: "meetingTypeLibrary")
+        let loaded = store.load()
+
+        for type in newTypes {
+            #expect(loaded.definition(for: type.rawValue) != nil, "reconciliation missed \(type.rawValue)")
+        }
+        // Existing definitions are untouched.
+        #expect(loaded.definition(for: MeetingType.general.rawValue) != nil)
+    }
+
+    @Test
+    func libraryStore_reconciliationPreservesBuiltInOverridesAndCustomTypes() throws {
+        let suiteName = "NewBuiltInMeetingTypesTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let oldTypes: [MeetingType] = [.autodetect, .general, .standup, .designReview, .oneOnOne, .presentation, .planning]
+        var definitions = oldTypes.map(MeetingTypeLibrary.builtInDefinition(for:))
+
+        // Override the general built-in.
+        var overridden = definitions[1]
+        overridden.promptComponents.objective = "My customized general objective."
+        definitions[1] = overridden
+
+        // Add a custom type.
+        definitions.append(
+            MeetingTypeDefinition(
+                typeId: "custom-abc",
+                displayName: "My Custom Type",
+                source: .custom,
+                isDeletable: true,
+                isEditableName: true,
+                autodetectEligible: false,
+                promptComponents: PromptComponentSet(objective: "Custom objective", summaryFocus: "Custom focus")
+            )
+        )
+
+        let library = MeetingTypeLibrary(definitions: definitions, defaultTypeId: MeetingType.autodetect.rawValue)
+        let data = try JSONEncoder().encode(try library.validated())
+        defaults.set(data, forKey: "meetingTypeLibrary")
+
+        let store = MeetingTypeLibraryStore(defaults: defaults, libraryKey: "meetingTypeLibrary")
+        let loaded = store.load()
+
+        let general = try #require(loaded.definition(for: MeetingType.general.rawValue))
+        #expect(general.promptComponents.objective == "My customized general objective.")
+        #expect(loaded.definition(for: "custom-abc") != nil)
+        #expect(loaded.definition(for: MeetingType.retrospective.rawValue) != nil)
+    }
+
+    @Test
+    func enrichedGeneralComponents_carrySpeakerAttributionGuidance() {
+        let components = MeetingTypeLibrary.defaultPromptComponents(for: .general)
+        let guidance = components.additionalGuidance.lowercased()
+        #expect(guidance.contains("direct address"))
+        #expect(guidance.contains("third person"))
+    }
+}

--- a/MinuteTests/MeetingDetailNoRegressionSmokeTests.swift
+++ b/MinuteTests/MeetingDetailNoRegressionSmokeTests.swift
@@ -78,4 +78,9 @@ private actor MockMeetingNotesBrowser: MeetingNotesBrowsing {
     func deleteNoteFiles(for item: MeetingNoteItem) async throws {
         _ = item
     }
+
+    func renameNoteFiles(for item: MeetingNoteItem, to newTitle: String) async throws -> MeetingNoteItem {
+        _ = newTitle
+        return item
+    }
 }

--- a/MinuteTests/MeetingNotesBrowserViewModelReprocessingTests.swift
+++ b/MinuteTests/MeetingNotesBrowserViewModelReprocessingTests.swift
@@ -140,6 +140,11 @@ private actor ReprocessingBrowserStub: MeetingNotesBrowsing {
     func loadNoteContent(for item: MeetingNoteItem) async throws -> String { noteByID[item.id] ?? "" }
     func loadTranscriptContent(for item: MeetingNoteItem) async throws -> String { transcriptByID[item.id] ?? "" }
     func deleteNoteFiles(for item: MeetingNoteItem) async throws { _ = item }
+
+    func renameNoteFiles(for item: MeetingNoteItem, to newTitle: String) async throws -> MeetingNoteItem {
+        _ = newTitle
+        return item
+    }
 }
 
 private final class MockMeetingTypeLibraryStore: MeetingTypeLibraryStoring, @unchecked Sendable {

--- a/MinuteTests/MinuteTests.swift
+++ b/MinuteTests/MinuteTests.swift
@@ -547,6 +547,11 @@ private actor SpeakerDraftIsolationBrowserStub: MeetingNotesBrowsing {
     func deleteNoteFiles(for item: MeetingNoteItem) async throws {
         _ = item
     }
+
+    func renameNoteFiles(for item: MeetingNoteItem, to newTitle: String) async throws -> MeetingNoteItem {
+        _ = newTitle
+        return item
+    }
 }
 
 @MainActor

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,7 +31,12 @@ Note structure (deterministic)
    - `speaker_map`: mapping of speaker IDs to participant names
      - YAML keys are strings (e.g. `"1"`), but represent stable speaker IDs as integers.
    - `speaker_order`: optional list of speaker IDs used to display speakers in a stable order
-- Sections: Summary, Decisions, Action Items, Open Questions, Key Points.
+- Sections: Participants (optional), Summary, Topics Discussed (optional), Decisions, Action Items, Open Questions, Key Points.
+   - `Participants` and `Topics Discussed` render only when the model supplies the optional
+     `participants` / `topics` JSON fields; models that omit them produce the original layout.
+   - Action items render as a table (`# | Action | Owner | Due Date | Status | Comments`) when any
+     item carries the optional `due_date`, `status`, or `comments` fields; otherwise they render as
+     the original checkbox list.
 - Links to the audio and transcript files in the vault.
 
 How the app works (pipeline)


### PR DESCRIPTION
## Summary

Allow users to skip the local LLM summarization step so they can summarize externally with cloud models.

When disabled, the pipeline still records, transcribes, and saves audio/transcript to the vault but skips inference entirely — producing a minimal note with just the title, date, and linked transcript/audio.

## Changes

- **AppConfiguration**: Added `summarizationEnabled` key (defaults to `true`, preserving current behavior)
- **PipelineContext**: Added `skipSummarization` flag
- **MeetingPipelineCoordinator**: Early-exit path that skips all LLM work when flag is set
- **MeetingPipelineViewModel**: Passes the setting into the pipeline context
- **GeneralSettingsSection**: Added "Summarize after recording" toggle in Recording & Output

## Testing

- MinuteCore builds cleanly (`swift build`)
- Existing behavior unchanged when setting is enabled (default)
- When disabled: transcription + audio saved, no LLM invoked